### PR TITLE
feat: add Qwen2.5 0.5B Compatibility

### DIFF
--- a/examples/demo_qwen.cpp
+++ b/examples/demo_qwen.cpp
@@ -22,6 +22,7 @@ int main(int argc, char **argv) {
     cmdParser.add<string>("merge", 'e', "specify mllm merge file path", false, "../vocab/qwen_merges.txt");
     cmdParser.add<string>("model", 'm', "specify mllm model path", false, "../models/qwen-1.5-1.8b-q8_0.mllm");
     cmdParser.add<string>("billion", 'b', "[0.5B | 1.8B | 1.5B |]", false, "1.8B");
+    cmdParser.add<string>("version", 'r', "[Qwen1.5 | Qwen2.5 |]", false, "Qwen1.5");
     cmdParser.add<int>("limits", 'l', "max KV cache size", false, 400);
     cmdParser.add<int>("thread", 't', "num of threads", false, 4);
     cmdParser.parse_check(argc, argv);
@@ -30,11 +31,12 @@ int main(int argc, char **argv) {
     string merge_path = cmdParser.get<string>("merge");
     string model_path = cmdParser.get<string>("model");
     string model_billion = cmdParser.get<string>("billion");
+    string model_version = cmdParser.get<string>("version");
     int tokens_limit = cmdParser.get<int>("limits");
     CPUBackend::cpu_threads = cmdParser.get<int>("thread");
 
     auto tokenizer = QWenTokenizer(vocab_path, merge_path);
-    QWenConfig config(tokens_limit, model_billion, RoPEType::HFHUBROPE);
+    QWenConfig config(tokens_limit, model_billion, RoPEType::HFHUBROPE, model_version);
     auto model = QWenForCausalLM(config);
     model.load(model_path);
 
@@ -51,10 +53,10 @@ int main(int argc, char **argv) {
 
         LlmTextGeneratorOpts opt{
             .max_new_tokens = 100,
-            .do_sample = true,
-            .temperature = 0.3F,
-            .top_k = 50,
-            .top_p = 0.F,
+            .do_sample = false,
+            //.temperature = 0.7F,
+            //.top_k = 20,
+            //.top_p = 0.8F,
         };
         model.generate(input_tensor, opt, [&](unsigned int out_token) -> bool {
             auto out_string = tokenizer.detokenize({out_token});

--- a/src/models/qwen/configuration_qwen.hpp
+++ b/src/models/qwen/configuration_qwen.hpp
@@ -77,13 +77,17 @@ public:
 };
 
 struct QWenConfig : public TransformerConfig {
-    explicit QWenConfig(int token_limit, string billions = "0.5B", RoPEType type = RoPEType::HFHUBROPE) :
+    explicit QWenConfig(int token_limit, string billions = "0.5B", RoPEType type = RoPEType::HFHUBROPE, string model_version = "Qwen1.5") :
         cache_limit(token_limit) {
         names_config.init(type);
         string billionsType;
         std::transform(billions.begin(), billions.end(), std::back_inserter(billionsType),
                        ::tolower);
-        if (billionsType == "0.5b") {
+        string modelVersion;
+        std::transform(model_version.begin(), model_version.end(), std::back_inserter(modelVersion),
+                       ::tolower);
+
+        if (billionsType == "0.5b" && modelVersion == "qwen1.5") {
             attention_dropout = 0.0;
             bos_token_id = 151643;
             eos_token_id = 151645;
@@ -97,6 +101,25 @@ struct QWenConfig : public TransformerConfig {
             num_attention_heads = 16;
             num_hidden_layers = 24;
             num_key_value_heads = 16;
+            rms_norm_eps = 1e-6;
+            rope_theta = 1000000.0;
+            sliding_window = 32768;
+            vocab_size = 151936;
+            tie_embedding_words = true;
+        } else if (billionsType == "0.5b" && modelVersion == "qwen2.5") {
+            attention_dropout = 0.0;
+            bos_token_id = 151643;
+            eos_token_id = 151645;
+            std::string hidden_act = "silu";
+            hidden_size = 896;
+            initializer_range = 0.02;
+            intermediate_size = 4864;
+            max_position_embeddings = 32768;
+            max_window_layers = 21;
+            model_type = "qwen2";
+            num_attention_heads = 14;
+            num_hidden_layers = 24;
+            num_key_value_heads = 2;
             rms_norm_eps = 1e-6;
             rope_theta = 1000000.0;
             sliding_window = 32768;
@@ -116,7 +139,7 @@ struct QWenConfig : public TransformerConfig {
             sliding_window = 32768;
             vocab_size = 151936;
             tie_embedding_words = false;
-        } else if (billionsType == "1.5b") {
+        } else if (billionsType == "1.5b" && modelVersion == "qwen2.5") {
             attention_dropout = 0.0;
             std::string hidden_act = "silu";
             hidden_size = 1536;


### PR DESCRIPTION
### 1. Description
The current mllm cannot handle Qwen2.5 0.5B models.
For example, the existing mllm throws dummy words even though the model is FP32.
However, now `QwenConfig` can handle Qwen2.5 0.5B models.

Basically, this modified `QwenConfig` class and its member functions do not harm the compatibility of the existing functionalities.
> **Compatible Quantized Models**: fp32, q4_0


### 2. Usage
The default Qwen model version of `QwenConfig` is 1.5.
To use Qwen2.5 0.5B models, you can add only "Qwen2.5" string to the arguments when constructing "QwenConfig" object.

```cpp
// demo_qwen.cpp

// model_version can be "qwen2.5" or "Qwen2.5"
// default model_version is "Qwen1.5"
QWenConfig config(tokens_limit, model_billion, RoPEType::HFHUBROPE, model_version);
```

```bash
# execution command example
./bin/demo_qwen \
    -m qwen2.5-0.5b-instruct-q4_k.mllm \
    -v vocab/qwen2.5_vocab.mllm \
    -e vocab/qwen2.5_merges.txt \
    -b 0.5B \
    -r Qwen2.5
```


### 3. Model Files
I utilized the quantization and converters that mllm team provides.
And, the files for deployment of `qwen2.5-0.5b` models are uploaded on my huggingface repository and you can download the file with `curl` command.

Click [here](https://huggingface.co/kjh2159/Qwen2.5-0.5B-Instruct-MLLM/tree/main) for the huggingface repository.

Execute the following command to download it.
```bash
curl -L https://huggingface.co/kjh2159/Qwen2.5-0.5B-Instruct-MLLM/resolve/main/qwen2.5-0.5b-instruct_q4_0.mllm --output qwen2.5-0.5b-instruct_q4_0.mllm
```