### PR TITLE
feat(cpu): add ARM backend fill kernel support

### DIFF
--- a/mllm/backends/cpu/kernels/arm/fill.cpp
+++ b/mllm/backends/cpu/kernels/arm/fill.cpp
@@ -1,0 +1,178 @@
+/**
+ * @file fill.cpp
+ * @author chenghua wang (chenghua.wang.edu@gmail.com)
+ * @brief
+ * @version 0.1
+ * @date 2025-07-31
+ *
+ */
+#include "mllm/backends/cpu/kernels/arm/fill.hpp"
+#include "mllm/utils/CPUArchHelper.hpp"
+
+#if defined(MLLM_HOST_ARCH_ARM64) || defined(MLLM_HOST_ARCH_ARM)
+
+#include <arm_neon.h>
+
+namespace mllm::cpu::arm {
+void fill_zeros(mllm_fp32_t* __restrict dst, size_t size, int thread_count) {
+  constexpr size_t vec_size = 4;  // 4 floats in NEON
+  const float32x4_t zero_vec = vdupq_n_f32(0.0f);
+
+  size_t vec_end = size / vec_size * vec_size;
+  size_t i = 0;
+
+  // Vectorized fill
+  for (; i < vec_end; i += vec_size) { vst1q_f32(dst + i, zero_vec); }
+
+  // Handle remaining elements
+  for (; i < size; ++i) { dst[i] = 0.0f; }
+}
+
+void fill_ones(mllm_fp32_t* __restrict dst, size_t size, int thread_count) {
+  constexpr size_t vec_size = 4;  // 4 floats in NEON
+  const float32x4_t ones_vec = vdupq_n_f32(1.0f);
+
+  size_t vec_end = size / vec_size * vec_size;
+  size_t i = 0;
+
+  // Vectorized fill
+  for (; i < vec_end; i += vec_size) { vst1q_f32(dst + i, ones_vec); }
+
+  // Handle remaining elements
+  for (; i < size; ++i) { dst[i] = 1.0f; }
+}
+
+void fill_specific_value(mllm_fp32_t* __restrict dst, size_t size, float value, int thread_count) {
+  constexpr size_t vec_size = 4;  // 4 floats in NEON
+  const float32x4_t value_vec = vdupq_n_f32(value);
+
+  size_t vec_end = size / vec_size * vec_size;
+  size_t i = 0;
+
+  // Vectorized fill
+  for (; i < vec_end; i += vec_size) { vst1q_f32(dst + i, value_vec); }
+
+  // Handle remaining elements
+  for (; i < size; ++i) { dst[i] = value; }
+}
+
+void fill_arange(mllm_fp32_t* __restrict dst, size_t size, float start, float end, float step, int thread_count) {
+  constexpr size_t vec_size = 4;  // 4 floats in NEON
+
+  size_t vec_end = size / vec_size * vec_size;
+  size_t i = 0;
+
+  // Vectorized arange
+  float current_value = start;
+  for (; i < vec_end; i += vec_size) {
+    float32x4_t val_vec = {current_value, current_value + step, current_value + 2 * step, current_value + 3 * step};
+    vst1q_f32(dst + i, val_vec);
+    current_value += step * vec_size;
+  }
+
+  // Handle remaining elements
+  for (; i < size; ++i) { dst[i] = start + i * step; }
+}
+
+void fill_random(mllm_fp32_t* __restrict dst, size_t size, float start, float end, uint64_t seed, int thread_count) {
+  uint64_t state = seed;
+  const uint64_t multiplier = 1103515245ULL;
+  const uint64_t increment = 12345ULL;
+  const uint64_t modulus = 1ULL << 31;  // 2^31
+
+  float range = end - start;
+
+  for (size_t i = 0; i < size; ++i) {
+    state = (multiplier * state + increment) % modulus;
+
+    float random_value = static_cast<float>(state) / static_cast<float>(modulus - 1);
+    dst[i] = start + random_value * range;
+  }
+}
+
+void fill_zeros_fp16(mllm_fp16_t* __restrict dst, size_t size, int thread_count) {
+  constexpr size_t vec_size = 8;  // 8 float16_t in NEON
+  const float16x8_t zero_vec = vdupq_n_f16(0.0f);
+
+  size_t vec_end = size / vec_size * vec_size;
+  size_t i = 0;
+
+  // Vectorized fill
+  for (; i < vec_end; i += vec_size) { vst1q_f16(dst + i, zero_vec); }
+
+  // Handle remaining elements
+  for (; i < size; ++i) { dst[i] = 0.0f; }
+}
+
+void fill_ones_fp16(mllm_fp16_t* __restrict dst, size_t size, int thread_count) {
+  constexpr size_t vec_size = 8;  // 8 float16_t in NEON
+  const float16x8_t ones_vec = vdupq_n_f16(1.0f);
+
+  size_t vec_end = size / vec_size * vec_size;
+  size_t i = 0;
+
+  // Vectorized fill
+  for (; i < vec_end; i += vec_size) { vst1q_f16(dst + i, ones_vec); }
+
+  // Handle remaining elements
+  for (; i < size; ++i) { dst[i] = 1.0f; }
+}
+
+void fill_specific_value_fp16(mllm_fp16_t* __restrict dst, size_t size, float value, int thread_count) {
+  constexpr size_t vec_size = 8;  // 8 float16_t in NEON
+  const float16x8_t value_vec = vdupq_n_f16(value);
+
+  size_t vec_end = size / vec_size * vec_size;
+  size_t i = 0;
+
+  // Vectorized fill
+  for (; i < vec_end; i += vec_size) { vst1q_f16(dst + i, value_vec); }
+
+  // Handle remaining elements
+  for (; i < size; ++i) { dst[i] = value; }
+}
+
+void fill_arange_fp16(mllm_fp16_t* __restrict dst, size_t size, float start, float end, float step, int thread_count) {
+  constexpr size_t vec_size = 8;  // 8 float16_t in NEON
+
+  size_t vec_end = size / vec_size * vec_size;
+  size_t i = 0;
+
+  // Vectorized arange
+  float current_value = start;
+  for (; i < vec_end; i += vec_size) {
+    float16x8_t val_vec = {static_cast<float16_t>(current_value),
+                           static_cast<float16_t>(current_value + step),
+                           static_cast<float16_t>(current_value + 2 * step),
+                           static_cast<float16_t>(current_value + 3 * step),
+                           static_cast<float16_t>(current_value + 4 * step),
+                           static_cast<float16_t>(current_value + 5 * step),
+                           static_cast<float16_t>(current_value + 6 * step),
+                           static_cast<float16_t>(current_value + 7 * step)};
+    vst1q_f16(dst + i, val_vec);
+    current_value += step * vec_size;
+  }
+
+  // Handle remaining elements
+  for (; i < size; ++i) { dst[i] = start + i * step; }
+}
+
+void fill_random_fp16(mllm_fp16_t* __restrict dst, size_t size, float start, float end, uint64_t seed, int thread_count) {
+  uint64_t state = seed;
+  const uint64_t multiplier = 1103515245ULL;
+  const uint64_t increment = 12345ULL;
+  const uint64_t modulus = 1ULL << 31;  // 2^31
+
+  float range = end - start;
+
+  for (size_t i = 0; i < size; ++i) {
+    state = (multiplier * state + increment) % modulus;
+
+    float random_value = static_cast<float>(state) / static_cast<float>(modulus - 1);
+    dst[i] = static_cast<float16_t>(start + random_value * range);
+  }
+}
+
+}  // namespace mllm::cpu::arm
+
+#endif

--- a/mllm/backends/cpu/kernels/arm/fill.hpp
+++ b/mllm/backends/cpu/kernels/arm/fill.hpp
@@ -1,0 +1,39 @@
+/**
+ * @file fill.hpp
+ * @author chenghua wang (chenghua.wang.edu@gmail.com)
+ * @brief
+ * @version 0.1
+ * @date 2025-07-31
+ *
+ */
+#pragma once
+
+#include "mllm/core/DataTypes.hpp"
+#include "mllm/utils/CPUArchHelper.hpp"
+
+#if defined(MLLM_HOST_ARCH_ARM64) || defined(MLLM_HOST_ARCH_ARM)
+
+namespace mllm::cpu::arm {
+void fill_zeros(mllm_fp32_t* __restrict dst, size_t size, int thread_count);
+
+void fill_ones(mllm_fp32_t* __restrict dst, size_t size, int thread_count);
+
+void fill_specific_value(mllm_fp32_t* __restrict dst, size_t size, float value, int thread_count);
+
+void fill_arange(mllm_fp32_t* __restrict dst, size_t size, float start, float end, float step, int thread_count);
+
+void fill_random(mllm_fp32_t* __restrict dst, size_t size, float start, float end, uint64_t seed, int thread_count);
+
+void fill_zeros_fp16(mllm_fp16_t* __restrict dst, size_t size, int thread_count);
+
+void fill_ones_fp16(mllm_fp16_t* __restrict dst, size_t size, int thread_count);
+
+void fill_specific_value_fp16(mllm_fp16_t* __restrict dst, size_t size, float value, int thread_count);
+
+void fill_arange_fp16(mllm_fp16_t* __restrict dst, size_t size, float start, float end, float step, int thread_count);
+
+void fill_random_fp16(mllm_fp16_t* __restrict dst, size_t size, float start, float end, uint64_t seed, int thread_count);
+
+}  // namespace mllm::cpu::arm
+
+#endif

--- a/mllm/backends/cpu/kernels/x86/fill.cpp
+++ b/mllm/backends/cpu/kernels/x86/fill.cpp
@@ -8,6 +8,9 @@
  */
 #include "mllm/backends/cpu/kernels/x86/fill.hpp"
 #include "mllm/backends/cpu/kernels/x86/simd.hpp"
+#include "mllm/utils/CPUArchHelper.hpp"
+
+#if defined(MLLM_HOST_ARCH_X86_64) || defined(MLLM_HOST_ARCH_X86)
 
 namespace mllm::x86 {
 
@@ -179,3 +182,5 @@ void fill_random(mllm_fp32_t* __restrict dst, size_t size, float start, float en
 }
 
 }  // namespace mllm::x86
+
+#endif

--- a/mllm/backends/cpu/kernels/x86/fill.hpp
+++ b/mllm/backends/cpu/kernels/x86/fill.hpp
@@ -9,6 +9,9 @@
 #pragma once
 
 #include "mllm/core/DataTypes.hpp"
+#include "mllm/utils/CPUArchHelper.hpp"
+
+#if defined(MLLM_HOST_ARCH_X86_64) || defined(MLLM_HOST_ARCH_X86)
 
 namespace mllm::x86 {
 
@@ -23,3 +26,5 @@ void fill_arange(mllm_fp32_t* __restrict dst, size_t size, float start, float en
 void fill_random(mllm_fp32_t* __restrict dst, size_t size, float start, float end, uint64_t seed, int thread_count);
 
 }  // namespace mllm::x86
+
+#endif

--- a/tasks/build_osx_apple_silicon.yaml
+++ b/tasks/build_osx_apple_silicon.yaml
@@ -4,7 +4,7 @@ Tasks:
       cmake_build_type: "Release"
       cmake_extra_args:
         - "-DMLLM_BUILD_ARM_BACKEND=ON"
-        - '-DMLLM_CPU_BACKEND_COMPILE_OPTIONS="-march=native+fp16+fp16fml+dotprod+i8mm+sve2+sme;-ffast-math;-Wno-nan-infinity-disabled"'
+        - '-DMLLM_CPU_BACKEND_COMPILE_OPTIONS="-march=native+fp16+fp16fml+dotprod+i8mm+sme;-ffast-math;-Wno-nan-infinity-disabled"'
 
   - CMakeBuildTask:
       cmake_cfg_path: "build-osx"

--- a/tests/compile/ir/ProgramLoweringTest.cpp
+++ b/tests/compile/ir/ProgramLoweringTest.cpp
@@ -55,6 +55,7 @@ int main() {
     pm.run();
 
     print(ir_ctx);
+    mllm::cleanThisThread();
   }
   mllm::memoryReport();
 }

--- a/tests/compile/ir/TraceFooNetTest.cpp
+++ b/tests/compile/ir/TraceFooNetTest.cpp
@@ -46,6 +46,7 @@ int main() {
 
     auto ir_ctx = mllm::ir::trace(net, Tensor::empty({2, 1, 312, 1024}, kFloat32));
     print(ir_ctx);
+    mllm::cleanThisThread();
   }
   mllm::memoryReport();
 }


### PR DESCRIPTION
- Implement fill operations for ARM architecture using NEON intrinsics
- Add support for float and half-precision data types
- Include functions for filling zeros, ones, specific values, arange, and random values
- Update X86 fill kernel to use CPUArchHelper
- Adjust build configuration for Apple Silicon