### PR TITLE
feat(tools): add mllm-params-inspector tool

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,8 +119,7 @@ install(
   PATTERN "*.hpp")
 
 # Install tools
-# install(TARGETS mllm-quantizer mllm-tokenize-checker mllm-power-counter
-#                 mllm-runner RUNTIME DESTINATION bin)
+install(TARGETS mllm-params-inspector DESTINATION bin)
 
 # Final config and file copy.
 install(

--- a/tests/core/CMakeLists.txt
+++ b/tests/core/CMakeLists.txt
@@ -1,12 +1,12 @@
 if(MLLM_BUILD_ARM_BACKEND)
-  set(MLLM_HOST_BACKEND_UTILS_TEST MllmArmBackend)
+  set(MLLM_HOST_BACKEND_CORE_TEST MllmArmBackend)
 else()
-  set(MLLM_HOST_BACKEND_UTILS_TEST MllmX86Backend)
+  set(MLLM_HOST_BACKEND_CORE_TEST MllmX86Backend)
 endif()
 
 
 add_executable(Mllm-Test-Core-LoadParams LoadParamsTest.cpp)
-target_link_libraries(Mllm-Test-Core-LoadParams PRIVATE MllmRT ${MLLM_HOST_BACKEND_UTILS_TEST})
+target_link_libraries(Mllm-Test-Core-LoadParams PRIVATE MllmRT ${MLLM_HOST_BACKEND_CORE_TEST})
 target_include_directories(Mllm-Test-Core-LoadParams PRIVATE ${MLLM_INCLUDE_DIR})
 
 include(GoogleTest)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(mllm-params-inspector)

--- a/tools/mllm-params-inspector/CMakeLists.txt
+++ b/tools/mllm-params-inspector/CMakeLists.txt
@@ -1,0 +1,10 @@
+if(MLLM_BUILD_ARM_BACKEND)
+  set(MLLM_HOST_BACKEND_TOOLS MllmArmBackend)
+else()
+  set(MLLM_HOST_BACKEND_TOOLS MllmX86Backend)
+endif()
+
+
+add_executable(mllm-params-inspector main.cpp)
+target_link_libraries(mllm-params-inspector PRIVATE MllmRT ${MLLM_HOST_BACKEND_TOOLS})
+target_include_directories(mllm-params-inspector PRIVATE ${MLLM_INCLUDE_DIR})

--- a/tools/mllm-params-inspector/main.cpp
+++ b/tools/mllm-params-inspector/main.cpp
@@ -1,0 +1,31 @@
+#include "mllm/mllm.hpp"
+
+using mllm::Argparse;
+using mllm::load;
+using mllm::print;
+
+int main(int argc, char** argv) {
+  mllm::initializeContext();
+  auto& help = Argparse::add<bool>("-h|--help").help("Show help message");
+  auto& input_files = Argparse::add<std::string>("-i|--input").help("Input file path.").meta("FILE").positional();
+  auto& specific_params = Argparse::add<std::string>("-n|--name").help("Specific param name.");
+
+  Argparse::parse(argc, argv);
+
+  if (help.isSet()) {
+    Argparse::printHelp();
+    return 0;
+  }
+
+  if (!input_files.isSet()) {
+    MLLM_ERROR_EXIT(mllm::ExitCode::kCoreError, "No input file path provided");
+    Argparse::printHelp();
+    return -1;
+  }
+
+  if (specific_params.isSet()) {
+    print(load(input_files.get())->pull(specific_params.get()));
+  } else {
+    print(load(input_files.get()));
+  }
+}


### PR DESCRIPTION
- Implement mllm-params-inspector tool for inspecting parameters of a model
- Add new CMakeLists.txt for mllm-params-inspector in tools directory
- Update root CMakeLists.txt to include mllm-params-inspector installation
- Refactor test CMakeLists.txt to use MLLM_HOST_BACKEND_CORE_TEST variable
- Remove commented-out installation of other tools in root CMakeLists.txt