### PR TITLE
Single precision inference support for the gemma-2B model

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -409,6 +409,18 @@ else ()
     target_link_libraries(demo_llava MLLM_CPU)
 endif ()
 
+add_executable(demo_gemma ${PROJECT_SOURCE_DIR}/examples/demo_gemma.cpp ${DIR_SRC_CPU} ${DIR_SRC_MEM_MANAGER} ${DIR_SRC_EXP} ${DIR_SRC}
+        src/tokenizers/Tokenizer.cpp
+        src/tokenizers/BPE/Bpe.cpp
+        src/processor/PreProcess.cpp
+)
+if (ARM AND NOT APK)
+    target_compile_options(demo_gemma PRIVATE -fopenmp)
+    target_link_libraries(demo_gemma PUBLIC MLLM_CPU -fopenmp -static-openmp)
+else ()
+    target_link_libraries(demo_gemma MLLM_CPU)
+endif ()
+
 
 if (APK)
     add_library(mllm_lib STATIC ${DIR_SRC_CPU} ${DIR_SRC_EXP} ${DIR_SRC} ${DIR_SRC_MEM_MANAGER}

--- a/examples/demo_gemma.cpp
+++ b/examples/demo_gemma.cpp
@@ -1,0 +1,63 @@
+/**
+ * @file demo_gemma.cpp
+ * @author Chenghua Wang (chenghua.wang@gmail.com)
+ * @brief
+ * @version 0.1
+ * @date 2024-04-06
+ *
+ * @copyright Copyright (c) 2024
+ *
+ */
+#include "cmdline.h"
+#include "models/gemma/configuration_gemma.hpp"
+#include "models/gemma/modeling_gemma.hpp"
+#include "models/gemma/tokenization_gemma.hpp"
+#include "processor/PostProcess.hpp"
+
+using namespace mllm;
+
+int main(int argc, char **argv) {
+    cmdline::parser cmdParser;
+    cmdParser.add<string>("vocab", 'v', "specify mllm tokenizer model path", false, "../vocab/gemma/gemma_vocab.mllm");
+    cmdParser.add<string>("model", 'm', "specify mllm model path", false, "../models/gemma/gemma-2b-q4_k.mllm");
+    cmdParser.add<int>("limits", 'l', "max KV cache size", false, 400);
+    cmdParser.add<int>("thread", 't', "num of threads", false, 4);
+    cmdParser.parse_check(argc, argv);
+
+    string vocab_path = cmdParser.get<string>("vocab");
+    string model_path = cmdParser.get<string>("model");
+    int tokens_limit = cmdParser.get<int>("limits");
+    CPUBackend::cpu_threads = cmdParser.get<int>("thread");
+
+    auto tokenizer = GemmaTokenizer(vocab_path);
+
+    GemmaConfig config(tokens_limit, "2B");
+    auto model = GemmaForCausalLM(config);
+    model.load(model_path);
+
+    vector<string> in_strs = {
+        " Hello, who are you?",
+        " What can you do?",
+        "Please introduce Beijing University of Posts and Telecommunications."};
+
+    for (int i = 0; i < in_strs.size(); ++i) {
+        auto in_str = in_strs[i];
+        auto input_tensor = tokenizer.tokenize(in_str, i);
+        std::cout << "[Q] " << in_str << std::endl;
+        std::cout << "[A] " << std::flush;
+        for (int step = 0; step < 100; step++) {
+            auto result = model({input_tensor});
+            auto outputs = tokenizer.detokenize(result[0]);
+            auto out_string = outputs.first;
+            auto out_token = outputs.second;
+            if (out_token == 2) {
+                break;
+            }
+            std::cout << out_string << std::flush;
+            chatPostProcessing(out_token, input_tensor, {});
+        }
+        printf("\n");
+    }
+
+    return 0;
+}

--- a/examples/demo_gemma.cpp
+++ b/examples/demo_gemma.cpp
@@ -31,13 +31,13 @@ int main(int argc, char **argv) {
 
     auto tokenizer = GemmaTokenizer(vocab_path);
 
-    GemmaConfig config(tokens_limit, "2B");
+    GemmaConfig config(tokens_limit, "2B", RoPEType::HFHUBROPE);
     auto model = GemmaForCausalLM(config);
     model.load(model_path);
 
     vector<string> in_strs = {
-        " Hello, who are you?",
-        " What can you do?",
+        "Hello, who are you?",
+        "What can you do?",
         "Please introduce Beijing University of Posts and Telecommunications."};
 
     for (int i = 0; i < in_strs.size(); ++i) {
@@ -50,9 +50,6 @@ int main(int argc, char **argv) {
             auto outputs = tokenizer.detokenize(result[0]);
             auto out_string = outputs.first;
             auto out_token = outputs.second;
-            if (out_token == 2) {
-                break;
-            }
             std::cout << out_string << std::flush;
             chatPostProcessing(out_token, input_tensor, {});
         }

--- a/examples/demo_gemma.cpp
+++ b/examples/demo_gemma.cpp
@@ -18,7 +18,7 @@ using namespace mllm;
 
 int main(int argc, char **argv) {
     cmdline::parser cmdParser;
-    cmdParser.add<string>("vocab", 'v', "specify mllm tokenizer model path", false, "../vocab/gemma/gemma_vocab.mllm");
+    cmdParser.add<string>("vocab", 'v', "specify mllm tokenizer model path", false, "../models/gemma/gemma_vocab.mllm");
     cmdParser.add<string>("model", 'm', "specify mllm model path", false, "../models/gemma/gemma-2b-q4_k.mllm");
     cmdParser.add<int>("limits", 'l', "max KV cache size", false, 400);
     cmdParser.add<int>("thread", 't', "num of threads", false, 4);

--- a/examples/demo_gemma.cpp
+++ b/examples/demo_gemma.cpp
@@ -18,8 +18,8 @@ using namespace mllm;
 
 int main(int argc, char **argv) {
     cmdline::parser cmdParser;
-    cmdParser.add<string>("vocab", 'v', "specify mllm tokenizer model path", false, "../models/gemma/gemma_vocab.mllm");
-    cmdParser.add<string>("model", 'm', "specify mllm model path", false, "../models/gemma/gemma-2b-q4_k.mllm");
+    cmdParser.add<string>("vocab", 'v', "specify mllm tokenizer model path", false, "../vocab/gemma_vocab.mllm");
+    cmdParser.add<string>("model", 'm', "specify mllm model path", false, "../models/gemma-2b-q4_k.mllm");
     cmdParser.add<int>("limits", 'l', "max KV cache size", false, 400);
     cmdParser.add<int>("thread", 't', "num of threads", false, 4);
     cmdParser.parse_check(argc, argv);

--- a/examples/demo_gemma.cpp
+++ b/examples/demo_gemma.cpp
@@ -50,6 +50,7 @@ int main(int argc, char **argv) {
             auto outputs = tokenizer.detokenize(result[0]);
             auto out_string = outputs.first;
             auto out_token = outputs.second;
+            if (out_token == tokenizer.eos_id) break;
             std::cout << out_string << std::flush;
             chatPostProcessing(out_token, input_tensor, {});
         }

--- a/examples/demo_gemma.cpp
+++ b/examples/demo_gemma.cpp
@@ -1,6 +1,6 @@
 /**
  * @file demo_gemma.cpp
- * @author Chenghua Wang (chenghua.wang@gmail.com)
+ * @author Chenghua Wang (chenghua.wang.edu@gmail.com)
  * @brief
  * @version 0.1
  * @date 2024-04-06
@@ -50,7 +50,7 @@ int main(int argc, char **argv) {
             auto outputs = tokenizer.detokenize(result[0]);
             auto out_string = outputs.first;
             auto out_token = outputs.second;
-            if (out_token == tokenizer.eos_id) break;
+            if (out_token == tokenizer.eos_id && step != 0) break;
             std::cout << out_string << std::flush;
             chatPostProcessing(out_token, input_tensor, {});
         }

--- a/include/Types.hpp
+++ b/include/Types.hpp
@@ -26,8 +26,8 @@ typedef enum {
 
 enum TensorStatus {
     TENSOR_DYNAMIC,
-    TENSOR_STATIC_INIT ,
-    TENSOR_STATIC_READY ,
+    TENSOR_STATIC_INIT,
+    TENSOR_STATIC_READY,
 };
 
 enum ErrorCode {
@@ -69,7 +69,6 @@ enum ChlType {
     DBHS = 13
 };
 
-
 inline std::map<std::vector<int>, ChlType> Chls2Type = {
     {{0, 2, 3, 1}, BDHS},
     {{0, 1, 3, 2}, BHDS},
@@ -79,9 +78,7 @@ inline std::map<std::vector<int>, ChlType> Chls2Type = {
     {{1, 2, 3, 0}, DBHS},
     {{0, 1, 2, 3, 4}, BTHWC},
     {{0, 2, 3, 4, 1}, BCTHW},
-    {{0, 3, 4, 1, 2}, BWCTH}
-};
-
+    {{0, 3, 4, 1, 2}, BWCTH}};
 
 enum TensorType {
     INPUT_TENSOR = 0,
@@ -94,8 +91,8 @@ enum Chl {
     HEAD = 2,
     DIMENSION = 3,
 
-    HD = 113, //only use for split attn.in_proj
-    D_HD = 313, //only use for split attn.in_proj
+    HD = 113,   // only use for split attn.in_proj
+    D_HD = 313, // only use for split attn.in_proj
 
     CHANNLE = 1,
     TIME = 2,
@@ -152,7 +149,7 @@ typedef __fp16 mllm_fp16_t;
 typedef uint16_t mllm_fp16_t;
 #endif
 
-//#define MLLM_QKK_64
+// #define MLLM_QKK_64
 #ifdef MLLM_QKK_64
 #define QK_K 64
 #define K_SCALE_SIZE 4
@@ -164,7 +161,7 @@ typedef uint16_t mllm_fp16_t;
 
 #pragma pack(1)
 typedef struct {
-    mllm_fp16_t d;            // delta
+    mllm_fp16_t d;         // delta
     uint8_t qs[QK4_0 / 2]; // nibbles / quants
 } block_q4_0;
 #pragma pack()
@@ -176,7 +173,7 @@ typedef struct {
 #ifdef MLLM_QKK_64
 #pragma pack(1)
 typedef struct {
-    mllm_fp16_t d[2];        // super-block scales/mins
+    mllm_fp16_t d[2];     // super-block scales/mins
     uint8_t scales[2];    // 4-bit block scales/mins
     uint8_t qs[QK_K / 2]; // 4--bit quants
 } block_q4_K;
@@ -185,8 +182,8 @@ static_assert(sizeof(block_q4_K) == 2 * sizeof(uint16_t) + QK_K / 2 + 2, "wrong 
 #else
 #pragma pack(1)
 typedef struct {
-    mllm_fp16_t d;                   // super-block scale for quantized scales
-    mllm_fp16_t dmin;                // super-block scale for quantized mins
+    mllm_fp16_t d;                // super-block scale for quantized scales
+    mllm_fp16_t dmin;             // super-block scale for quantized mins
     uint8_t scales[K_SCALE_SIZE]; // scales and mins, quantized with 6 bits
     uint8_t qs[QK_K / 2];         // 4--bit quants
 } block_q4_K;
@@ -202,12 +199,12 @@ typedef struct {
     mllm_fp16_t d;            // super-block scale
 } block_q6_K;
 #pragma pack()
-static_assert(sizeof(block_q6_K) == sizeof(mllm_fp16_t) + QK_K / 16 + 3*QK_K/4, "wrong q6_K block size/padding");
+static_assert(sizeof(block_q6_K) == sizeof(mllm_fp16_t) + QK_K / 16 + 3 * QK_K / 4, "wrong q6_K block size/padding");
 
 #define QK8_0 32
 #pragma pack(1)
 typedef struct {
-    mllm_fp16_t d;       // delta
+    mllm_fp16_t d;    // delta
     int8_t qs[QK8_0]; // quants
 } block_q8_0;
 #pragma pack()
@@ -256,28 +253,28 @@ static string DataTypeName(DataType dataType) {
         return "Unknown";
     }
 }
-static size_t DataTypeSize(DataType dtype, int count=1) {
+static size_t DataTypeSize(DataType dtype, int count = 1) {
     switch (dtype) {
     case MLLM_TYPE_F32:
-        return sizeof(float) *count;
+        return sizeof(float) * count;
     case MLLM_TYPE_F16:
-        return sizeof(mllm_fp16_t)*count;
+        return sizeof(mllm_fp16_t) * count;
     case MLLM_TYPE_I32:
-        return sizeof(int)*count;
+        return sizeof(int) * count;
     case MLLM_TYPE_I16:
-        return sizeof(short)*count;
+        return sizeof(short) * count;
     case MLLM_TYPE_I8:
-        return sizeof(char)*count;
+        return sizeof(char) * count;
     case MLLM_TYPE_Q4_0:
-        return (sizeof(block_q4_0))*count / (QK4_0);
+        return (sizeof(block_q4_0)) * count / (QK4_0);
     case MLLM_TYPE_Q4_K:
-        return (sizeof(block_q4_K))*count / (QK_K);
+        return (sizeof(block_q4_K)) * count / (QK_K);
     case MLLM_TYPE_Q6_K:
-        return (sizeof(block_q6_K))*count / (QK_K);
+        return (sizeof(block_q6_K)) * count / (QK_K);
     case MLLM_TYPE_Q8_0:
-        return (sizeof(block_q8_0))*count / (QK8_0);
+        return (sizeof(block_q8_0)) * count / (QK8_0);
     case MLLM_TYPE_Q8_K:
-        return (sizeof(block_q8_K))*count / (QK_K);
+        return (sizeof(block_q8_K)) * count / (QK_K);
     case MLLM_TYPE_Q4_1:
     case MLLM_TYPE_Q8_1:
     case MLLM_TYPE_COUNT:
@@ -317,7 +314,6 @@ struct BackendConfig {
     /** user defined context */
     void *sharedContext = nullptr;
 };
-
 
 } // namespace mllm
 #endif //__cplusplus

--- a/src/Layer.hpp
+++ b/src/Layer.hpp
@@ -589,6 +589,14 @@ public:
         param_["epsilon"] = epsilon;
         init(std::move(name), OpType::RMSNORM);
     }
+
+    explicit RMSNorm(int norm_size, float epsilon, bool add_unit_offset, std::string name) {
+        param_["norm_size"] = norm_size;
+        param_["epsilon"] = epsilon;
+        param_["add_unit_offset"] = (float)add_unit_offset;
+        init(std::move(name), OpType::RMSNORM);
+    }
+
     Tensor &operator()(Tensor &input) {
         return _1I1O_OP(input);
     }

--- a/src/Layer.hpp
+++ b/src/Layer.hpp
@@ -16,6 +16,7 @@
 
 #include <regex>
 #include <string>
+#include <vector>
 
 namespace mllm {
 
@@ -178,11 +179,11 @@ protected:
             }
             switch (input0.status()) {
             case TENSOR_STATIC_INIT: {
-                if (Tensor::gph_.find(input0.name()) == Tensor::gph_.end()|| input0.count() != Tensor::gph_[input0.name()].count()) {
+                if (Tensor::gph_.find(input0.name()) == Tensor::gph_.end() || input0.count() != Tensor::gph_[input0.name()].count()) {
                     Tensor::gph_[input0.name()] = input0;
                     Tensor::gph_[input0.name()].setName(input0.name());
                 }
-                if (Tensor::gph_.find(input1.name()) == Tensor::gph_.end()|| input1.count() != Tensor::gph_[input1.name()].count()) {
+                if (Tensor::gph_.find(input1.name()) == Tensor::gph_.end() || input1.count() != Tensor::gph_[input1.name()].count()) {
                     Tensor::gph_[input1.name()] = input1;
                     Tensor::gph_[input1.name()].setName(input1.name());
                 }
@@ -252,11 +253,11 @@ protected:
                     Tensor::gph_[input0.name()] = input0;
                     Tensor::gph_[input0.name()].setName(input0.name());
                 }
-                if (Tensor::gph_.find(input1.name()) == Tensor::gph_.end()|| input1.count() != Tensor::gph_[input1.name()].count()) {
+                if (Tensor::gph_.find(input1.name()) == Tensor::gph_.end() || input1.count() != Tensor::gph_[input1.name()].count()) {
                     Tensor::gph_[input1.name()] = input1;
                     Tensor::gph_[input1.name()].setName(input1.name());
                 }
-                if (Tensor::gph_.find(input2.name()) == Tensor::gph_.end()|| input2.count() != Tensor::gph_[input0.name()].count()) {
+                if (Tensor::gph_.find(input2.name()) == Tensor::gph_.end() || input2.count() != Tensor::gph_[input0.name()].count()) {
                     Tensor::gph_[input2.name()] = input2;
                     Tensor::gph_[input2.name()].setName(input2.name());
                 }
@@ -608,12 +609,24 @@ public:
 class Split final : public Layer {
 public:
     Split() = default;
+
     explicit Split(int split_num, Chl split_dim, int split_dim_size, std::string name) {
         param_["split_num"] = (float)split_num;
         param_["split_dim"] = (float)split_dim;
         param_["split_dim_size"] = (float)split_dim_size;
         init(std::move(name), OpType::SPLIT);
     }
+
+    explicit Split(const std::vector<int> &each_dims, Chl split_dim, const std::string &name) {
+        param_["split_num"] = (float)each_dims.size();
+        param_["split_dim"] = (float)split_dim;
+        // store each dims
+        for (size_t i = 0; i < each_dims.size(); ++i) {
+            param_["split_dim_size_" + std::to_string(i)] = (float)each_dims[i];
+        }
+        init(std::move(name), OpType::SPLIT);
+    }
+
     vector<Tensor> operator()(Tensor &input) {
         return _1INO_OP(input, (int)param_["split_num"]);
     }

--- a/src/backends/cpu/CPURMSNorm.cpp
+++ b/src/backends/cpu/CPURMSNorm.cpp
@@ -7,7 +7,8 @@ namespace mllm {
 // int32_t opp = 897988541;
 
 // int32_t op_params[1];
-CPURMSNorm::CPURMSNorm(Backend *bn, string opName, int normSize, float epsilon, int threadCount) : thread_count(threadCount),
+CPURMSNorm::CPURMSNorm(Backend *bn, string opName, int normSize, float epsilon, bool add_unit_offset_, int threadCount) :
+    thread_count(threadCount), add_unit_offset_(add_unit_offset_),
     Op(bn, opName), epsilon_(epsilon) {
     // op_params[0] = 897988541;s, sizeof(float));
     // memcpy(&epsilon_, op_param)
@@ -40,13 +41,20 @@ ErrorCode CPURMSNorm::execute(vector<shared_ptr<Tensor>> inputs, vector<shared_p
                     float value = input->dataAt<float>(n, h, s, d);
                     sum_squares += (double)value * value;
                 }
-                const float mean = sum_squares/dim;
-                const float rms = 1.0f/sqrtf(mean + epsilon_);
-                // use memset to set the value of the memory block
-                #pragma omp parallel for num_threads(thread_count)
+                const float mean = sum_squares / dim;
+                const float rms = 1.0f / sqrtf(mean + epsilon_);
+// use memset to set the value of the memory block
+#pragma omp parallel for num_threads(thread_count)
                 for (int d = 0; d < dim; d++) {
                     float value = input->dataAt<float>(n, h, s, d);
-                    outputs[0]->setDataAt<float>(n, h, s, d, weight_.dataAt<float>(0, 0, 0, d) * value * rms);
+                    float weight = weight_.dataAt<float>(0, 0, 0, d);
+                    float output = value * rms;
+                    if (add_unit_offset_) {
+                        output = output * (1 + weight);
+                    } else {
+                        output = output * weight;
+                    }
+                    outputs[0]->setDataAt<float>(n, h, s, d, output);
                 }
             }
         }

--- a/src/backends/cpu/CPURMSNorm.hpp
+++ b/src/backends/cpu/CPURMSNorm.hpp
@@ -8,7 +8,7 @@ namespace mllm {
 
 class CPURMSNorm final : public Op {
 public:
-    CPURMSNorm(Backend *bn, string opName,int normSize, float epsilon = 1e-6,  int threadCount=4);
+    CPURMSNorm(Backend *bn, string opName, int normSize, float epsilon = 1e-6, bool add_unit_offset_ = false, int threadCount = 4);
     virtual ~CPURMSNorm() = default;
     virtual ErrorCode reshape(vector<shared_ptr<Tensor>> inputs, vector<shared_ptr<Tensor>> outputs) override;
     virtual ErrorCode load(AbstructLoader &loader) override;
@@ -25,6 +25,7 @@ private:
     int axis_ = 1;
     Tensor weight_;
     int normSize_;
+    bool add_unit_offset_;
     // Tensor bias_;
 };
 
@@ -33,7 +34,8 @@ public:
     virtual Op *create(OpParam op_param, Backend *bn, string name, int threadCount) const {
         int normSize = (int)op_param["norm_size"];
         float epsilon = (float)op_param["epsilon"];
-        return new CPURMSNorm(bn, name, normSize, epsilon, threadCount);
+        bool add_unit_offset_ = (op_param.find("add_unit_offset") == op_param.end()) ? false : true;
+        return new CPURMSNorm(bn, name, normSize, epsilon, add_unit_offset_, threadCount);
     }
 };
 } // namespace mllm

--- a/src/backends/cpu/CPUSplit.cpp
+++ b/src/backends/cpu/CPUSplit.cpp
@@ -2,69 +2,125 @@
 
 namespace mllm {
 
-CPUSplit::CPUSplit(Backend *bn,  string opName,  int splitNum, Chl splitDim, int splitDimSize, int threadCount) : thread_count(threadCount),
-    Op(bn, opName) {
-    split_num_ = splitNum;
-    split_dim_ = splitDim;
-    split_dim_size_ =  splitDimSize;
+CPUSplit::CPUSplit(Backend *bn, string opName, int splitNum, Chl splitDim, int splitDimSize, int threadCount, std::vector<int> each_dims) :
+    thread_count(threadCount), split_num_(splitNum), split_dim_(splitDim), split_dim_size_(splitDimSize), each_dims_(each_dims), Op(bn, opName) {
 }
 
 ErrorCode CPUSplit::reshape(vector<shared_ptr<Tensor>> inputs, vector<shared_ptr<Tensor>> outputs) {
-
     assert(split_num_ == outputs.size());
     assert(inputs.size() == 1);
     switch (split_dim_) {
-        case Chl::HEAD: {
-            assert(inputs[0]->head() % split_num_== 0);
-            for (auto &output: outputs) {
+    case Chl::HEAD: {
+        switch (split_dim_size_) {
+        case -1: /*using each_dims*/ {
+            // check shape
+            assert(each_dims_.size() > 0 && "split op with split_dims_size_ == 1 should has each_dims_ params");
+            {
+                int head_sum = 0;
+                for (auto item : each_dims_) head_sum += item;
+                assert(head_sum == inputs[0]->head() && "sum(each_dims_) miss match inputs[0]'s head dim");
+            }
+            assert(outputs.size() == each_dims_.size() && "outputs size miss match each_dims_ size");
+
+            // reshape output
+            for (size_t i = 0; i < each_dims_.size(); ++i) {
+                outputs[i]->reshape(inputs[0]->batch(), each_dims_[i], inputs[0]->sequence(), inputs[0]->dimension());
+            }
+            break;
+        }
+        default: /*split for same size*/ {
+            assert(inputs[0]->head() % split_num_ == 0);
+            for (auto &output : outputs) {
                 output->reshape(inputs[0]->batch(), inputs[0]->head() / split_num_, inputs[0]->sequence(), inputs[0]->dimension());
             }
             break;
         }
-        case Chl::SEQUENCE: {
-            assert(inputs[0]->sequence() % split_num_ == 0);
-            for (auto &output: outputs) {
-                output->reshape(inputs[0]->batch(), inputs[0]->head(), inputs[0]->sequence() / split_num_, inputs[0]->dimension());
-            }
-            break;
         }
-        case Chl::DIMENSION: {
-            assert(inputs[0]->dimension() % split_num_ == 0);
-            for (auto &output: outputs) {
-                output->reshape(inputs[0]->batch(), inputs[0]->head(), inputs[0]->sequence(), inputs[0]->dimension() / split_num_);
+        break;
+    }
+    case Chl::SEQUENCE: {
+        switch (split_dim_size_) {
+        case -1: /*using each_dims*/ {
+            // check shape
+            assert(each_dims_.size() > 0 && "split op with split_dims_size_ == 1 should has each_dims_ params");
+            {
+                int seq_sum = 0;
+                for (auto item : each_dims_) seq_sum += item;
+                assert(seq_sum == inputs[0]->sequence() && "sum(each_dims_) miss match inputs[0]'s sequence dim");
             }
-            break;
-        }
-        case D_HD: {
-            assert(inputs[0]->dimension() % split_num_ == 0);
-            for (auto &output: outputs) {
-                output->reshape(inputs[0]->batch(), split_dim_size_, inputs[0]->sequence(), inputs[0]->dimension() / (split_num_*split_dim_size_));
-            }
-            break;
-        }
-        case HD: {
-            assert(inputs[0]->dimension() % split_num_ == 0);
-            for (auto &output : outputs) {
-                output->reshape(inputs[0]->batch(), split_dim_size_, inputs[0]->sequence(), inputs[0]->dimension() / (split_num_ * split_dim_size_));
+            assert(outputs.size() == each_dims_.size() && "outputs size miss match each_dims_ size");
+
+            // reshape output
+            for (size_t i = 0; i < each_dims_.size(); ++i) {
+                outputs[i]->reshape(inputs[0]->batch(), inputs[0]->head(), each_dims_[i], inputs[0]->dimension());
             }
             break;
         }
         default: {
+            assert(inputs[0]->sequence() % split_num_ == 0);
+            for (auto &output : outputs) {
+                output->reshape(inputs[0]->batch(), inputs[0]->head(), inputs[0]->sequence() / split_num_, inputs[0]->dimension());
+            }
             break;
         }
+        }
+        break;
+    }
+    case Chl::DIMENSION: {
+        switch (split_dim_size_) {
+        case -1: /*using each_dims*/ {
+            // check shape
+            assert(each_dims_.size() > 0 && "split op with split_dims_size_ == 1 should has each_dims_ params");
+            {
+                int dimension_sum = 0;
+                for (auto item : each_dims_) dimension_sum += item;
+                assert(dimension_sum == inputs[0]->sequence() && "sum(each_dims_) miss match inputs[0]'s dimension dim");
+            }
+            assert(outputs.size() == each_dims_.size() && "outputs size miss match each_dims_ size");
+
+            // reshape output
+            for (size_t i = 0; i < each_dims_.size(); ++i) {
+                outputs[i]->reshape(inputs[0]->batch(), inputs[0]->head(), inputs[0]->sequence(), each_dims_[i]);
+            }
+            break;
+        }
+        default: {
+            assert(inputs[0]->dimension() % split_num_ == 0);
+            for (auto &output : outputs) {
+                output->reshape(inputs[0]->batch(), inputs[0]->head(), inputs[0]->sequence(), inputs[0]->dimension() / split_num_);
+            }
+            break;
+        }
+        }
+        break;
+    }
+    case Chl::D_HD: {
+        assert(inputs[0]->dimension() % split_num_ == 0);
+        for (auto &output : outputs) {
+            output->reshape(inputs[0]->batch(), split_dim_size_, inputs[0]->sequence(), inputs[0]->dimension() / (split_num_ * split_dim_size_));
+        }
+        break;
+    }
+    case Chl::HD: {
+        assert(inputs[0]->dimension() % split_num_ == 0);
+        for (auto &output : outputs) {
+            output->reshape(inputs[0]->batch(), split_dim_size_, inputs[0]->sequence(), inputs[0]->dimension() / (split_num_ * split_dim_size_));
+        }
+        break;
+    }
+    default: {
+        break;
+    }
     }
     inputs[0]->addTensors(outputs, split_dim_);
     return Op::reshape(inputs, outputs);
 }
 
 ErrorCode CPUSplit::execute(vector<shared_ptr<Tensor>> inputs, vector<shared_ptr<Tensor>> outputs) {
-
     return Op::execute(inputs, outputs);
 }
 
 ErrorCode CPUSplit::setUp(vector<shared_ptr<Tensor>> inputs, vector<shared_ptr<Tensor>> outputs) {
-
     return Op::setUp(inputs, outputs);
 }
 } // namespace mllm
-

--- a/src/backends/cpu/CPUSplit.hpp
+++ b/src/backends/cpu/CPUSplit.hpp
@@ -9,7 +9,7 @@ namespace mllm {
 
 class CPUSplit final : public Op {
 public:
-    CPUSplit(Backend *bn, string opName, int splitNum, Chl splitDim, int splitDimSize, int threadCount);
+    CPUSplit(Backend *bn, string opName, int splitNum, Chl splitDim, int splitDimSize, int threadCount, std::vector<int> each_dims = {});
     virtual ~CPUSplit() = default;
     virtual ErrorCode reshape(vector<shared_ptr<Tensor>> inputs, vector<shared_ptr<Tensor>> outputs) override;
     virtual ErrorCode execute(vector<shared_ptr<Tensor>> inputs, vector<shared_ptr<Tensor>> outputs) override;
@@ -20,6 +20,7 @@ private:
     int split_num_;
     Chl split_dim_;
     int split_dim_size_;
+    std::vector<int> each_dims_;
 };
 
 class CPUSplitCreator : public CPUBackend::Creator {
@@ -27,8 +28,24 @@ public:
     virtual Op *create(OpParam op_param, Backend *bn, string name, int threadCount) const {
         int splitNum = (int)op_param["split_num"];
         Chl splitDim = (Chl)op_param["split_dim"];
-        int splitDimSize = (int)op_param["split_dim_size"];
-        return new CPUSplit(bn, name, splitNum, splitDim, splitDimSize,threadCount);
+        int splitDimSize;
+        if (op_param.find("split_dim_size") != op_param.end()) {
+            splitDimSize = (int)op_param["split_dim_size"];
+        } else {
+            splitDimSize = -1;
+        }
+
+        // if using each_dim
+        std::vector<int> each_dims = {};
+        if (splitDimSize == -1) {
+            int cnt = 0;
+            while (true) {
+                auto iter = op_param.find("split_dim_size_" + std::to_string(cnt++));
+                if (iter == op_param.end()) break;
+                each_dims.push_back((int)iter->second);
+            }
+        }
+        return new CPUSplit(bn, name, splitNum, splitDim, splitDimSize, threadCount, each_dims);
     }
 };
 

--- a/src/backends/new_op.py
+++ b/src/backends/new_op.py
@@ -16,7 +16,7 @@ namespace mllm {
 class CPUAbc final : public Op {
 public:
     CPUAbc(Backend *bn, string opName, int threadCount);
-    ~CPUReplace() override = default;
+    ~CPUAbc() override = default;
     ErrorCode reshape(vector<shared_ptr<Tensor>> inputs, vector<shared_ptr<Tensor>> outputs) override;
     ErrorCode execute(vector<shared_ptr<Tensor>> inputs, vector<shared_ptr<Tensor>> outputs) override;
     ErrorCode load(AbstructLoader &loader) override;

--- a/src/models/gemma/README.md
+++ b/src/models/gemma/README.md
@@ -2,6 +2,54 @@
 
 ## Arch
 
+## Config
+
+### 2B
+
+```python
+# The number of tokens in the vocabulary.
+vocab_size: int = 256000
+# The maximum sequence length that this model might ever be used with.
+max_position_embeddings: int = 8192
+# The number of blocks in the model.
+num_hidden_layers: int = 18
+# The number of attention heads used in the attention layers of the model.
+num_attention_heads: int = 8
+# The number of key-value heads for implementing attention.
+num_key_value_heads: int = 1
+# The hidden size of the model.
+hidden_size: int = 2048
+# The dimension of the MLP representations.
+intermediate_size: int = 16384
+# The number of head dimensions.
+head_dim: int = 256
+# The epsilon used by the rms normalization layers.
+rms_norm_eps: float = 1e-6
+```
+
+### 7B
+
+```python
+# The number of tokens in the vocabulary.
+vocab_size: int = 256000
+# The maximum sequence length that this model might ever be used with.
+max_position_embeddings: int = 8192
+# The number of blocks in the model.
+num_hidden_layers: int = 28
+# The number of attention heads used in the attention layers of the model.
+num_attention_heads: int = 16
+# The number of key-value heads for implementing attention.
+num_key_value_heads: int = 16
+# The hidden size of the model.
+hidden_size: int = 3072
+# The dimension of the MLP representations.
+intermediate_size: int = 24576
+# The number of head dimensions.
+head_dim: int = 256
+# The epsilon used by the rms normalization layers.
+rms_norm_eps: float = 1e-6
+```
+
 ## Limits
 
 ## Licence

--- a/src/models/gemma/README.md
+++ b/src/models/gemma/README.md
@@ -1,6 +1,16 @@
 # Gemma LLM
 
+see https://ai.google.dev/gemma/docs
+
+> Gemma is a family of lightweight, state-of-the-art open models from Google, built from the same research and technology used to create the Gemini models. They are text-to-text, decoder-only large language models, available in English, with open weights, pre-trained variants, and instruction-tuned variants. Gemma models are well-suited for a variety of text generation tasks, including question answering, summarization, and reasoning. Their relatively small size makes it possible to deploy them in environments with limited resources such as a laptop, desktop or your own cloud infrastructure, democratizing access to state of the art AI models and helping foster innovation for everyone.
+
 ## Arch
+
+Quite similar to Llama, with three main differences:
+
+1. the 2B version uses MQA
+2. RMSNorm uses unit_offset. 3.
+3. Gemma does sqrt(hidden_size) normalization (embed * sqrt(hidden_size)) on the embedding result after embedding.
 
 ## Config
 
@@ -50,6 +60,6 @@ head_dim: int = 256
 rms_norm_eps: float = 1e-6
 ```
 
-## Limits
-
 ## Licence
+
+Gemma Licence

--- a/src/models/gemma/README.md
+++ b/src/models/gemma/README.md
@@ -1,0 +1,7 @@
+# Gemma LLM
+
+## Arch
+
+## Limits
+
+## Licence

--- a/src/models/gemma/configuration_gemma.hpp
+++ b/src/models/gemma/configuration_gemma.hpp
@@ -1,0 +1,29 @@
+/**
+ * @file configuration_gemma.hpp
+ * @author Chenghua Wang (chenghua.wang@gmail.com)
+ * @brief configuration file of gemma llm.
+ * @version 0.1
+ * @date 2024-04-03
+ *
+ * @copyright Copyright (c) 2024
+ *
+ */
+
+#ifndef CONFIG_GEMMA_HPP
+#define CONFIG_GEMMA_HPP
+#include "models/transformer/configuration_transformer.hpp"
+
+using namespace mllm;
+
+class GemmaNameConfig : public TransformerNameConfig {
+public:
+private:
+};
+
+struct GemmaConfig {
+    explicit GemmaConfig(){
+
+    };
+};
+
+#endif //! CONFIG_GEMMA_HPP

--- a/src/models/gemma/configuration_gemma.hpp
+++ b/src/models/gemma/configuration_gemma.hpp
@@ -1,6 +1,6 @@
 /**
  * @file configuration_gemma.hpp
- * @author Chenghua Wang (chenghua.wang@gmail.com)
+ * @author Chenghua Wang (chenghua.wang.edu@gmail.com)
  * @brief configuration file of gemma llm.
  * @version 0.1
  * @date 2024-04-03

--- a/src/models/gemma/configuration_gemma.hpp
+++ b/src/models/gemma/configuration_gemma.hpp
@@ -43,6 +43,24 @@ public:
             lm_head_name = "lm_head";
             break;
         }
+        case RoPEType::LLAMAROPE: /*the gemma is same to llama*/ {
+            blk_name = "layers.";
+            _attn_base_name = "attention.";
+            _ffn_base_name = "feed_forward.";
+            _q_proj_name = "wq";
+            _k_proj_name = "wk";
+            _v_proj_name = "wv";
+            _o_proj_name = "wo";
+            _gate_proj_name = "w1";
+            _up_proj_name = "w3";
+            _down_proj_name = "w2";
+            _attn_norm_name = "attention_norm";
+            _ffn_norm_name = "ffn_norm";
+            token_embd_name = "tok_embeddings";
+            post_norm_name = "norm";
+            lm_head_name = "output";
+            break;
+        }
         default: {
             throw std::runtime_error("Unsupported gemma RoPE type");
         }
@@ -57,7 +75,7 @@ public:
 };
 
 struct GemmaConfig {
-    explicit GemmaConfig(int token_limit, const string billions = "2B") :
+    explicit GemmaConfig(int token_limit, const string billions = "2B", RoPEType type = RoPEType::HFHUBROPE) :
         cache_limit(token_limit) {
         names_config.init(RoPEType::HFHUBROPE);
         if (!(billions == "2B" || billions == "2b")) {

--- a/src/models/gemma/configuration_gemma.hpp
+++ b/src/models/gemma/configuration_gemma.hpp
@@ -40,7 +40,7 @@ public:
             _ffn_norm_name = "post_attention_layernorm";
             token_embd_name = "model.embed_tokens";
             post_norm_name = "model.norm";
-            lm_head_name = "lm_head";
+            lm_head_name = "model.embed_tokens";
             break;
         }
         case RoPEType::LLAMAROPE: /*the gemma is same to llama*/ {
@@ -58,7 +58,7 @@ public:
             _ffn_norm_name = "ffn_norm";
             token_embd_name = "tok_embeddings";
             post_norm_name = "norm";
-            lm_head_name = "output";
+            lm_head_name = "tok_embeddings";
             break;
         }
         default: {
@@ -77,10 +77,11 @@ public:
 struct GemmaConfig {
     explicit GemmaConfig(int token_limit, const string billions = "2B", RoPEType type = RoPEType::HFHUBROPE) :
         cache_limit(token_limit) {
-        names_config.init(RoPEType::HFHUBROPE);
+        names_config.init(type);
         if (!(billions == "2B" || billions == "2b")) {
             throw std::runtime_error("Unsupported model size");
         }
+        RoPE_type = type;
     };
 
     int vocab_size = 256000;
@@ -91,7 +92,7 @@ struct GemmaConfig {
     int hidden_size = 2048;
     int intermediate_size = 16384;
     int head_dim = 256;
-    float rms_norm_eps = 1e-6f;
+    float rms_norm_eps = 1e-6;
 
     int cache_limit;
     RoPEType RoPE_type = RoPEType::HFHUBROPE;

--- a/src/models/gemma/configuration_gemma.hpp
+++ b/src/models/gemma/configuration_gemma.hpp
@@ -11,19 +11,73 @@
 
 #ifndef CONFIG_GEMMA_HPP
 #define CONFIG_GEMMA_HPP
+#include "Types.hpp"
 #include "models/transformer/configuration_transformer.hpp"
 
 using namespace mllm;
 
 class GemmaNameConfig : public TransformerNameConfig {
 public:
-private:
+    /**
+     * @brief Gemma following the hugging face naming method
+     *
+     * @param type RoPEType
+     */
+    void init(RoPEType type = RoPEType::HFHUBROPE) {
+        switch (type) {
+        case RoPEType::HFHUBROPE: {
+            blk_name = "model.layers.";
+            _attn_base_name = "self_attn.";
+            _ffn_base_name = "mlp.";
+            _q_proj_name = "q_proj";
+            _k_proj_name = "k_proj";
+            _v_proj_name = "v_proj";
+            _o_proj_name = "o_proj";
+            _gate_proj_name = "gate_proj";
+            _up_proj_name = "up_proj";
+            _down_proj_name = "down_proj";
+            _attn_norm_name = "input_layernorm";
+            _ffn_norm_name = "post_attention_layernorm";
+            token_embd_name = "model.embed_tokens";
+            post_norm_name = "model.norm";
+            lm_head_name = "lm_head";
+            break;
+        }
+        default: {
+            throw std::runtime_error("Unsupported gemma RoPE type");
+        }
+        }
+    }
+
+    std::string blk_name;
+    std::string token_embd_name;
+    std::string post_norm_name;
+    std::string lm_head_name;
+    std::string _gate_proj_name;
 };
 
 struct GemmaConfig {
-    explicit GemmaConfig(){
-
+    explicit GemmaConfig(int token_limit, const string billions = "2B") :
+        cache_limit(token_limit) {
+        names_config.init(RoPEType::HFHUBROPE);
+        if (!(billions == "2B" || billions == "2b")) {
+            throw std::runtime_error("Unsupported model size");
+        }
     };
+
+    int vocab_size = 256000;
+    int max_position_embeddings = 8192;
+    int num_hidden_layers = 18;
+    int num_attention_heads = 8;
+    int num_key_value_heads = 1;
+    int hidden_size = 2048;
+    int intermediate_size = 16384;
+    int head_dim = 256;
+    float rms_norm_eps = 1e-6f;
+
+    int cache_limit;
+    RoPEType RoPE_type = RoPEType::HFHUBROPE;
+    GemmaNameConfig names_config;
 };
 
 #endif //! CONFIG_GEMMA_HPP

--- a/src/models/gemma/modeling_gemma.hpp
+++ b/src/models/gemma/modeling_gemma.hpp
@@ -11,10 +11,12 @@
 #ifndef MODELING_GEMMA_HPP
 #define MODELING_GEMMA_HPP
 
+#include "Backend.hpp"
 #include "Layer.hpp"
 #include "Module.hpp"
 #include "configuration_gemma.hpp"
 #include "models/transformer/modeling_transformer.hpp"
+#include <cmath>
 
 using namespace mllm;
 
@@ -47,25 +49,126 @@ private:
     Layer gelu; ///< F.gelu(gate, approximate="tanh")
 };
 
+///< gemma-2B use MQA while 7B use MHA
 class GemmaAttention final : public Module {
 public:
     GemmaAttention() = default;
-    GemmaAttention(int hidden_size, int num_heads, int num_kv_heads, int head_dims, int cache_limit, const GemmaNameConfig &names, const string &base_name) {
+    GemmaAttention(int hidden_size, int num_heads, int num_kv_heads, int head_dim, int cache_limit, const GemmaNameConfig &names, const string &base_name) :
+        hidden_size(hidden_size), num_heads(num_heads), num_kv_heads(num_kv_heads), head_dim(head_dim) {
+        assert(num_heads % num_kv_heads == 0 && "When using MQA/GQA. num_heads mod num_kv_heads should 0");
+
+        // for MQA and GQA
+        num_queries_per_kv = num_heads / num_kv_heads;
+        q_size = num_heads * head_dim;
+        kv_size = num_kv_heads * head_dim;
+
+        // scaling
+        scaling = 1.f / std::sqrt(head_dim);
+
+        // init layers
+        qkv_proj = Linear(hidden_size, (num_heads + 2 * num_kv_heads) * head_dim, false, base_name + names._qkv_proj_name);
+        qkv_split = Split({q_size, kv_size, kv_size}, Chl::DIMENSION, base_name + names._qkv_proj_name + ".split");
+        o_proj = Linear(num_heads * head_dim, hidden_size, false, base_name + names._o_proj_name);
+        // FIXME RoPEType::HFHUBROPE
+        q_rope = RoPE(RoPEType::HFHUBROPE, base_name + "q_rope");
+        k_rope = RoPE(RoPEType::HFHUBROPE, base_name + "k_rope");
+        if (cache_limit > 0) {
+            k_cache = KVCache(num_heads / num_kv_heads, cache_limit, base_name + "k_cache");
+            v_cache = KVCache(num_heads / num_kv_heads, cache_limit, base_name + "v_cache");
+        }
+        mask = Causalmask(base_name + "mask");
+        softmax = Softmax(DIMENSION, base_name + "softmax");
     }
 
     std::vector<Tensor> Forward(std::vector<Tensor> inputs, std::vector<std::any> args) override {
-        return {attention({inputs[0], inputs[0], inputs[0]})[0]};
+        auto hidden_sates = inputs[0];
+        auto hidden_sates_shape = hidden_sates.shape();
+        auto batch_size = hidden_sates_shape[0];
+        auto input_size = hidden_sates_shape[1];
+
+        auto qkv = qkv_proj(hidden_sates);
+        auto qkv_sp = qkv_split(qkv);
+        auto xq = qkv_sp[0];
+        auto xk = qkv_sp[1];
+        auto xv = qkv_sp[2];
+
+        xq = xq.view(batch_size, -1, num_heads, head_dim);
+        xk = xk.view(batch_size, -1, num_kv_heads, head_dim);
+        xv = xv.view(batch_size, -1, num_kv_heads, head_dim);
+
+        // position embedding
+        xq = q_rope(xq);
+        xk = k_rope(xk);
+
+        // kv cache
+        auto key = k_cache(xk);
+        auto value = v_cache(xv);
+
+        // repeat
+        if (num_kv_heads != num_heads) {
+            std::vector<Tensor> _key_repeat, _value_repeat;
+            for (int i = 0; i < num_queries_per_kv; ++i) _key_repeat.push_back(key);
+            for (int i = 0; i < num_queries_per_kv; ++i) _value_repeat.push_back(value);
+            key = Tensor::cat(_key_repeat, /*dims*/ Chl::SEQUENCE);
+            value = Tensor::cat(_value_repeat, /*dims*/ Chl::SEQUENCE);
+        }
+
+        // [batch, head, seq, dim]
+        auto q = xq.transpose(Chl::HEAD, Chl::SEQUENCE);
+        auto k = key.transpose(Chl::HEAD, Chl::SEQUENCE);
+        auto v = value.transpose(Chl::HEAD, Chl::SEQUENCE);
+
+        // [batch_size, n_local_heads, input_len, max_seq_len]
+        auto scores = Tensor::mm(q, k.transpose(Chl::SEQUENCE, Chl::DIMENSION)) * scaling;
+        scores = mask(scores);
+        scores = softmax(scores);
+
+        // output
+        auto output = Tensor::mm(scores, v);
+        // FIXME fix vie size.
+        output = output.transpose(Chl::HEAD, Chl::SEQUENCE).view(batch_size, input_size, -1, -1);
+        output = o_proj(output);
+        return {output};
     }
 
 private:
-    MultiHeadAttention attention;
+    int hidden_size;
+    int num_heads;
+    int num_kv_heads;
+    int head_dim;
+
+    int num_queries_per_kv;
+    int q_size;
+    int kv_size;
+    float scaling;
+
+    // layers
+    Layer qkv_proj;
+    Layer o_proj;
+    Split qkv_split;
+    Layer q_rope;
+    Layer k_rope;
+    Layer k_cache;
+    Layer v_cache;
+    Layer mask;
+    Layer softmax;
 };
 
 class GemmaDecoder final : public Module {
 public:
     GemmaDecoder() = default;
-    GemmaDecoder(const GemmaNameConfig &names, const string &base_name) {
-        // TODO
+    GemmaDecoder(const GemmaConfig &config, const GemmaNameConfig &names, const string &base_name) {
+        self_atten = GemmaAttention(
+            config.hidden_size,
+            config.num_attention_heads,
+            config.num_key_value_heads,
+            config.head_dim,
+            config.cache_limit,
+            names,
+            base_name);
+        mlp = GemmaMLP(config.hidden_size, config.intermediate_size, names, base_name);
+        input_layernorm = RMSNorm(config.hidden_size, config.rms_norm_eps, base_name + names._attn_norm_name);
+        post_attention_layernorm = RMSNorm(config.hidden_size, config.rms_norm_eps, base_name + names._ffn_norm_name);
     }
 
     std::vector<Tensor> Forward(std::vector<Tensor> inputs, std::vector<std::any> args) override {
@@ -93,6 +196,12 @@ private:
 
 class GemmaModle final : public Module {
 public:
+    GemmaModle() = default;
+    GemmaModle(const GemmaConfig &config, const GemmaNameConfig &names, const string &base_name) {
+        for (int i = 0; i < config.num_hidden_layers; ++i) layers.push_back(GemmaDecoder(config, names, base_name));
+        norm = RMSNorm(config.hidden_size, config.rms_norm_eps, base_name + names.post_norm_name);
+    }
+
     std::vector<Tensor> Forward(std::vector<Tensor> inputs, std::vector<std::any> args) override {
         auto x = inputs[0];
         for (auto &layer : layers) {
@@ -109,7 +218,21 @@ private:
 
 class GemmaForCausalLM final : public Module {
 public:
+    GemmaForCausalLM(GemmaConfig &config) {
+        auto names = config.names_config;
+        embedding = Embedding(config.vocab_size, config.hidden_size, names.token_embd_name);
+        model = GemmaModle(config, names, names.blk_name);
+    }
+
+    std::vector<Tensor> Forward(std::vector<Tensor> inputs, std::vector<std::any> args) override {
+        auto x = embedding(inputs[0]);
+        auto outputs = model({x});
+        return outputs;
+    }
+
 private:
+    Layer embedding;
+    GemmaModle model;
 };
 
 #endif //! MODELING_GEMMA_HPP

--- a/src/models/gemma/modeling_gemma.hpp
+++ b/src/models/gemma/modeling_gemma.hpp
@@ -1,0 +1,29 @@
+/**
+ * @file modeling_gemma.hpp
+ * @author Chenghua Wang (chenghua.wang@gmail.com)
+ * @brief The defination of gemma model
+ * @version 0.1
+ * @date 2024-04-03
+ *
+ * @copyright Copyright (c) 2024
+ *
+ */
+#ifndef MODELING_GEMMA_HPP
+#define MODELING_GEMMA_HPP
+
+#include "Layer.hpp"
+#include "Module.hpp"
+#include "configuration_gemma.hpp"
+#include "models/transformer/modeling_transformer.hpp"
+
+using namespace mllm;
+
+class GemmaMLP final : public Module {};
+
+class GemmaAttention final : public Module {};
+
+class GemmaDecoder final : public Module {};
+
+class GemmaModle final : public Module {};
+
+#endif //! MODELING_GEMMA_HPP

--- a/src/models/gemma/modeling_gemma.hpp
+++ b/src/models/gemma/modeling_gemma.hpp
@@ -146,10 +146,10 @@ private:
     Layer post_attention_layernorm;
 };
 
-class GemmaModle final : public Module {
+class GemmaModel final : public Module {
 public:
-    GemmaModle() = default;
-    GemmaModle(const GemmaConfig &config, const GemmaNameConfig &names, const string &base_name) {
+    GemmaModel() = default;
+    GemmaModel(const GemmaConfig &config, const GemmaNameConfig &names, const string &base_name) {
         blocks = List<GemmaDecoder>(config.num_hidden_layers, config, names, base_name);
         norm = RMSNorm(config.hidden_size, config.rms_norm_eps, true, names.post_norm_name);
     }
@@ -174,7 +174,7 @@ public:
         auto names = config.names_config;
         hidden_size = config.hidden_size;
         embedding = Embedding(config.vocab_size, config.hidden_size, names.token_embd_name);
-        model = GemmaModle(config, names, names.blk_name);
+        model = GemmaModel(config, names, names.blk_name);
 
         // gemma's lm_head and tok_embedding is tied together.
         // They share same parameters. Use a Transpose to do the lm_head instead.
@@ -197,7 +197,7 @@ private:
     int hidden_size;
     Layer embedding;
     Parameter lm_head;
-    GemmaModle model;
+    GemmaModel model;
 };
 
 #endif //! MODELING_GEMMA_HPP

--- a/src/models/gemma/modeling_gemma.hpp
+++ b/src/models/gemma/modeling_gemma.hpp
@@ -18,12 +18,98 @@
 
 using namespace mllm;
 
-class GemmaMLP final : public Module {};
+class GemmaMLP final : public Module {
+public:
+    GemmaMLP() = default;
+    GemmaMLP(int hidden_size, int intermediate_size, const GemmaNameConfig &names, const std::string &base_name) {
+        gate_proj = Linear(hidden_size, intermediate_size, false, base_name + names._gate_proj_name);
+        gelu = GELU(base_name + "act");
+        up_proj = Linear(hidden_size, intermediate_size, false, base_name + names._up_proj_name);
+        down_proj = Linear(intermediate_size, hidden_size, false, base_name + names._down_proj_name);
+    }
 
-class GemmaAttention final : public Module {};
+    std::vector<Tensor> Forward(std::vector<Tensor> inputs, std::vector<std::any> args) override {
+        auto x = inputs[0];
+        auto gate = gate_proj(x);
+        gate = gelu(x);
+        auto up = up_proj(x);
+        auto fuse = gate * up;
+        auto outputs = down_proj(fuse);
+        return {outputs};
+    }
 
-class GemmaDecoder final : public Module {};
+private:
+    Layer gate_proj;
+    Layer up_proj;
+    Layer down_proj;
 
-class GemmaModle final : public Module {};
+    // FIXME: Check the default method is gelu with tanh or not.
+    Layer gelu; ///< F.gelu(gate, approximate="tanh")
+};
+
+class GemmaAttention final : public Module {
+public:
+    GemmaAttention() = default;
+    GemmaAttention(int hidden_size, int num_heads, int num_kv_heads, int head_dims, int cache_limit, const GemmaNameConfig &names, const string &base_name) {
+    }
+
+    std::vector<Tensor> Forward(std::vector<Tensor> inputs, std::vector<std::any> args) override {
+        return {attention({inputs[0], inputs[0], inputs[0]})[0]};
+    }
+
+private:
+    MultiHeadAttention attention;
+};
+
+class GemmaDecoder final : public Module {
+public:
+    GemmaDecoder() = default;
+    GemmaDecoder(const GemmaNameConfig &names, const string &base_name) {
+        // TODO
+    }
+
+    std::vector<Tensor> Forward(std::vector<Tensor> inputs, std::vector<std::any> args) override {
+        // self attention
+        auto residual = inputs[0];
+        auto hidden_sates = input_layernorm(inputs[0]);
+        hidden_sates = self_atten({hidden_sates})[0];
+        hidden_sates = hidden_sates + residual;
+
+        // mlp
+        residual = hidden_sates;
+        hidden_sates = post_attention_layernorm(hidden_sates);
+        hidden_sates = mlp({hidden_sates})[0];
+        hidden_sates = residual + hidden_sates;
+
+        return {hidden_sates};
+    }
+
+private:
+    GemmaAttention self_atten;
+    GemmaMLP mlp;
+    Layer input_layernorm;
+    Layer post_attention_layernorm;
+};
+
+class GemmaModle final : public Module {
+public:
+    std::vector<Tensor> Forward(std::vector<Tensor> inputs, std::vector<std::any> args) override {
+        auto x = inputs[0];
+        for (auto &layer : layers) {
+            x = layer({x})[0];
+        }
+        x = norm(x);
+        return {x};
+    }
+
+private:
+    std::vector<GemmaDecoder> layers;
+    Layer norm;
+};
+
+class GemmaForCausalLM final : public Module {
+public:
+private:
+};
 
 #endif //! MODELING_GEMMA_HPP

--- a/src/models/gemma/modeling_gemma.hpp
+++ b/src/models/gemma/modeling_gemma.hpp
@@ -2,6 +2,7 @@
  * @file modeling_gemma.hpp
  * @author Chenghua Wang (chenghua.wang@gmail.com)
  * @brief The defination of gemma model
+ * https://github.com/huggingface/transformers/blob/main/src/transformers/models/gemma/modeling_gemma.py
  * @version 0.1
  * @date 2024-04-03
  *
@@ -124,8 +125,8 @@ public:
     GemmaDecoder(const GemmaConfig &config, const GemmaNameConfig &names, const string &base_name) {
         self_atten = GemmaAttention(config, names, base_name + names._attn_base_name);
         mlp = GemmaMLP(config.hidden_size, config.intermediate_size, names, base_name + names._ffn_base_name);
-        input_layernorm = RMSNorm(config.hidden_size, config.rms_norm_eps, base_name + names._attn_norm_name);
-        post_attention_layernorm = RMSNorm(config.hidden_size, config.rms_norm_eps, base_name + names._ffn_norm_name);
+        input_layernorm = RMSNorm(config.hidden_size, config.rms_norm_eps, true, base_name + names._attn_norm_name);
+        post_attention_layernorm = RMSNorm(config.hidden_size, config.rms_norm_eps, true, base_name + names._ffn_norm_name);
     }
 
     std::vector<Tensor> Forward(std::vector<Tensor> inputs, std::vector<std::any> args) override {
@@ -150,7 +151,7 @@ public:
     GemmaModle() = default;
     GemmaModle(const GemmaConfig &config, const GemmaNameConfig &names, const string &base_name) {
         blocks = List<GemmaDecoder>(config.num_hidden_layers, config, names, base_name);
-        norm = RMSNorm(config.hidden_size, config.rms_norm_eps, names.post_norm_name);
+        norm = RMSNorm(config.hidden_size, config.rms_norm_eps, true, names.post_norm_name);
     }
 
     std::vector<Tensor> Forward(std::vector<Tensor> inputs, std::vector<std::any> args) override {

--- a/src/models/gemma/modeling_gemma.hpp
+++ b/src/models/gemma/modeling_gemma.hpp
@@ -30,13 +30,12 @@ public:
     }
 
     std::vector<Tensor> Forward(std::vector<Tensor> inputs, std::vector<std::any> args) override {
-        auto x = inputs[0];
-        auto gate = gate_proj(x);
-        gate = gelu(gate);
-        auto up = up_proj(x);
-        auto fuse = gate * up;
-        auto outputs = down_proj(fuse);
-        return {outputs};
+        auto x = gate_proj(inputs[0]);
+        x = gelu(x);
+        auto y = up_proj(inputs[0]);
+        x = x * y;
+        x = down_proj(x);
+        return {x};
     }
 
 private:

--- a/src/models/gemma/tokenization_gemma.hpp
+++ b/src/models/gemma/tokenization_gemma.hpp
@@ -32,11 +32,11 @@ public:
 
     Tensor tokenize(std::string &text, int str_i = 0) const {
         // replace all blanck to '_'
-        text = BPETokenizer::replaceString(text, ' ', "▁");
+        std::string new_text = BPETokenizer::replaceString(text, ' ', "▁");
 
         // Returns a tokenized string. The Gemma tokenizer never adds a prefix space
         auto tokens_id = vector<token_id_t>();
-        tokenizer->tokenize(text, tokens_id, false);
+        tokenizer->tokenize(new_text, tokens_id, false);
 
         // insert <bos>
         tokens_id.insert(tokens_id.begin(), bos_id);

--- a/src/models/gemma/tokenization_gemma.hpp
+++ b/src/models/gemma/tokenization_gemma.hpp
@@ -1,6 +1,6 @@
 /**
  * @file tokenization_gemma.hpp
- * @author Chenghua Wang (chenghua.wang@gmail.com)
+ * @author Chenghua Wang (chenghua.wang.edu@gmail.com)
  * @version 0.1
  * @date 2024-04-03
  *
@@ -16,6 +16,7 @@
 
 #include "tokenizers/BPE/Bpe.hpp"
 #include <algorithm>
+#include <regex>
 
 using namespace mllm;
 
@@ -58,7 +59,9 @@ public:
             scores.push_back(value);
         }
         auto token_idx = this->argmax(scores);
-        return make_pair(tokenizer->detokenize({token_idx}), token_idx);
+        auto text = tokenizer->detokenize({token_idx});
+        text = std::regex_replace(text, std::regex("▁"), " ");
+        return make_pair(text, token_idx);
     }
 
 private:

--- a/src/models/gemma/tokenization_gemma.hpp
+++ b/src/models/gemma/tokenization_gemma.hpp
@@ -31,18 +31,9 @@ public:
     }
 
     Tensor tokenize(std::string &text, int str_i = 0) const {
-        // add blank char to the front of text as sentence piece did
-        // ['_'] is the beginning symbol of sentencepiece, indicating
-        // that the token is at the beginning of a word or sentence.
-        if (text[0] != ' ') {
-            text = ' ' + text;
-        }
+        // Returns a tokenized string. The Gemma tokenizer never adds a prefix space
         auto tokens_id = vector<token_id_t>();
         tokenizer->tokenize(text, tokens_id, true);
-        // if not the first sentence, add '\n' to first place.
-        if (str_i > 0) {
-            tokens_id[0] = 13;
-        }
         return BPETokenizer::tokens2Input(tokens_id);
     }
 

--- a/src/models/gemma/tokenization_gemma.hpp
+++ b/src/models/gemma/tokenization_gemma.hpp
@@ -1,0 +1,31 @@
+/**
+ * @file tokenization_gemma.hpp
+ * @author Chenghua Wang (chenghua.wang@gmail.com)
+ * @version 0.1
+ * @date 2024-04-03
+ *
+ * @copyright Copyright (c) 2024
+ *
+ */
+#ifndef TOKENIZATION_GEMMA_HPP
+#define TOKENIZATION_GEMMA_HPP
+
+#include "tokenizers/BPE/Bpe.hpp"
+#include <algorithm>
+
+using namespace mllm;
+
+class GemmaTokenizer final {
+public:
+private:
+    unsigned int argmax(const std::vector<float> &scores) {
+        if (scores.empty()) {
+            throw std::invalid_argument("Input vector is empty");
+        }
+        return std::max_element(scores.begin(), scores.end()) - scores.begin();
+    }
+
+    BPETokenizer *tokenizer;
+};
+
+#endif //! TOKENIZATION_GEMMA_HPP

--- a/src/quantizer/QuantWriter.cpp
+++ b/src/quantizer/QuantWriter.cpp
@@ -34,7 +34,7 @@ float *QuantWriter::getParam(std::string param_name) {
     return static_cast<float *>((void *)data);
 }
 
-vector<string> fp32_layers = {"norm", "rope", "bias","rotary_emb",
+vector<string> fp32_layers = {"norm", "rope", "bias","rotary_emb", "embed_tokens",
                                 "vision_embed_tokens",
                                 "embeddings", "logit_scale",  //, "tok_embeddings"};
                                 "modality_preprocessors", "modality_heads", "modality_postprocessors", "pre_transformer_layer"};


### PR DESCRIPTION
# What's new?

* Single precision inference support for the gemma-2B model.

![image](https://github.com/UbiquitousLearning/mllm/assets/68260701/33dea904-4047-4a0a-90fc-8f83aa60d721)

# Op Changed

## Split

A new SplitOp constructor with `each_dims` option.

```c++
Split(const std::vector<int> &each_dims, Chl split_dim, const std::string &name)
```

Support operation like(in python API):

```python
qkv.split([q_size, kv_size, kv_size], dim=-1)
```

## RMSNorm

A new RMSNorm constructor with `add_unit_offset` flag.

```c++
RMSNorm(int norm_size, float epsilon, bool add_unit_offset, std::string name)
```
If `add_unit_offset` flag is set, RMSNorm will do $output = output \times (1.f + weight)$. RMSNorm in Llama does not have an `add_unit_offset` operation, it only does $output = output \times weight$.

# The differences between Gemma and Llama

1. Multiply llama's input embeddings by $\sqrt{\text{hidden size}}$ -- gemma calls it normalization and applies to all inputs(be it from vocab or passed directly)
2. Add 1 to weights of LlamaRMSLayerNorm. Gemma's RMSNorm returns $output \times (1.f + weight)$, llama doesn't add 1.
3. The token embedding layer's weight is tied with lm_head.
4. Gemma-2b uses MQA instead of MHA.