### PR TITLE
feat(x86 backend): implement arange and random fill operations for x8…

### DIFF
--- a/mllm/backends/cpu/kernels/x86/fill.hpp
+++ b/mllm/backends/cpu/kernels/x86/fill.hpp
@@ -18,4 +18,8 @@ void fill_ones(mllm_fp32_t* __restrict dst, size_t size, int thread_count);
 
 void fill_specific_value(mllm_fp32_t* __restrict dst, size_t size, float value, int thread_count);
 
+void fill_arange(mllm_fp32_t* __restrict dst, size_t size, float start, float end, float step, int thread_count);
+
+void fill_random(mllm_fp32_t* __restrict dst, size_t size, float start, float end, uint64_t seed, int thread_count);
+
 }  // namespace mllm::x86

--- a/mllm/backends/cpu/ops/FillOp.cpp
+++ b/mllm/backends/cpu/ops/FillOp.cpp
@@ -53,9 +53,31 @@ void CPUFillOp::forward(const std::vector<Tensor>& inputs, std::vector<Tensor>& 
       break;
     }
     case aops::FillOpTypes::kArange: {
+      switch (dst.dtype()) {
+        case kFloat32: {
+#if defined(MLLM_HOST_ARCH_X86_64) || defined(MLLM_HOST_ARCH_X86)
+          x86::fill_arange(dst.ptr<mllm_fp32_t>(), dst.numel(), options_.start, options_.end, options_.step, threads);
+#endif
+          break;
+        }
+        default: {
+          NYI("FillOp::forward[arange] not implemented for this data type");
+        }
+      }
       break;
     }
     case aops::FillOpTypes::kRandom: {
+      switch (dst.dtype()) {
+        case kFloat32: {
+#if defined(MLLM_HOST_ARCH_X86_64) || defined(MLLM_HOST_ARCH_X86)
+          x86::fill_random(dst.ptr<mllm_fp32_t>(), dst.numel(), options_.start, options_.end, options_.seed, threads);
+#endif
+          break;
+        }
+        default: {
+          NYI("FillOp::forward[random] not implemented for this data type")
+        }
+      }
       break;
     }
     case aops::FillOpTypes::kSpecific: {

--- a/mllm/core/aops/FillOp.hpp
+++ b/mllm/core/aops/FillOp.hpp
@@ -29,6 +29,7 @@ struct FillOpOptions : public BaseOpOptions<FillOpOptions> {
   float start = 0.f;
   float end = 0.f;
   float step = 0.f;
+  uint64_t seed = 42;
 };
 
 class FillOp : public BaseOp {

--- a/mllm/engine/Context.cpp
+++ b/mllm/engine/Context.cpp
@@ -88,4 +88,8 @@ SessionTCB::ptr_t Context::thisThread() {
 
 SessionTCB::ptr_t Context::mainThread() { return main_thread_; }
 
+void Context::setRandomSeed(uint64_t seed) { random_seed_ = seed; }
+
+uint64_t Context::getRandomSeed() { return random_seed_; }
+
 }  // namespace mllm

--- a/mllm/engine/Context.hpp
+++ b/mllm/engine/Context.hpp
@@ -50,7 +50,12 @@ class Context {
 
   SessionTCB::ptr_t mainThread();
 
+  void setRandomSeed(uint64_t seed);
+
+  uint64_t getRandomSeed();
+
  private:
+  uint64_t random_seed_ = 42;
   SessionTCB::ptr_t main_thread_;
   std::unordered_map<std::thread::id, SessionTCB::ptr_t> session_threads_;
 

--- a/mllm/mllm.cpp
+++ b/mllm/mllm.cpp
@@ -17,9 +17,7 @@ void shutdownContext() {
   // TODO
 }
 
-void setRandomSeed(uint32_t seed) {
-  // TODO
-}
+void setRandomSeed(uint64_t seed) { Context::instance().setRandomSeed(seed); }
 
 void setMaximumNumThreads(uint32_t num_threads) {
   // TODO

--- a/mllm/mllm.hpp
+++ b/mllm/mllm.hpp
@@ -55,7 +55,7 @@ inline void initializeContext() {
 
 void shutdownContext();
 
-void setRandomSeed(uint32_t seed);
+void setRandomSeed(uint64_t seed);
 
 void setMaximumNumThreads(uint32_t num_threads);
 

--- a/mllm/nn/Module.hpp
+++ b/mllm/nn/Module.hpp
@@ -124,12 +124,16 @@ class ModuleList final : public Module {
   ModuleList() = default;
 
   template<typename... Args>
-  ModuleList(const std::string& name, int nums, Args&&... args){
-      // TODO
+  ModuleList(const std::string& name, int nums, Args&&... args) : Module(name) {
+    for (int i = 0; i < nums; ++i) {
+      layers_.emplace_back(reg<T>(/*name*/ std::to_string(i), /*args*/ std::forward<Args>(args)...));
+    }
   };
 
   std::vector<Tensor> forward(const std::vector<Tensor>& inputs) override {
-    // TODO
+    std::vector<Tensor> o = inputs;
+    for (auto& layer : layers_) { o = layer.forward(o); }
+    return o;
   }
 
   std::vector<T>& list() { return layers_; }
@@ -143,12 +147,16 @@ class ModuleListSuffixed final : public Module {
   ModuleListSuffixed() = default;
 
   template<typename... Args>
-  ModuleListSuffixed(const std::string& name, int suffix_start, int nums, Args&&... args){
-      // TODO
+  ModuleListSuffixed(const std::string& name, int suffix_start, int nums, Args&&... args) : Module(name) {
+    for (int i = 0; i < nums; ++i) {
+      layers_.emplace_back(reg<T>(/*name*/ std::to_string(suffix_start + i), /*args*/ std::forward<Args>(args)...));
+    }
   };
 
   std::vector<Tensor> forward(const std::vector<Tensor>& inputs) override {
-    // TODO
+    std::vector<Tensor> o = inputs;
+    for (auto& layer : layers_) { o = layer.forward(o); }
+    return o;
   }
 
   std::vector<T>& list() { return layers_; }


### PR DESCRIPTION
…6 backend

- Add fill_arange and fill_random functions to x86/fill.cpp
- Update fill.hpp to include new function declarations
- Modify FillOp.cpp to support arange and random fill operations
- Implement arange and random functions in Tensor class
- Add random seed functionality to Context class
- Update mllm.cpp and mllm.hpp to use 64-bit random seed