### PR TITLE
feat(cpu): add support for transpose and permute operations

### DIFF
--- a/mllm/backends/cpu/CPUBackend.cpp
+++ b/mllm/backends/cpu/CPUBackend.cpp
@@ -14,12 +14,16 @@
 #include "mllm/backends/cpu/ops/FillOp.hpp"
 #include "mllm/backends/cpu/ops/GraphOps.hpp"
 #include "mllm/backends/cpu/ops/LinearOp.hpp"
+#include "mllm/backends/cpu/ops/PermuteOp.hpp"
+#include "mllm/backends/cpu/ops/ReduceOps.hpp"
+#include "mllm/backends/cpu/ops/TransposeOp.hpp"
 
 namespace mllm::cpu {
 
 CPUBackend::CPUBackend() : Backend(kCPU, createCPUAllocator()) {
   regOpFactory<CPULinearOpFactory, CPUFillOpFactory, CPUGraphBeginOpFactory, CPUGraphEndOpFactory, CPUAddOpFactory,
-               CPUSubOpFactory, CPUMulOpFactory, CPUDivOpFactory, CPUNegOpFactory>();
+               CPUSubOpFactory, CPUMulOpFactory, CPUDivOpFactory, CPUNegOpFactory, CPUReduceMaxOpFactory, CPUReduceMinOpFactory,
+               CPUReduceSumOpFactory, CPUTransposeOpFactory, CPUPermuteOpFactory>();
 }
 
 std::shared_ptr<CPUBackend> createCPUBackend() { return std::make_shared<CPUBackend>(); }

--- a/mllm/backends/cpu/kernels/Kernels.hpp
+++ b/mllm/backends/cpu/kernels/Kernels.hpp
@@ -17,4 +17,7 @@
 #if defined(MLLM_HOST_ARCH_ARM64) || defined(MLLM_HOST_ARCH_ARM)
 #include "mllm/backends/cpu/kernels/arm/fill.hpp"         // IWYU pragma: export
 #include "mllm/backends/cpu/kernels/arm/elementwise.hpp"  // IWYU pragma: export
+#include "mllm/backends/cpu/kernels/arm/reduce.hpp"       // IWYU pragma: export
+#include "mllm/backends/cpu/kernels/arm/transpose.hpp"    // IWYU pragma: export
+#include "mllm/backends/cpu/kernels/arm/permute.hpp"      // IWYU pragma: export
 #endif

--- a/mllm/backends/cpu/kernels/arm/elementwise.cpp
+++ b/mllm/backends/cpu/kernels/arm/elementwise.cpp
@@ -1,11 +1,6 @@
-/**
- * @file elementwise.cpp
- * @author chenghua wang (chenghua.wang.edu@gmail.com)
- * @brief
- * @version 0.1
- * @date 2025-07-31
- *
- */
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
+
 #include "mllm/core/DataTypes.hpp"
 #include "mllm/utils/CPUArchHelper.hpp"
 #include "mllm/backends/cpu/kernels/arm/elementwise.hpp"

--- a/mllm/backends/cpu/kernels/arm/elementwise.hpp
+++ b/mllm/backends/cpu/kernels/arm/elementwise.hpp
@@ -1,11 +1,6 @@
-/**
- * @file elementwise.hpp
- * @author chenghua wang (chenghua.wang.edu@gmail.com)
- * @brief
- * @version 0.1
- * @date 2025-07-31
- *
- */
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
+
 #pragma once
 
 #include "mllm/core/DataTypes.hpp"

--- a/mllm/backends/cpu/kernels/arm/fill.cpp
+++ b/mllm/backends/cpu/kernels/arm/fill.cpp
@@ -1,11 +1,6 @@
-/**
- * @file fill.cpp
- * @author chenghua wang (chenghua.wang.edu@gmail.com)
- * @brief
- * @version 0.1
- * @date 2025-07-31
- *
- */
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
+
 #include "mllm/backends/cpu/kernels/arm/fill.hpp"
 #include "mllm/utils/CPUArchHelper.hpp"
 

--- a/mllm/backends/cpu/kernels/arm/fill.hpp
+++ b/mllm/backends/cpu/kernels/arm/fill.hpp
@@ -1,11 +1,6 @@
-/**
- * @file fill.hpp
- * @author chenghua wang (chenghua.wang.edu@gmail.com)
- * @brief
- * @version 0.1
- * @date 2025-07-31
- *
- */
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
+
 #pragma once
 
 #include "mllm/core/DataTypes.hpp"

--- a/mllm/backends/cpu/kernels/arm/gelu.cpp
+++ b/mllm/backends/cpu/kernels/arm/gelu.cpp
@@ -1,11 +1,5 @@
-/**
- * @file gelu.cpp
- * @author chenghua wang (chenghua.wang.edu@gmail.com)
- * @brief
- * @version 0.1
- * @date 2025-07-29
- *
- */
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
 
 #include "mllm/utils/CPUArchHelper.hpp"
 

--- a/mllm/backends/cpu/kernels/arm/gelu.hpp
+++ b/mllm/backends/cpu/kernels/arm/gelu.hpp
@@ -1,11 +1,6 @@
-/**
- * @file gelu.hpp
- * @author chenghua wang (chenghua.wang.edu@gmail.com)
- * @brief
- * @version 0.1
- * @date 2025-07-29
- *
- */
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
+
 #pragma once
 
 #include "mllm/utils/CPUArchHelper.hpp"

--- a/mllm/backends/cpu/kernels/arm/linear/mkernel/u1.hpp
+++ b/mllm/backends/cpu/kernels/arm/linear/mkernel/u1.hpp
@@ -12,4 +12,28 @@
 
 #include "mllm/backends/cpu/kernels/arm/macro.hpp"
 
-namespace mllm::cpu::arm {}  // namespace mllm::cpu::arm
+namespace mllm::cpu::arm {
+
+// We use the code from torch for u1-u7 bits packing/unpacking.
+
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the license found in the
+// LICENSE file in the root directory of this source tree.
+MLLM_CPU_ARM_FORCE_INLINE void pack_8_uint1_values(uint8_t* packed, const uint8_t* unpacked) {
+  // Input is 8 bytes
+  // Output is 1 bytes
+  packed[0] = 0;
+#pragma unroll
+  for (int i = 0; i < 8; i++) { packed[0] |= (unpacked[i] << (7 - i)); }
+}
+
+MLLM_CPU_ARM_FORCE_INLINE void unpack_8_uint1_values(uint8_t* unpacked, const uint8_t* packed) {
+// Input is 8 bits = 1 byte
+// Output is 8 bytes
+#pragma unroll
+  for (int i = 0; i < 8; i++) { unpacked[i] = (packed[0] >> (7 - i)) & 1; }
+}
+
+}  // namespace mllm::cpu::arm

--- a/mllm/backends/cpu/kernels/arm/macro.hpp
+++ b/mllm/backends/cpu/kernels/arm/macro.hpp
@@ -1,11 +1,6 @@
-/**
- * @file macro.hpp
- * @author chenghua wang (chenghua.wang.edu@gmail.com)
- * @brief
- * @version 0.1
- * @date 2025-07-28
- *
- */
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
+
 #pragma once
 
 namespace mllm::cpu::arm {

--- a/mllm/backends/cpu/kernels/arm/math.hpp
+++ b/mllm/backends/cpu/kernels/arm/math.hpp
@@ -1,11 +1,6 @@
-/**
- * @file math.hpp
- * @author chenghua wang (chenghua.wang.edu@gmail.com)
- * @brief
- * @version 0.1
- * @date 2025-07-29
- *
- */
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
+
 #pragma once
 
 #include "mllm/utils/CPUArchHelper.hpp"

--- a/mllm/backends/cpu/kernels/arm/permute.cpp
+++ b/mllm/backends/cpu/kernels/arm/permute.cpp
@@ -1,0 +1,147 @@
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
+
+#include "mllm/backends/cpu/kernels/arm/permute.hpp"
+#include <vector>
+#include "mllm/utils/Common.hpp"
+
+#if defined(MLLM_HOST_ARCH_ARM64) || defined(MLLM_HOST_ARCH_ARM)
+
+namespace mllm::cpu::arm {
+
+namespace MLLM_ANONYMOUS_NAMESPACE {
+void compute_strides(const int* shape, int ndim, int* strides) {
+  strides[ndim - 1] = 1;
+  for (int i = ndim - 2; i >= 0; --i) { strides[i] = strides[i + 1] * shape[i + 1]; }
+}
+}  // namespace MLLM_ANONYMOUS_NAMESPACE
+
+void permute_fp32(const mllm_fp32_t* __restrict__ input, mllm_fp32_t* __restrict__ output, const int* __restrict__ in_shape,
+                  const int* __restrict__ perm, int ndim) {
+  std::vector<int> out_shape(ndim);
+  for (int i = 0; i < ndim; ++i) { out_shape[i] = in_shape[perm[i]]; }
+  std::vector<int> in_strides(ndim), out_strides(ndim);
+  compute_strides(in_shape, ndim, in_strides.data());
+  compute_strides(out_shape.data(), ndim, out_strides.data());
+  int total_elements = 1;
+  for (int i = 0; i < ndim; ++i) { total_elements *= in_shape[i]; }
+  bool inner_dim_contiguous = (perm[ndim - 1] == ndim - 1);
+  int inner_dim_size = out_shape[ndim - 1];
+  if (inner_dim_contiguous && inner_dim_size >= 4) {
+    int outer_elements = total_elements / inner_dim_size;
+    int chunk_size = 4;
+    for (int outer_idx = 0; outer_idx < outer_elements; ++outer_idx) {
+      std::vector<int> coord(ndim - 1);
+      int temp = outer_idx;
+      for (int i = ndim - 2; i >= 0; --i) {
+        coord[i] = temp % out_shape[i];
+        temp /= out_shape[i];
+      }
+      int in_offset = 0;
+      int out_offset = 0;
+      for (int i = 0; i < ndim - 1; ++i) {
+        int orig_dim = perm[i];
+        in_offset += coord[i] * in_strides[orig_dim];
+        out_offset += coord[i] * out_strides[i];
+      }
+      const float* in_ptr = input + in_offset;
+      float* out_ptr = output + out_offset;
+      int j = 0;
+      for (; j <= inner_dim_size - chunk_size; j += chunk_size) {
+        float32x4_t vec = vld1q_f32(in_ptr + j);
+        vst1q_f32(out_ptr + j, vec);
+      }
+      for (; j < inner_dim_size; ++j) { out_ptr[j] = in_ptr[j]; }
+    }
+  } else {
+    for (int linear_idx = 0; linear_idx < total_elements; ++linear_idx) {
+      std::vector<int> out_coord(ndim);
+      int temp = linear_idx;
+      for (int i = ndim - 1; i >= 0; --i) {
+        out_coord[i] = temp % out_shape[i];
+        temp /= out_shape[i];
+      }
+      std::vector<int> in_coord(ndim);
+      for (int i = 0; i < ndim; ++i) { in_coord[perm[i]] = out_coord[i]; }
+      int in_idx = 0;
+      for (int i = 0; i < ndim; ++i) { in_idx += in_coord[i] * in_strides[i]; }
+      output[linear_idx] = input[in_idx];
+    }
+  }
+}
+
+void permute_fp16(const mllm_fp16_t* __restrict__ input, mllm_fp16_t* __restrict__ output, const int* __restrict__ in_shape,
+                  const int* __restrict__ perm, int ndim) {
+  std::vector<int> out_shape(ndim);
+  for (int i = 0; i < ndim; ++i) { out_shape[i] = in_shape[perm[i]]; }
+
+  std::vector<int> in_strides(ndim), out_strides(ndim);
+  compute_strides(in_shape, ndim, in_strides.data());
+  compute_strides(out_shape.data(), ndim, out_strides.data());
+
+  int total_elements = 1;
+  for (int i = 0; i < ndim; ++i) { total_elements *= in_shape[i]; }
+
+  bool inner_dim_contiguous = (perm[ndim - 1] == ndim - 1);
+  int inner_dim_size = out_shape[ndim - 1];
+
+  if (inner_dim_contiguous && inner_dim_size >= 8) {
+    int outer_elements = total_elements / inner_dim_size;
+    const int chunk_size = 8;
+
+    for (int outer_idx = 0; outer_idx < outer_elements; ++outer_idx) {
+      std::vector<int> coord(ndim - 1);
+      int temp = outer_idx;
+      for (int i = ndim - 2; i >= 0; --i) {
+        coord[i] = temp % out_shape[i];
+        temp /= out_shape[i];
+      }
+
+      int in_offset = 0;
+      int out_offset = 0;
+      for (int i = 0; i < ndim - 1; ++i) {
+        int orig_dim = perm[i];
+        in_offset += coord[i] * in_strides[orig_dim];
+        out_offset += coord[i] * out_strides[i];
+      }
+
+      const float16_t* in_ptr = input + in_offset;
+      float16_t* out_ptr = output + out_offset;
+
+      int j = 0;
+      for (; j <= inner_dim_size - chunk_size; j += chunk_size) {
+        float16x8_t vec = vld1q_f16(in_ptr + j);
+        vst1q_f16(out_ptr + j, vec);
+      }
+
+      if (inner_dim_size - j >= 4) {
+        float16x4_t vec4 = vld1_f16(in_ptr + j);
+        vst1_f16(out_ptr + j, vec4);
+        j += 4;
+      }
+
+      for (; j < inner_dim_size; j++) { out_ptr[j] = in_ptr[j]; }
+    }
+  } else {
+    for (int linear_idx = 0; linear_idx < total_elements; ++linear_idx) {
+      std::vector<int> out_coord(ndim);
+      int temp = linear_idx;
+      for (int i = ndim - 1; i >= 0; --i) {
+        out_coord[i] = temp % out_shape[i];
+        temp /= out_shape[i];
+      }
+
+      std::vector<int> in_coord(ndim);
+      for (int i = 0; i < ndim; ++i) { in_coord[perm[i]] = out_coord[i]; }
+
+      int in_idx = 0;
+      for (int i = 0; i < ndim; ++i) { in_idx += in_coord[i] * in_strides[i]; }
+
+      output[linear_idx] = input[in_idx];
+    }
+  }
+}
+
+}  // namespace mllm::cpu::arm
+
+#endif

--- a/mllm/backends/cpu/kernels/arm/permute.hpp
+++ b/mllm/backends/cpu/kernels/arm/permute.hpp
@@ -1,0 +1,24 @@
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "mllm/core/DataTypes.hpp"
+#include "mllm/utils/CPUArchHelper.hpp"
+
+#if defined(MLLM_HOST_ARCH_ARM64) || defined(MLLM_HOST_ARCH_ARM)
+
+#include <cstddef>
+#include <arm_neon.h>
+
+namespace mllm::cpu::arm {
+
+void permute_fp32(const mllm_fp32_t* __restrict__ input, mllm_fp32_t* __restrict__ output, const int* __restrict__ in_shape,
+                  const int* __restrict__ perm, int ndim);
+
+void permute_fp16(const mllm_fp16_t* __restrict__ input, mllm_fp16_t* __restrict__ output, const int* __restrict__ in_shape,
+                  const int* __restrict__ perm, int ndim);
+
+}  // namespace mllm::cpu::arm
+
+#endif

--- a/mllm/backends/cpu/kernels/arm/primitives.hpp
+++ b/mllm/backends/cpu/kernels/arm/primitives.hpp
@@ -1,11 +1,6 @@
-/**
- * @file primitives.hpp
- * @author chenghua wang (chenghua.wang.edu@gmail.com)
- * @brief
- * @version 0.1
- * @date 2025-07-31
- *
- */
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
+
 #pragma once
 
 #include "mllm/core/DataTypes.hpp"

--- a/mllm/backends/cpu/kernels/arm/reduce.cpp
+++ b/mllm/backends/cpu/kernels/arm/reduce.cpp
@@ -1,11 +1,6 @@
-/**
- * @file reduce.cpp
- * @author chenghua wang (chenghua.wang.edu@gmail.com)
- * @brief
- * @version 0.1
- * @date 2025-07-31
- *
- */
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
+
 #include "mllm/backends/cpu/kernels/arm/reduce.hpp"
 #include "mllm/backends/cpu/kernels/arm/primitives.hpp"
 #include "mllm/core/DataTypes.hpp"

--- a/mllm/backends/cpu/kernels/arm/reduce.hpp
+++ b/mllm/backends/cpu/kernels/arm/reduce.hpp
@@ -1,11 +1,6 @@
-/**
- * @file reduce.hpp
- * @author chenghua wang (chenghua.wang.edu@gmail.com)
- * @brief
- * @version 0.1
- * @date 2025-07-31
- *
- */
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
+
 #pragma once
 
 #include "mllm/core/DataTypes.hpp"

--- a/mllm/backends/cpu/kernels/arm/relu.cpp
+++ b/mllm/backends/cpu/kernels/arm/relu.cpp
@@ -1,0 +1,10 @@
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
+
+#include "mllm/backends/cpu/kernels/arm/transpose.hpp"
+
+#if defined(MLLM_HOST_ARCH_ARM64) || defined(MLLM_HOST_ARCH_ARM)
+
+namespace mllm::cpu::arm {}
+
+#endif

--- a/mllm/backends/cpu/kernels/arm/relu.hpp
+++ b/mllm/backends/cpu/kernels/arm/relu.hpp
@@ -1,0 +1,13 @@
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
+#pragma once
+
+#include "mllm/utils/CPUArchHelper.hpp"
+
+#if defined(MLLM_HOST_ARCH_ARM64) || defined(MLLM_HOST_ARCH_ARM)
+
+#include <arm_neon.h>
+
+namespace mllm::cpu::arm {}
+
+#endif

--- a/mllm/backends/cpu/kernels/arm/transpose.cpp
+++ b/mllm/backends/cpu/kernels/arm/transpose.cpp
@@ -1,0 +1,268 @@
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
+
+#include "mllm/backends/cpu/kernels/arm/transpose.hpp"
+
+#if defined(MLLM_HOST_ARCH_ARM64) || defined(MLLM_HOST_ARCH_ARM)
+
+#include <cstddef>
+#include <arm_neon.h>
+
+namespace mllm::cpu::arm {
+
+void transpose_hw_wh_fp32(const mllm_fp32_t* __restrict X, mllm_fp32_t* __restrict Y, size_t H, size_t W) {
+  for (size_t i = 0; i + 4 <= H; i += 4) {
+    for (size_t j = 0; j + 4 <= W; j += 4) {
+      float32x4_t r0 = vld1q_f32(X + i * W + j);
+      float32x4_t r1 = vld1q_f32(X + (i + 1) * W + j);
+      float32x4_t r2 = vld1q_f32(X + (i + 2) * W + j);
+      float32x4_t r3 = vld1q_f32(X + (i + 3) * W + j);
+
+      float32x4x2_t r0r1 = vtrnq_f32(r0, r1);
+      float32x4x2_t r2r3 = vtrnq_f32(r2, r3);
+
+      float32x4_t col0 = vcombine_f32(vget_low_f32(r0r1.val[0]), vget_low_f32(r2r3.val[0]));
+      float32x4_t col1 = vcombine_f32(vget_low_f32(r0r1.val[1]), vget_low_f32(r2r3.val[1]));
+      float32x4_t col2 = vcombine_f32(vget_high_f32(r0r1.val[0]), vget_high_f32(r2r3.val[0]));
+      float32x4_t col3 = vcombine_f32(vget_high_f32(r0r1.val[1]), vget_high_f32(r2r3.val[1]));
+
+      vst1q_f32(Y + j * H + i, col0);
+      vst1q_f32(Y + (j + 1) * H + i, col1);
+      vst1q_f32(Y + (j + 2) * H + i, col2);
+      vst1q_f32(Y + (j + 3) * H + i, col3);
+    }
+
+    size_t j_remain = W - (W % 4);
+    for (size_t j = j_remain; j < W; ++j) {
+      float32x4_t col = {X[i * W + j], X[(i + 1) * W + j], X[(i + 2) * W + j], X[(i + 3) * W + j]};
+      vst1q_f32(Y + j * H + i, col);
+    }
+  }
+
+  size_t i_remain = H - (H % 4);
+  for (size_t j = 0; j < W; ++j) {
+    for (size_t i = i_remain; i < H; ++i) { Y[j * H + i] = X[i * W + j]; }
+  }
+}
+
+void transpose_bshd_bhsd_fp32(const mllm_fp32_t* __restrict X, mllm_fp32_t* __restrict Y, size_t B, size_t S, size_t H,
+                              size_t D) {
+  for (int b = 0; b < B; ++b) {
+    for (int h = 0; h < H; ++h) {
+      for (int s = 0; s < S; ++s) {
+        int d;
+        for (d = 0; d <= D - 4; d += 4) {
+          // B, S, H, D
+          const mllm_fp32_t* src_ptr = X + b * S * H * D + s * H * D + h * D + d;
+
+          // B, H, S, D
+          mllm_fp32_t* dst_ptr = Y + b * H * S * D + h * S * D + s * D + d;
+
+          float32x4_t data;
+          data = vld1q_f32(src_ptr);
+          vst1q_f32(dst_ptr, data);
+        }
+        for (; d < D; ++d) {
+          const mllm_fp32_t* src_ptr = X + b * S * H * D + s * H * D + h * D + d;
+          mllm_fp32_t* dst_ptr = Y + b * H * S * D + h * S * D + s * D + d;
+          *dst_ptr = *src_ptr;
+        }
+      }
+    }
+  }
+}
+
+void transpose_hw_wh_fp16(const mllm_fp16_t* __restrict X, mllm_fp16_t* __restrict Y, size_t H, size_t W) {
+  for (size_t i = 0; i + 4 <= H; i += 4) {
+    for (size_t j = 0; j + 8 <= W; j += 8) {
+      float16x8_t r0 = vld1q_f16(X + i * W + j);
+      float16x8_t r1 = vld1q_f16(X + (i + 1) * W + j);
+      float16x8_t r2 = vld1q_f16(X + (i + 2) * W + j);
+      float16x8_t r3 = vld1q_f16(X + (i + 3) * W + j);
+
+      float16x4_t r00 = vget_low_f16(r0);
+      float16x4_t r01 = vget_high_f16(r0);
+      float16x4_t r10 = vget_low_f16(r1);
+      float16x4_t r11 = vget_high_f16(r1);
+      float16x4_t r20 = vget_low_f16(r2);
+      float16x4_t r21 = vget_high_f16(r2);
+      float16x4_t r30 = vget_low_f16(r3);
+      float16x4_t r31 = vget_high_f16(r3);
+
+      float16x4x2_t tr00 = vtrn_f16(r00, r10);
+      float16x4x2_t tr01 = vtrn_f16(r20, r30);
+      float32x2x2_t tr00_32 = vtrn_f32(vreinterpret_f32_f16(tr00.val[0]), vreinterpret_f32_f16(tr01.val[0]));
+      float32x2x2_t tr01_32 = vtrn_f32(vreinterpret_f32_f16(tr00.val[1]), vreinterpret_f32_f16(tr01.val[1]));
+
+      float16x4x2_t tr10 = vtrn_f16(r01, r11);
+      float16x4x2_t tr11 = vtrn_f16(r21, r31);
+      float32x2x2_t tr10_32 = vtrn_f32(vreinterpret_f32_f16(tr10.val[0]), vreinterpret_f32_f16(tr11.val[0]));
+      float32x2x2_t tr11_32 = vtrn_f32(vreinterpret_f32_f16(tr10.val[1]), vreinterpret_f32_f16(tr11.val[1]));
+
+      float16x4_t col0 = vreinterpret_f16_f32(tr00_32.val[0]);
+      float16x4_t col1 = vreinterpret_f16_f32(tr01_32.val[0]);
+      float16x4_t col2 = vreinterpret_f16_f32(tr00_32.val[1]);
+      float16x4_t col3 = vreinterpret_f16_f32(tr01_32.val[1]);
+      float16x4_t col4 = vreinterpret_f16_f32(tr10_32.val[0]);
+      float16x4_t col5 = vreinterpret_f16_f32(tr11_32.val[0]);
+      float16x4_t col6 = vreinterpret_f16_f32(tr10_32.val[1]);
+      float16x4_t col7 = vreinterpret_f16_f32(tr11_32.val[1]);
+
+      vst1_f16(Y + (j)*H + i, col0);
+      vst1_f16(Y + (j + 1) * H + i, col1);
+      vst1_f16(Y + (j + 2) * H + i, col2);
+      vst1_f16(Y + (j + 3) * H + i, col3);
+      vst1_f16(Y + (j + 4) * H + i, col4);
+      vst1_f16(Y + (j + 5) * H + i, col5);
+      vst1_f16(Y + (j + 6) * H + i, col6);
+      vst1_f16(Y + (j + 7) * H + i, col7);
+    }
+
+    size_t j_remain = W - (W % 8);
+    for (size_t j = j_remain; j < W; ++j) {
+      for (size_t ii = 0; ii < 4; ++ii) { Y[j * H + i + ii] = X[(i + ii) * W + j]; }
+    }
+  }
+
+  size_t i_remain = H - (H % 4);
+  for (size_t j = 0; j < W; ++j) {
+    for (size_t i = i_remain; i < H; ++i) { Y[j * H + i] = X[i * W + j]; }
+  }
+}
+
+void transpose_bshd_bhsd_fp16(const mllm_fp16_t* __restrict X, mllm_fp16_t* __restrict Y, size_t B, size_t S, size_t H,
+                              size_t D) {
+  for (int b = 0; b < B; ++b) {
+    for (int h = 0; h < H; ++h) {
+      for (int s = 0; s < S; ++s) {
+        int d;
+        for (d = 0; d <= D - 8; d += 8) {
+          // B, S, H, D
+          const mllm_fp16_t* src_ptr = X + b * S * H * D + s * H * D + h * D + d;
+
+          // B, H, S, D
+          mllm_fp16_t* dst_ptr = Y + b * H * S * D + h * S * D + s * D + d;
+
+          float16x8_t data;
+          data = vld1q_f16(src_ptr);
+          vst1q_f16(dst_ptr, data);
+        }
+        for (; d < D; ++d) {
+          const mllm_fp16_t* src_ptr = X + b * S * H * D + s * H * D + h * D + d;
+          mllm_fp16_t* dst_ptr = Y + b * H * S * D + h * S * D + s * D + d;
+          *dst_ptr = *src_ptr;
+        }
+      }
+    }
+  }
+}
+
+void transpose_last_dims_fp32(const mllm_fp32_t* __restrict input, mllm_fp32_t* __restrict output, size_t batch, size_t dim0,
+                              size_t dim1) {
+  for (size_t b = 0; b < batch; b++) {
+    const mllm_fp32_t* input_batch = input + b * dim0 * dim1;
+    mllm_fp32_t* output_batch = output + b * dim0 * dim1;
+
+    for (size_t i = 0; i + 4 <= dim0; i += 4) {
+      for (size_t j = 0; j + 4 <= dim1; j += 4) {
+        float32x4_t r0 = vld1q_f32(input_batch + i * dim1 + j);
+        float32x4_t r1 = vld1q_f32(input_batch + (i + 1) * dim1 + j);
+        float32x4_t r2 = vld1q_f32(input_batch + (i + 2) * dim1 + j);
+        float32x4_t r3 = vld1q_f32(input_batch + (i + 3) * dim1 + j);
+
+        float32x4x2_t r0r1 = vtrnq_f32(r0, r1);
+        float32x4x2_t r2r3 = vtrnq_f32(r2, r3);
+
+        float32x4_t col0 = vcombine_f32(vget_low_f32(r0r1.val[0]), vget_low_f32(r2r3.val[0]));
+        float32x4_t col1 = vcombine_f32(vget_low_f32(r0r1.val[1]), vget_low_f32(r2r3.val[1]));
+        float32x4_t col2 = vcombine_f32(vget_high_f32(r0r1.val[0]), vget_high_f32(r2r3.val[0]));
+        float32x4_t col3 = vcombine_f32(vget_high_f32(r0r1.val[1]), vget_high_f32(r2r3.val[1]));
+
+        vst1q_f32(output_batch + j * dim0 + i, col0);
+        vst1q_f32(output_batch + (j + 1) * dim0 + i, col1);
+        vst1q_f32(output_batch + (j + 2) * dim0 + i, col2);
+        vst1q_f32(output_batch + (j + 3) * dim0 + i, col3);
+      }
+
+      size_t j_remain = dim1 - (dim1 % 4);
+      for (size_t j = j_remain; j < dim1; ++j) {
+        float32x4_t col = {input_batch[i * dim1 + j], input_batch[(i + 1) * dim1 + j], input_batch[(i + 2) * dim1 + j],
+                           input_batch[(i + 3) * dim1 + j]};
+        vst1q_f32(output_batch + j * dim0 + i, col);
+      }
+    }
+
+    size_t i_remain = dim0 - (dim0 % 4);
+    for (size_t j = 0; j < dim1; ++j) {
+      for (size_t i = i_remain; i < dim0; ++i) { output_batch[j * dim0 + i] = input_batch[i * dim1 + j]; }
+    }
+  }
+}
+
+void transpose_last_dims_fp16(const mllm_fp16_t* __restrict input, mllm_fp16_t* __restrict output, size_t batch, size_t dim0,
+                              size_t dim1) {
+  for (size_t b = 0; b < batch; b++) {
+    const mllm_fp16_t* input_batch = input + b * dim0 * dim1;
+    mllm_fp16_t* output_batch = output + b * dim0 * dim1;
+
+    for (size_t i = 0; i + 4 <= dim0; i += 4) {
+      for (size_t j = 0; j + 8 <= dim1; j += 8) {
+        float16x8_t r0 = vld1q_f16(input_batch + i * dim1 + j);
+        float16x8_t r1 = vld1q_f16(input_batch + (i + 1) * dim1 + j);
+        float16x8_t r2 = vld1q_f16(input_batch + (i + 2) * dim1 + j);
+        float16x8_t r3 = vld1q_f16(input_batch + (i + 3) * dim1 + j);
+
+        float16x4_t r00 = vget_low_f16(r0);
+        float16x4_t r01 = vget_high_f16(r0);
+        float16x4_t r10 = vget_low_f16(r1);
+        float16x4_t r11 = vget_high_f16(r1);
+        float16x4_t r20 = vget_low_f16(r2);
+        float16x4_t r21 = vget_high_f16(r2);
+        float16x4_t r30 = vget_low_f16(r3);
+        float16x4_t r31 = vget_high_f16(r3);
+
+        float16x4x2_t tr00 = vtrn_f16(r00, r10);
+        float16x4x2_t tr01 = vtrn_f16(r20, r30);
+        float32x2x2_t tr00_32 = vtrn_f32(vreinterpret_f32_f16(tr00.val[0]), vreinterpret_f32_f16(tr01.val[0]));
+        float32x2x2_t tr01_32 = vtrn_f32(vreinterpret_f32_f16(tr00.val[1]), vreinterpret_f32_f16(tr01.val[1]));
+
+        float16x4x2_t tr10 = vtrn_f16(r01, r11);
+        float16x4x2_t tr11 = vtrn_f16(r21, r31);
+        float32x2x2_t tr10_32 = vtrn_f32(vreinterpret_f32_f16(tr10.val[0]), vreinterpret_f32_f16(tr11.val[0]));
+        float32x2x2_t tr11_32 = vtrn_f32(vreinterpret_f32_f16(tr10.val[1]), vreinterpret_f32_f16(tr11.val[1]));
+
+        float16x4_t col0 = vreinterpret_f16_f32(tr00_32.val[0]);
+        float16x4_t col1 = vreinterpret_f16_f32(tr01_32.val[0]);
+        float16x4_t col2 = vreinterpret_f16_f32(tr00_32.val[1]);
+        float16x4_t col3 = vreinterpret_f16_f32(tr01_32.val[1]);
+        float16x4_t col4 = vreinterpret_f16_f32(tr10_32.val[0]);
+        float16x4_t col5 = vreinterpret_f16_f32(tr11_32.val[0]);
+        float16x4_t col6 = vreinterpret_f16_f32(tr10_32.val[1]);
+        float16x4_t col7 = vreinterpret_f16_f32(tr11_32.val[1]);
+
+        vst1_f16(output_batch + (j)*dim0 + i, col0);
+        vst1_f16(output_batch + (j + 1) * dim0 + i, col1);
+        vst1_f16(output_batch + (j + 2) * dim0 + i, col2);
+        vst1_f16(output_batch + (j + 3) * dim0 + i, col3);
+        vst1_f16(output_batch + (j + 4) * dim0 + i, col4);
+        vst1_f16(output_batch + (j + 5) * dim0 + i, col5);
+        vst1_f16(output_batch + (j + 6) * dim0 + i, col6);
+        vst1_f16(output_batch + (j + 7) * dim0 + i, col7);
+      }
+
+      size_t j_remain = dim1 - (dim1 % 8);
+      for (size_t j = j_remain; j < dim1; ++j) {
+        for (size_t ii = 0; ii < 4; ++ii) { output_batch[j * dim0 + i + ii] = input_batch[(i + ii) * dim1 + j]; }
+      }
+    }
+
+    size_t i_remain = dim0 - (dim0 % 4);
+    for (size_t j = 0; j < dim1; ++j) {
+      for (size_t i = i_remain; i < dim0; ++i) { output_batch[j * dim0 + i] = input_batch[i * dim1 + j]; }
+    }
+  }
+}
+
+}  // namespace mllm::cpu::arm
+
+#endif

--- a/mllm/backends/cpu/kernels/arm/transpose.hpp
+++ b/mllm/backends/cpu/kernels/arm/transpose.hpp
@@ -1,0 +1,34 @@
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "mllm/core/DataTypes.hpp"
+#include "mllm/utils/CPUArchHelper.hpp"
+
+#if defined(MLLM_HOST_ARCH_ARM64) || defined(MLLM_HOST_ARCH_ARM)
+
+#include <cstddef>
+#include <arm_neon.h>
+
+namespace mllm::cpu::arm {
+
+void transpose_hw_wh_fp32(const mllm_fp32_t* __restrict X, mllm_fp32_t* __restrict Y, size_t H, size_t W);
+
+void transpose_bshd_bhsd_fp32(const mllm_fp32_t* __restrict X, mllm_fp32_t* __restrict Y, size_t B, size_t S, size_t H,
+                              size_t D);
+
+void transpose_last_dims_fp32(const mllm_fp32_t* __restrict input, mllm_fp32_t* __restrict output, size_t batch, size_t dim0,
+                              size_t dim1);
+
+void transpose_hw_wh_fp16(const mllm_fp16_t* __restrict X, mllm_fp16_t* __restrict Y, size_t H, size_t W);
+
+void transpose_bshd_bhsd_fp16(const mllm_fp16_t* __restrict X, mllm_fp16_t* __restrict Y, size_t B, size_t S, size_t H,
+                              size_t D);
+
+void transpose_last_dims_fp16(const mllm_fp16_t* __restrict input, mllm_fp16_t* __restrict output, size_t batch, size_t dim0,
+                              size_t dim1);
+
+}  // namespace mllm::cpu::arm
+
+#endif

--- a/mllm/backends/cpu/ops/ElewiseOps.cpp
+++ b/mllm/backends/cpu/ops/ElewiseOps.cpp
@@ -1,11 +1,6 @@
-/**
- * @file ElewiseOps.cpp
- * @author chenghua wang (chenghua.wang.edu@gmail.com)
- * @brief
- * @version 0.1
- * @date 2025-07-31
- *
- */
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
+
 #include "mllm/backends/cpu/ops/ElewiseOps.hpp"
 #include "mllm/backends/cpu/kernels/Kernels.hpp"
 #include "mllm/core/DataTypes.hpp"

--- a/mllm/backends/cpu/ops/ElewiseOps.hpp
+++ b/mllm/backends/cpu/ops/ElewiseOps.hpp
@@ -1,11 +1,6 @@
-/**
- * @file ElewiseOps.hpp
- * @author chenghua wang (chenghua.wang.edu@gmail.com)
- * @brief
- * @version 0.1
- * @date 2025-07-31
- *
- */
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
+
 #pragma once
 
 #include "mllm/core/BaseOp.hpp"

--- a/mllm/backends/cpu/ops/FillOp.cpp
+++ b/mllm/backends/cpu/ops/FillOp.cpp
@@ -1,11 +1,6 @@
-/**
- * @file FillOp.cpp
- * @author chenghua wang (chenghua.wang.edu@gmail.com)
- * @brief
- * @version 0.1
- * @date 2025-07-27
- *
- */
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
+
 #include "mllm/backends/cpu/ops/FillOp.hpp"
 #include "mllm/backends/cpu/kernels/Kernels.hpp"
 #include "mllm/utils/PlatformRTHelper.hpp"
@@ -27,6 +22,8 @@ void CPUFillOp::forward(const std::vector<Tensor>& inputs, std::vector<Tensor>& 
         case kFloat32: {
 #if defined(MLLM_HOST_ARCH_X86_64) || defined(MLLM_HOST_ARCH_X86)
           x86::fill_zeros(dst.ptr<mllm_fp32_t>(), dst.numel(), threads);
+#elif defined(MLLM_HOST_ARCH_ARM64) || defined(MLLM_HOST_ARCH_ARM)
+          arm::fill_zeros(dst.ptr<mllm_fp32_t>(), dst.numel(), threads);
 #endif
           break;
         }
@@ -42,6 +39,8 @@ void CPUFillOp::forward(const std::vector<Tensor>& inputs, std::vector<Tensor>& 
         case kFloat32: {
 #if defined(MLLM_HOST_ARCH_X86_64) || defined(MLLM_HOST_ARCH_X86)
           x86::fill_ones(dst.ptr<mllm_fp32_t>(), dst.numel(), threads);
+#elif defined(MLLM_HOST_ARCH_ARM64) || defined(MLLM_HOST_ARCH_ARM)
+          arm::fill_ones(dst.ptr<mllm_fp32_t>(), dst.numel(), threads);
 #endif
           break;
         }
@@ -57,6 +56,8 @@ void CPUFillOp::forward(const std::vector<Tensor>& inputs, std::vector<Tensor>& 
         case kFloat32: {
 #if defined(MLLM_HOST_ARCH_X86_64) || defined(MLLM_HOST_ARCH_X86)
           x86::fill_arange(dst.ptr<mllm_fp32_t>(), dst.numel(), options_.start, options_.end, options_.step, threads);
+#elif defined(MLLM_HOST_ARCH_ARM64) || defined(MLLM_HOST_ARCH_ARM)
+          arm::fill_arange(dst.ptr<mllm_fp32_t>(), dst.numel(), options_.start, options_.end, options_.step, threads);
 #endif
           break;
         }
@@ -71,6 +72,8 @@ void CPUFillOp::forward(const std::vector<Tensor>& inputs, std::vector<Tensor>& 
         case kFloat32: {
 #if defined(MLLM_HOST_ARCH_X86_64) || defined(MLLM_HOST_ARCH_X86)
           x86::fill_random(dst.ptr<mllm_fp32_t>(), dst.numel(), options_.start, options_.end, options_.seed, threads);
+#elif defined(MLLM_HOST_ARCH_ARM64) || defined(MLLM_HOST_ARCH_ARM)
+          arm::fill_random(dst.ptr<mllm_fp32_t>(), dst.numel(), options_.start, options_.end, options_.seed, threads);
 #endif
           break;
         }
@@ -85,6 +88,8 @@ void CPUFillOp::forward(const std::vector<Tensor>& inputs, std::vector<Tensor>& 
         case kFloat32: {
 #if defined(MLLM_HOST_ARCH_X86_64) || defined(MLLM_HOST_ARCH_X86)
           x86::fill_specific_value(dst.ptr<mllm_fp32_t>(), dst.numel(), options_.value, threads);
+#elif defined(MLLM_HOST_ARCH_ARM64) || defined(MLLM_HOST_ARCH_ARM)
+          arm::fill_specific_value(dst.ptr<mllm_fp32_t>(), dst.numel(), options_.value, threads);
 #endif
           break;
         }

--- a/mllm/backends/cpu/ops/FillOp.hpp
+++ b/mllm/backends/cpu/ops/FillOp.hpp
@@ -1,11 +1,6 @@
-/**
- * @file FillOp.hpp
- * @author chenghua wang (chenghua.wang.edu@gmail.com)
- * @brief
- * @version 0.1
- * @date 2025-07-27
- *
- */
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
+
 #pragma once
 
 #include "mllm/core/BaseOp.hpp"

--- a/mllm/backends/cpu/ops/GraphOps.cpp
+++ b/mllm/backends/cpu/ops/GraphOps.cpp
@@ -1,11 +1,5 @@
-/**
- * @file GraphOps.cpp
- * @author chenghua wang (chenghua.wang.edu@gmail.com)
- * @brief
- * @version 0.1
- * @date 2025-07-29
- *
- */
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
 
 #include "mllm/backends/cpu/ops/GraphOps.hpp"
 

--- a/mllm/backends/cpu/ops/GraphOps.hpp
+++ b/mllm/backends/cpu/ops/GraphOps.hpp
@@ -1,11 +1,6 @@
-/**
- * @file GraphOps.hpp
- * @author chenghua wang (chenghua.wang.edu@gmail.com)
- * @brief
- * @version 0.1
- * @date 2025-07-29
- *
- */
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
+
 #pragma once
 
 #include "mllm/core/BaseOp.hpp"

--- a/mllm/backends/cpu/ops/LinearOp.cpp
+++ b/mllm/backends/cpu/ops/LinearOp.cpp
@@ -1,11 +1,6 @@
-/**
- * @file LinearOp.cpp
- * @author chenghua wang (chenghua.wang.edu@gmail.com)
- * @brief
- * @version 0.1
- * @date 2025-07-25
- *
- */
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
+
 #include "mllm/backends/cpu/ops/LinearOp.hpp"
 
 namespace mllm::cpu {

--- a/mllm/backends/cpu/ops/LinearOp.hpp
+++ b/mllm/backends/cpu/ops/LinearOp.hpp
@@ -1,11 +1,6 @@
-/**
- * @file LinearOp.hpp
- * @author chenghua wang (chenghua.wang.edu@gmail.com)
- * @brief
- * @version 0.1
- * @date 2025-07-25
- *
- */
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
+
 #pragma once
 
 #include "mllm/core/aops/LinearOp.hpp"

--- a/mllm/backends/cpu/ops/PermuteOp.cpp
+++ b/mllm/backends/cpu/ops/PermuteOp.cpp
@@ -1,0 +1,37 @@
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
+
+#include "mllm/backends/cpu/ops/PermuteOp.hpp"
+#include "mllm/backends/cpu/kernels/Kernels.hpp"
+#include "mllm/core/DataTypes.hpp"
+
+namespace mllm::cpu {
+
+CPUPermuteOp::CPUPermuteOp(const aops::PermuteOpOptions& options) : aops::PermuteOp(options) {}
+
+void CPUPermuteOp::forward(const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) {
+  auto& input = inputs[0];
+  auto& output = outputs[0];
+
+  auto dtype = input.dtype();
+
+  switch (dtype) {
+    case kFloat32: {
+#if defined(MLLM_HOST_ARCH_ARM64) || defined(MLLM_HOST_ARCH_ARM)
+      arm::permute_fp32(input.ptr<mllm_fp32_t>(), output.ptr<mllm_fp32_t>(), input.shape().data(), options_.axis.data(),
+                        options_.axis.size());
+#endif
+      break;
+    }
+    case kFloat16: {
+#if defined(MLLM_HOST_ARCH_ARM64) || defined(MLLM_HOST_ARCH_ARM)
+      arm::permute_fp16(input.ptr<mllm_fp16_t>(), output.ptr<mllm_fp16_t>(), input.shape().data(), options_.axis.data(),
+                        options_.axis.size());
+#endif
+      break;
+    }
+    default: NYI("Data type not supported");
+  }
+}
+
+}  // namespace mllm::cpu

--- a/mllm/backends/cpu/ops/PermuteOp.hpp
+++ b/mllm/backends/cpu/ops/PermuteOp.hpp
@@ -1,0 +1,26 @@
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "mllm/core/BaseOp.hpp"
+#include "mllm/core/Tensor.hpp"
+#include "mllm/core/aops/PermuteOp.hpp"
+
+namespace mllm::cpu {
+
+class CPUPermuteOp final : public aops::PermuteOp {
+ public:
+  explicit CPUPermuteOp(const aops::PermuteOpOptions& options);
+
+  void forward(const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) override;
+};
+
+class CPUPermuteOpFactory final : public TypedOpFactory<OpTypes::kPermute, aops::PermuteOpOptions> {
+ public:
+  std::shared_ptr<BaseOp> createOpImpl(const aops::PermuteOpOptions& options) override {
+    return std::make_shared<CPUPermuteOp>(options);
+  }
+};
+
+}  // namespace mllm::cpu

--- a/mllm/backends/cpu/ops/ReduceOps.cpp
+++ b/mllm/backends/cpu/ops/ReduceOps.cpp
@@ -1,0 +1,412 @@
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
+
+#include "mllm/backends/cpu/ops/ReduceOps.hpp"
+#include "mllm/backends/cpu/kernels/Kernels.hpp"
+#include "mllm/core/DataTypes.hpp"
+
+namespace mllm::cpu {
+
+CPUReduceMaxOp::CPUReduceMaxOp(const aops::ReduceMaxOpOptions& options) : aops::ReduceMaxOp(options) {}
+
+void CPUReduceMaxOp::forward(const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) {
+  auto& input = inputs[0];
+  auto& output = outputs[0];
+
+  auto dtype = input.dtype();
+  auto dim = options_.dim;
+  auto keep_dim = options_.keep_dim;
+
+  // Handle negative dimension index
+  if (dim < 0) { dim += input.shape().size(); }
+
+  // Special case: reduce over all dimensions
+  if (dim == 0x7fffffff) {
+    switch (dtype) {
+      case kFloat32: {
+#if defined(MLLM_HOST_ARCH_ARM64) || defined(MLLM_HOST_ARCH_ARM)
+        arm::reduce_max_fp32(output.ptr<mllm_fp32_t>(), input.ptr<mllm_fp32_t>(), input.numel(), options_.getThreads());
+#endif
+        break;
+      }
+      case kFloat16: {
+#if defined(MLLM_HOST_ARCH_ARM64) || defined(MLLM_HOST_ARCH_ARM)
+        arm::reduce_max_fp16(output.ptr<mllm_fp16_t>(), input.ptr<mllm_fp16_t>(), input.numel(), options_.getThreads());
+#endif
+        break;
+      }
+      case kInt8: {
+#if defined(MLLM_HOST_ARCH_ARM64) || defined(MLLM_HOST_ARCH_ARM)
+        arm::reduce_max_int8(output.ptr<mllm_int8_t>(), input.ptr<mllm_int8_t>(), input.numel(), options_.getThreads());
+#endif
+        break;
+      }
+      case kInt16: {
+#if defined(MLLM_HOST_ARCH_ARM64) || defined(MLLM_HOST_ARCH_ARM)
+        arm::reduce_max_int16(output.ptr<mllm_int16_t>(), input.ptr<mllm_int16_t>(), input.numel(), options_.getThreads());
+#endif
+        break;
+      }
+      case kInt32: {
+#if defined(MLLM_HOST_ARCH_ARM64) || defined(MLLM_HOST_ARCH_ARM)
+        arm::reduce_max_int32(output.ptr<mllm_int32_t>(), input.ptr<mllm_int32_t>(), input.numel(), options_.getThreads());
+#endif
+        break;
+      }
+      default: NYI("Unsupported data type for ReduceMaxOp");
+    }
+    return;
+  }
+
+  // For specific dimension reduction
+  auto outer_size = 1;
+  auto inner_size = 1;
+  auto axis_size = input.shape()[dim];
+
+  for (int i = 0; i < dim; ++i) { outer_size *= input.shape()[i]; }
+  for (int i = dim + 1; i < input.shape().size(); ++i) { inner_size *= input.shape()[i]; }
+
+  switch (dtype) {
+    case kFloat32: {
+      auto input_ptr = input.ptr<mllm_fp32_t>();
+      auto output_ptr = output.ptr<mllm_fp32_t>();
+
+      for (int out = 0; out < outer_size; ++out) {
+        for (int in = 0; in < inner_size; ++in) {
+#if defined(MLLM_HOST_ARCH_ARM64) || defined(MLLM_HOST_ARCH_ARM)
+          arm::reduce_max_fp32(&output_ptr[out * inner_size + in], &input_ptr[out * axis_size * inner_size + in], axis_size,
+                               options_.getThreads());
+#endif
+        }
+      }
+      break;
+    }
+    case kFloat16: {
+      auto input_ptr = input.ptr<mllm_fp16_t>();
+      auto output_ptr = output.ptr<mllm_fp16_t>();
+
+      for (int out = 0; out < outer_size; ++out) {
+        for (int in = 0; in < inner_size; ++in) {
+#if defined(MLLM_HOST_ARCH_ARM64) || defined(MLLM_HOST_ARCH_ARM)
+          arm::reduce_max_fp16(&output_ptr[out * inner_size + in], &input_ptr[out * axis_size * inner_size + in], axis_size,
+                               options_.getThreads());
+#endif
+        }
+      }
+      break;
+    }
+    case kInt8: {
+      auto input_ptr = input.ptr<mllm_int8_t>();
+      auto output_ptr = output.ptr<mllm_int8_t>();
+
+      for (int out = 0; out < outer_size; ++out) {
+        for (int in = 0; in < inner_size; ++in) {
+#if defined(MLLM_HOST_ARCH_ARM64) || defined(MLLM_HOST_ARCH_ARM)
+          arm::reduce_max_int8(&output_ptr[out * inner_size + in], &input_ptr[out * axis_size * inner_size + in], axis_size,
+                               options_.getThreads());
+#endif
+        }
+      }
+      break;
+    }
+    case kInt16: {
+      auto input_ptr = input.ptr<mllm_int16_t>();
+      auto output_ptr = output.ptr<mllm_int16_t>();
+
+      for (int out = 0; out < outer_size; ++out) {
+        for (int in = 0; in < inner_size; ++in) {
+#if defined(MLLM_HOST_ARCH_ARM64) || defined(MLLM_HOST_ARCH_ARM)
+          arm::reduce_max_int16(&output_ptr[out * inner_size + in], &input_ptr[out * axis_size * inner_size + in], axis_size,
+                                options_.getThreads());
+#endif
+        }
+      }
+      break;
+    }
+    case kInt32: {
+      auto input_ptr = input.ptr<mllm_int32_t>();
+      auto output_ptr = output.ptr<mllm_int32_t>();
+
+      for (int out = 0; out < outer_size; ++out) {
+        for (int in = 0; in < inner_size; ++in) {
+#if defined(MLLM_HOST_ARCH_ARM64) || defined(MLLM_HOST_ARCH_ARM)
+          arm::reduce_max_int32(&output_ptr[out * inner_size + in], &input_ptr[out * axis_size * inner_size + in], axis_size,
+                                options_.getThreads());
+#endif
+        }
+      }
+      break;
+    }
+    default: NYI("Unsupported data type for ReduceMaxOp");
+  }
+}
+
+CPUReduceMinOp::CPUReduceMinOp(const aops::ReduceMinOpOptions& options) : aops::ReduceMinOp(options) {}
+
+void CPUReduceMinOp::forward(const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) {
+  auto& input = inputs[0];
+  auto& output = outputs[0];
+
+  auto dtype = input.dtype();
+  auto dim = options_.dim;
+  auto keep_dim = options_.keep_dim;
+
+  // Handle negative dimension index
+  if (dim < 0) { dim += input.shape().size(); }
+
+  // Special case: reduce over all dimensions
+  if (dim == 0x7fffffff) {
+    switch (dtype) {
+      case kFloat32: {
+#if defined(MLLM_HOST_ARCH_ARM64) || defined(MLLM_HOST_ARCH_ARM)
+        arm::reduce_min_fp32(output.ptr<mllm_fp32_t>(), input.ptr<mllm_fp32_t>(), input.numel(), options_.getThreads());
+#endif
+        break;
+      }
+      case kFloat16: {
+#if defined(MLLM_HOST_ARCH_ARM64) || defined(MLLM_HOST_ARCH_ARM)
+        arm::reduce_min_fp16(output.ptr<mllm_fp16_t>(), input.ptr<mllm_fp16_t>(), input.numel(), options_.getThreads());
+#endif
+        break;
+      }
+      case kInt8: {
+#if defined(MLLM_HOST_ARCH_ARM64) || defined(MLLM_HOST_ARCH_ARM)
+        arm::reduce_min_int8(output.ptr<mllm_int8_t>(), input.ptr<mllm_int8_t>(), input.numel(), options_.getThreads());
+#endif
+        break;
+      }
+      case kInt16: {
+#if defined(MLLM_HOST_ARCH_ARM64) || defined(MLLM_HOST_ARCH_ARM)
+        arm::reduce_min_int16(output.ptr<mllm_int16_t>(), input.ptr<mllm_int16_t>(), input.numel(), options_.getThreads());
+#endif
+        break;
+      }
+      case kInt32: {
+#if defined(MLLM_HOST_ARCH_ARM64) || defined(MLLM_HOST_ARCH_ARM)
+        arm::reduce_min_int32(output.ptr<mllm_int32_t>(), input.ptr<mllm_int32_t>(), input.numel(), options_.getThreads());
+#endif
+        break;
+      }
+      default: NYI("Unsupported data type for ReduceMinOp");
+    }
+    return;
+  }
+
+  // For specific dimension reduction
+  auto outer_size = 1;
+  auto inner_size = 1;
+  auto axis_size = input.shape()[dim];
+
+  for (int i = 0; i < dim; ++i) { outer_size *= input.shape()[i]; }
+  for (int i = dim + 1; i < input.shape().size(); ++i) { inner_size *= input.shape()[i]; }
+
+  switch (dtype) {
+    case kFloat32: {
+      auto input_ptr = input.ptr<mllm_fp32_t>();
+      auto output_ptr = output.ptr<mllm_fp32_t>();
+
+      for (int out = 0; out < outer_size; ++out) {
+        for (int in = 0; in < inner_size; ++in) {
+#if defined(MLLM_HOST_ARCH_ARM64) || defined(MLLM_HOST_ARCH_ARM)
+          arm::reduce_min_fp32(&output_ptr[out * inner_size + in], &input_ptr[out * axis_size * inner_size + in], axis_size,
+                               options_.getThreads());
+#endif
+        }
+      }
+      break;
+    }
+    case kFloat16: {
+      auto input_ptr = input.ptr<mllm_fp16_t>();
+      auto output_ptr = output.ptr<mllm_fp16_t>();
+
+      for (int out = 0; out < outer_size; ++out) {
+        for (int in = 0; in < inner_size; ++in) {
+#if defined(MLLM_HOST_ARCH_ARM64) || defined(MLLM_HOST_ARCH_ARM)
+          arm::reduce_min_fp16(&output_ptr[out * inner_size + in], &input_ptr[out * axis_size * inner_size + in], axis_size,
+                               options_.getThreads());
+#endif
+        }
+      }
+      break;
+    }
+    case kInt8: {
+      auto input_ptr = input.ptr<mllm_int8_t>();
+      auto output_ptr = output.ptr<mllm_int8_t>();
+
+      for (int out = 0; out < outer_size; ++out) {
+        for (int in = 0; in < inner_size; ++in) {
+#if defined(MLLM_HOST_ARCH_ARM64) || defined(MLLM_HOST_ARCH_ARM)
+          arm::reduce_min_int8(&output_ptr[out * inner_size + in], &input_ptr[out * axis_size * inner_size + in], axis_size,
+                               options_.getThreads());
+#endif
+        }
+      }
+      break;
+    }
+    case kInt16: {
+      auto input_ptr = input.ptr<mllm_int16_t>();
+      auto output_ptr = output.ptr<mllm_int16_t>();
+
+      for (int out = 0; out < outer_size; ++out) {
+        for (int in = 0; in < inner_size; ++in) {
+#if defined(MLLM_HOST_ARCH_ARM64) || defined(MLLM_HOST_ARCH_ARM)
+          arm::reduce_min_int16(&output_ptr[out * inner_size + in], &input_ptr[out * axis_size * inner_size + in], axis_size,
+                                options_.getThreads());
+#endif
+        }
+      }
+      break;
+    }
+    case kInt32: {
+      auto input_ptr = input.ptr<mllm_int32_t>();
+      auto output_ptr = output.ptr<mllm_int32_t>();
+
+      for (int out = 0; out < outer_size; ++out) {
+        for (int in = 0; in < inner_size; ++in) {
+#if defined(MLLM_HOST_ARCH_ARM64) || defined(MLLM_HOST_ARCH_ARM)
+          arm::reduce_min_int32(&output_ptr[out * inner_size + in], &input_ptr[out * axis_size * inner_size + in], axis_size,
+                                options_.getThreads());
+#endif
+        }
+      }
+      break;
+    }
+    default: NYI("Unsupported data type for ReduceMinOp");
+  }
+}
+
+CPUReduceSumOp::CPUReduceSumOp(const aops::ReduceSumOpOptions& options) : aops::ReduceSumOp(options) {}
+
+void CPUReduceSumOp::forward(const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) {
+  auto& input = inputs[0];
+  auto& output = outputs[0];
+
+  auto dtype = input.dtype();
+  auto dim = options_.dim;
+  auto keep_dim = options_.keep_dim;
+
+  // Handle negative dimension index
+  if (dim < 0) { dim += input.shape().size(); }
+
+  // Special case: reduce over all dimensions
+  if (dim == 0x7fffffff) {
+    switch (dtype) {
+      case kFloat32: {
+#if defined(MLLM_HOST_ARCH_ARM64) || defined(MLLM_HOST_ARCH_ARM)
+        arm::reduce_sum_fp32(output.ptr<mllm_fp32_t>(), input.ptr<mllm_fp32_t>(), input.numel(), options_.getThreads());
+#endif
+        break;
+      }
+      case kFloat16: {
+#if defined(MLLM_HOST_ARCH_ARM64) || defined(MLLM_HOST_ARCH_ARM)
+        arm::reduce_sum_fp16(output.ptr<mllm_fp16_t>(), input.ptr<mllm_fp16_t>(), input.numel(), options_.getThreads());
+#endif
+        break;
+      }
+      case kInt8: {
+#if defined(MLLM_HOST_ARCH_ARM64) || defined(MLLM_HOST_ARCH_ARM)
+        arm::reduce_sum_int8(output.ptr<mllm_int8_t>(), input.ptr<mllm_int8_t>(), input.numel(), options_.getThreads());
+#endif
+        break;
+      }
+      case kInt16: {
+#if defined(MLLM_HOST_ARCH_ARM64) || defined(MLLM_HOST_ARCH_ARM)
+        arm::reduce_sum_int16(output.ptr<mllm_int16_t>(), input.ptr<mllm_int16_t>(), input.numel(), options_.getThreads());
+#endif
+        break;
+      }
+      case kInt32: {
+#if defined(MLLM_HOST_ARCH_ARM64) || defined(MLLM_HOST_ARCH_ARM)
+        arm::reduce_sum_int32(output.ptr<mllm_int32_t>(), input.ptr<mllm_int32_t>(), input.numel(), options_.getThreads());
+#endif
+        break;
+      }
+      default: NYI("Unsupported data type for ReduceSumOp");
+    }
+    return;
+  }
+
+  // For specific dimension reduction
+  auto outer_size = 1;
+  auto inner_size = 1;
+  auto axis_size = input.shape()[dim];
+
+  for (int i = 0; i < dim; ++i) { outer_size *= input.shape()[i]; }
+  for (int i = dim + 1; i < input.shape().size(); ++i) { inner_size *= input.shape()[i]; }
+
+  switch (dtype) {
+    case kFloat32: {
+      auto input_ptr = input.ptr<mllm_fp32_t>();
+      auto output_ptr = output.ptr<mllm_fp32_t>();
+
+      for (int out = 0; out < outer_size; ++out) {
+        for (int in = 0; in < inner_size; ++in) {
+#if defined(MLLM_HOST_ARCH_ARM64) || defined(MLLM_HOST_ARCH_ARM)
+          arm::reduce_sum_fp32(&output_ptr[out * inner_size + in], &input_ptr[out * axis_size * inner_size + in], axis_size,
+                               options_.getThreads());
+#endif
+        }
+      }
+      break;
+    }
+    case kFloat16: {
+      auto input_ptr = input.ptr<mllm_fp16_t>();
+      auto output_ptr = output.ptr<mllm_fp16_t>();
+
+      for (int out = 0; out < outer_size; ++out) {
+        for (int in = 0; in < inner_size; ++in) {
+#if defined(MLLM_HOST_ARCH_ARM64) || defined(MLLM_HOST_ARCH_ARM)
+          arm::reduce_sum_fp16(&output_ptr[out * inner_size + in], &input_ptr[out * axis_size * inner_size + in], axis_size,
+                               options_.getThreads());
+#endif
+        }
+      }
+      break;
+    }
+    case kInt8: {
+      auto input_ptr = input.ptr<mllm_int8_t>();
+      auto output_ptr = output.ptr<mllm_int8_t>();
+
+      for (int out = 0; out < outer_size; ++out) {
+        for (int in = 0; in < inner_size; ++in) {
+#if defined(MLLM_HOST_ARCH_ARM64) || defined(MLLM_HOST_ARCH_ARM)
+          arm::reduce_sum_int8(&output_ptr[out * inner_size + in], &input_ptr[out * axis_size * inner_size + in], axis_size,
+                               options_.getThreads());
+#endif
+        }
+      }
+      break;
+    }
+    case kInt16: {
+      auto input_ptr = input.ptr<mllm_int16_t>();
+      auto output_ptr = output.ptr<mllm_int16_t>();
+
+      for (int out = 0; out < outer_size; ++out) {
+        for (int in = 0; in < inner_size; ++in) {
+#if defined(MLLM_HOST_ARCH_ARM64) || defined(MLLM_HOST_ARCH_ARM)
+          arm::reduce_sum_int16(&output_ptr[out * inner_size + in], &input_ptr[out * axis_size * inner_size + in], axis_size,
+                                options_.getThreads());
+#endif
+        }
+      }
+      break;
+    }
+    case kInt32: {
+      auto input_ptr = input.ptr<mllm_int32_t>();
+      auto output_ptr = output.ptr<mllm_int32_t>();
+
+      for (int out = 0; out < outer_size; ++out) {
+        for (int in = 0; in < inner_size; ++in) {
+#if defined(MLLM_HOST_ARCH_ARM64) || defined(MLLM_HOST_ARCH_ARM)
+          arm::reduce_sum_int32(&output_ptr[out * inner_size + in], &input_ptr[out * axis_size * inner_size + in], axis_size,
+                                options_.getThreads());
+#endif
+        }
+      }
+      break;
+    }
+    default: NYI("Unsupported data type for ReduceSumOp");
+  }
+}
+
+}  // namespace mllm::cpu

--- a/mllm/backends/cpu/ops/ReduceOps.hpp
+++ b/mllm/backends/cpu/ops/ReduceOps.hpp
@@ -1,0 +1,52 @@
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "mllm/core/aops/ReduceOps.hpp"
+
+namespace mllm::cpu {
+
+class CPUReduceMaxOp final : public aops::ReduceMaxOp {
+ public:
+  explicit CPUReduceMaxOp(const aops::ReduceMaxOpOptions& options);
+
+  void forward(const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) override;
+};
+
+class CPUReduceMaxOpFactory final : public TypedOpFactory<OpTypes::kReduceMax, aops::ReduceMaxOpOptions> {
+ public:
+  std::shared_ptr<BaseOp> createOpImpl(const aops::ReduceMaxOpOptions& options) override {
+    return std::make_shared<CPUReduceMaxOp>(options);
+  }
+};
+
+class CPUReduceMinOp final : public aops::ReduceMinOp {
+ public:
+  explicit CPUReduceMinOp(const aops::ReduceMinOpOptions& options);
+
+  void forward(const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) override;
+};
+
+class CPUReduceMinOpFactory final : public TypedOpFactory<OpTypes::kReduceMin, aops::ReduceMinOpOptions> {
+ public:
+  std::shared_ptr<BaseOp> createOpImpl(const aops::ReduceMinOpOptions& options) override {
+    return std::make_shared<CPUReduceMinOp>(options);
+  }
+};
+
+class CPUReduceSumOp final : public aops::ReduceSumOp {
+ public:
+  explicit CPUReduceSumOp(const aops::ReduceSumOpOptions& options);
+
+  void forward(const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) override;
+};
+
+class CPUReduceSumOpFactory final : public TypedOpFactory<OpTypes::kReduceSum, aops::ReduceSumOpOptions> {
+ public:
+  std::shared_ptr<BaseOp> createOpImpl(const aops::ReduceSumOpOptions& options) override {
+    return std::make_shared<CPUReduceSumOp>(options);
+  }
+};
+
+}  // namespace mllm::cpu

--- a/mllm/backends/cpu/ops/TransposeOp.cpp
+++ b/mllm/backends/cpu/ops/TransposeOp.cpp
@@ -1,0 +1,117 @@
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
+
+#include "mllm/backends/cpu/ops/TransposeOp.hpp"
+#include "mllm/backends/cpu/kernels/Kernels.hpp"
+#include "mllm/core/DataTypes.hpp"
+
+namespace mllm::cpu {
+
+CPUTransposeOp::CPUTransposeOp(const aops::TransposeOpOptions& options) : aops::TransposeOp(options) {}
+
+void CPUTransposeOp::forward(const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) {
+  auto& input = inputs[0];
+  auto& output = outputs[0];
+
+  auto dtype = input.dtype();
+
+  int dim0 = options_.dim0;
+  int dim1 = options_.dim1;
+
+  if (dim0 < 0) dim0 += input.shape().size();
+  if (dim1 < 0) dim1 += input.shape().size();
+
+  auto input_shape = input.shape();
+
+  // CASE 1. HW -> WH
+  if (input_shape.size() == 2 && (dim0 + dim1 == 1)) {
+    switch (dtype) {
+      case kFloat32: {
+#if defined(MLLM_HOST_ARCH_ARM64) || defined(MLLM_HOST_ARCH_ARM)
+        arm::transpose_hw_wh_fp32(input.ptr<mllm_fp32_t>(), output.ptr<mllm_fp32_t>(), input_shape[0], input_shape[1]);
+#endif
+        break;
+      }
+      case kFloat16: {
+#if defined(MLLM_HOST_ARCH_ARM64) || defined(MLLM_HOST_ARCH_ARM)
+        arm::transpose_hw_wh_fp16(input.ptr<mllm_fp16_t>(), output.ptr<mllm_fp16_t>(), input_shape[0], input_shape[1]);
+#endif
+        break;
+      }
+      default: NYI("Data type not supported");
+    }
+  }
+
+  // CASE 2. BSHD -> BHSD
+  else if (input.shape().size() == 4 && ((dim0 == 1 && dim1 == 2) || (dim0 == 2 && dim1 == 1))) {
+    switch (dtype) {
+      case kFloat32: {
+#if defined(MLLM_HOST_ARCH_ARM64) || defined(MLLM_HOST_ARCH_ARM)
+        arm::transpose_bshd_bhsd_fp32(input.ptr<mllm_fp32_t>(), output.ptr<mllm_fp32_t>(), input_shape[0], input_shape[1],
+                                      input_shape[2], input_shape[3]);
+#endif
+        break;
+      }
+      case kFloat16: {
+#if defined(MLLM_HOST_ARCH_ARM64) || defined(MLLM_HOST_ARCH_ARM)
+        arm::transpose_bshd_bhsd_fp16(input.ptr<mllm_fp16_t>(), output.ptr<mllm_fp16_t>(), input_shape[0], input_shape[1],
+                                      input_shape[2], input_shape[3]);
+#endif
+        break;
+      }
+      default: NYI("Data type not supported");
+    }
+  }
+
+  // CASE 3. Exchange last 2 dims.
+  else if (input_shape.size() != 2 && (dim0 + dim1 == 1)) {
+    int batch = 0;
+    for (int i = 0; i < input_shape.size() - 2; i++) { batch *= input_shape[i]; }
+
+    switch (dtype) {
+      case kFloat32: {
+#if defined(MLLM_HOST_ARCH_ARM64) || defined(MLLM_HOST_ARCH_ARM)
+        arm::transpose_last_dims_fp32(input.ptr<mllm_fp32_t>(), output.ptr<mllm_fp32_t>(), batch, input_shape[0],
+                                      input_shape[1]);
+#endif
+        break;
+      }
+      case kFloat16: {
+#if defined(MLLM_HOST_ARCH_ARM64) || defined(MLLM_HOST_ARCH_ARM)
+        arm::transpose_last_dims_fp16(input.ptr<mllm_fp16_t>(), output.ptr<mllm_fp16_t>(), batch, input_shape[0],
+                                      input_shape[1]);
+#endif
+        break;
+      }
+      default: NYI("Data type not supported");
+    }
+  }
+
+  // CASE 4. General permute
+  else {
+    std::vector<int32_t> permute_axis(input_shape.size());
+    for (int i = 0; i < input_shape.size(); i++) { permute_axis[i] = input_shape[i]; }
+
+    std::swap(permute_axis[dim0], permute_axis[dim1]);
+
+    switch (dtype) {
+      case kFloat32: {
+#if defined(MLLM_HOST_ARCH_ARM64) || defined(MLLM_HOST_ARCH_ARM)
+        arm::permute_fp32(input.ptr<mllm_fp32_t>(), output.ptr<mllm_fp32_t>(), input.shape().data(), permute_axis.data(),
+                          permute_axis.size());
+#endif
+        break;
+      }
+      case kFloat16: {
+#if defined(MLLM_HOST_ARCH_ARM64) || defined(MLLM_HOST_ARCH_ARM)
+        arm::permute_fp16(input.ptr<mllm_fp16_t>(), output.ptr<mllm_fp16_t>(), input.shape().data(), permute_axis.data(),
+                          permute_axis.size());
+#endif
+        break;
+      }
+      default: NYI("Data type not supported");
+    }
+  }
+}
+
+}  // namespace mllm::cpu

--- a/mllm/backends/cpu/ops/TransposeOp.hpp
+++ b/mllm/backends/cpu/ops/TransposeOp.hpp
@@ -1,0 +1,26 @@
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "mllm/core/BaseOp.hpp"
+#include "mllm/core/Tensor.hpp"
+#include "mllm/core/aops/TransposeOp.hpp"
+
+namespace mllm::cpu {
+
+class CPUTransposeOp final : public aops::TransposeOp {
+ public:
+  explicit CPUTransposeOp(const aops::TransposeOpOptions& options);
+
+  void forward(const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) override;
+};
+
+class CPUTransposeOpFactory final : public TypedOpFactory<OpTypes::kTranspose, aops::TransposeOpOptions> {
+ public:
+  std::shared_ptr<BaseOp> createOpImpl(const aops::TransposeOpOptions& options) override {
+    return std::make_shared<CPUTransposeOp>(options);
+  }
+};
+
+}  // namespace mllm::cpu

--- a/mllm/compile/ir/GeneratedRTTIKind.hpp
+++ b/mllm/compile/ir/GeneratedRTTIKind.hpp
@@ -1,4 +1,4 @@
-// Auto generated: 2025-07-30 05:50:05
+// Auto generated: 2025-08-01 10:40:41
 // do not modify this file
 #pragma once
 
@@ -51,6 +51,9 @@ enum NodeKind : uint32_t {
   RK_Op_LinalgIROp_CloneOp,
   RK_Op_LinalgIROp_NegOp,
   RK_Op_LinalgIROp_ConcatOp,
+  RK_Op_LinalgIROp_ReduceMinOp,
+  RK_Op_LinalgIROp_ReduceMaxOp,
+  RK_Op_LinalgIROp_ReduceSumOp,
   RK_Op_LinalgIROp_Last,
   RK_Op_GraphIROp,
   RK_Op_GraphIROp_SubGraphOp,

--- a/mllm/compile/ir/NodeRTTIClassOfImpl.hpp
+++ b/mllm/compile/ir/NodeRTTIClassOfImpl.hpp
@@ -1,4 +1,4 @@
-// Auto generated: 2025-07-30 05:50:05
+// Auto generated: 2025-08-01 10:40:41
 // do not modify this file
 #pragma once
 namespace mllm::ir {
@@ -122,6 +122,15 @@ struct NodeRTTIClassOfImpl {
 
 #define RTTI_RK_OP_LINALGIROP_CONCATOP_IMPL(v) \
   return (v)->getKind() >= RK_Op_LinalgIROp_ConcatOp && (v)->getKind() <= RK_Op_LinalgIROp_ConcatOp
+
+#define RTTI_RK_OP_LINALGIROP_REDUCEMINOP_IMPL(v) \
+  return (v)->getKind() >= RK_Op_LinalgIROp_ReduceMinOp && (v)->getKind() <= RK_Op_LinalgIROp_ReduceMinOp
+
+#define RTTI_RK_OP_LINALGIROP_REDUCEMAXOP_IMPL(v) \
+  return (v)->getKind() >= RK_Op_LinalgIROp_ReduceMaxOp && (v)->getKind() <= RK_Op_LinalgIROp_ReduceMaxOp
+
+#define RTTI_RK_OP_LINALGIROP_REDUCESUMOP_IMPL(v) \
+  return (v)->getKind() >= RK_Op_LinalgIROp_ReduceSumOp && (v)->getKind() <= RK_Op_LinalgIROp_ReduceSumOp
 
 #define RTTI_RK_OP_GRAPHIROP_IMPL(v) return (v)->getKind() >= RK_Op_GraphIROp && (v)->getKind() <= RK_Op_GraphIROp_Last
 

--- a/mllm/compile/ir/linalg/Op.cpp
+++ b/mllm/compile/ir/linalg/Op.cpp
@@ -63,4 +63,8 @@ LINALG_AOPS_DECL(OpTypes::kClone, CloneOp);
 LINALG_AOPS_DECL(OpTypes::kNeg, NegOp);
 LINALG_AOPS_DECL(OpTypes::kConcat, ConcatOp);
 
+LINALG_AOPS_DECL(OpTypes::kReduceMax, ReduceMaxOp);
+LINALG_AOPS_DECL(OpTypes::kReduceMin, ReduceMinOp);
+LINALG_AOPS_DECL(OpTypes::kReduceSum, ReduceSumOp);
+
 }  // namespace mllm::ir::linalg

--- a/mllm/compile/ir/linalg/Op.hpp
+++ b/mllm/compile/ir/linalg/Op.hpp
@@ -51,6 +51,9 @@ class CopyOp;
 class CloneOp;
 class NegOp;
 class ConcatOp;
+class ReduceMaxOp;
+class ReduceMinOp;
+class ReduceSumOp;
 }  // namespace mllm
 
 #define LINALG_AOPS_DEFINE(class_name, rtti_name)                                                                       \
@@ -156,4 +159,8 @@ LINALG_AOPS_DEFINE(CloneOp, CLONEOP);
 
 LINALG_AOPS_DEFINE(NegOp, NEGOP);
 LINALG_AOPS_DEFINE(ConcatOp, CONCATOP);
+
+LINALG_AOPS_DEFINE(ReduceMaxOp, REDUCEMAXOP);
+LINALG_AOPS_DEFINE(ReduceMinOp, REDUCEMINOP);
+LINALG_AOPS_DEFINE(ReduceSumOp, REDUCESUMOP);
 }  // namespace mllm::ir::linalg

--- a/mllm/compile/ir/rtti_kind_gen.py
+++ b/mllm/compile/ir/rtti_kind_gen.py
@@ -251,6 +251,9 @@ def define_lianlg_ir(ir: dict):
     op.derive(Cls("CloneOp"))
     op.derive(Cls("NegOp"))
     op.derive(Cls("ConcatOp"))
+    op.derive(Cls("ReduceMinOp"))
+    op.derive(Cls("ReduceMaxOp"))
+    op.derive(Cls("ReduceSumOp"))
 
     # value
 

--- a/mllm/core/OpTypes.hpp
+++ b/mllm/core/OpTypes.hpp
@@ -54,6 +54,9 @@ enum class OpTypes : int32_t {
   kConcat,
   kReLU,
   kReLU2,
+  kReduceMax,
+  kReduceMin,
+  kReduceSum,
 
   // Graph Control Ops
   kGraphBegin,

--- a/mllm/core/Tensor.cpp
+++ b/mllm/core/Tensor.cpp
@@ -1,16 +1,12 @@
-/**
- * @file Tensor.cpp
- * @author chenghua Wang (chenghua.wang.edu@gmail.com)
- * @brief
- * @version 0.1
- * @date 2025-07-21
- *
- * @copyright Copyright (c) 2025
- *
- */
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
+
 #include "mllm/core/Tensor.hpp"
 #include "mllm/core/aops/ElewiseOps.hpp"
 #include "mllm/core/aops/FillOp.hpp"
+#include "mllm/core/aops/PermuteOp.hpp"
+#include "mllm/core/aops/ReduceOps.hpp"
+#include "mllm/core/aops/TransposeOp.hpp"
 #include "mllm/engine/Context.hpp"
 
 namespace mllm {
@@ -139,11 +135,25 @@ Tensor Tensor::operator/(float rhs) {
   return Context::instance().buildOpAndSubmitTask(OpTypes::kDiv, aops::DivOpOptions{}, {*this, rhs_tensor})[0];
 }
 
+Tensor Tensor::min(bool keep_dim, int32_t dim) {
+  return Context::instance().buildOpAndSubmitTask(OpTypes::kReduceMin,
+                                                  aops::ReduceMinOpOptions{.dim = dim, .keep_dim = keep_dim}, {*this})[0];
+}
+
+Tensor Tensor::max(bool keep_dim, int32_t dim) {
+  return Context::instance().buildOpAndSubmitTask(OpTypes::kReduceMax,
+                                                  aops::ReduceMaxOpOptions{.dim = dim, .keep_dim = keep_dim}, {*this})[0];
+}
+
+Tensor Tensor::sum(bool keep_dim, int32_t dim) {
+  return Context::instance().buildOpAndSubmitTask(OpTypes::kReduceSum,
+                                                  aops::ReduceSumOpOptions{.dim = dim, .keep_dim = keep_dim}, {*this})[0];
+}
 Tensor Tensor::operator-() { return Context::instance().buildOpAndSubmitTask(OpTypes::kNeg, aops::NegOpOptions{}, {*this})[0]; }
 
 Tensor Tensor::transpose(int dim0, int dim1) {
-  // TODO
-  return Tensor::nil();
+  return Context::instance().buildOpAndSubmitTask(OpTypes::kTranspose, aops::TransposeOpOptions{.dim0 = dim0, .dim1 = dim1},
+                                                  {*this})[0];
 }
 
 Tensor Tensor::T() { return transpose(-1, -2); }
@@ -244,8 +254,7 @@ Tensor Tensor::clone() {
 }
 
 Tensor Tensor::permute(const shape_t& indices) {
-  // TODO
-  return Tensor::nil();
+  return Context::instance().buildOpAndSubmitTask(OpTypes::kPermute, aops::PermuteOpOptions{.axis = indices}, {*this})[0];
 }
 
 size_t Tensor::bytes() { return impl_->size(); }

--- a/mllm/core/Tensor.hpp
+++ b/mllm/core/Tensor.hpp
@@ -1,13 +1,6 @@
-/**
- * @file Tensor.hpp
- * @author chenghua Wang (chenghua.wang.edu@gmail.com)
- * @brief
- * @version 0.1
- * @date 2025-07-21
- *
- * @copyright Copyright (c) 2025
- *
- */
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
+
 #pragma once
 
 #include <memory>
@@ -161,6 +154,30 @@ class Tensor {
   Tensor operator*(float rhs);
   Tensor operator/(float rhs);
   /// @}
+
+  /**
+   * @brief Get min
+   *
+   * @param dim if dim == 0x7fffffff, return a scalar value.
+   * @return Tensor
+   */
+  Tensor min(bool keep_dim = false, int32_t dim = 0x7fffffff);
+
+  /**
+   * @brief Get max
+   *
+   * @param dim if dim == 0x7fffffff, return a scalar value.
+   * @return Tensor
+   */
+  Tensor max(bool keep_dim = false, int32_t dim = 0x7fffffff);
+
+  /**
+   * @brief Get sum
+   *
+   * @param dim if dim == 0x7fffffff, return a scalar value.
+   * @return Tensor
+   */
+  Tensor sum(bool keep_dim = false, int32_t dim = 0x7fffffff);
 
   /**
    * @brief Negative

--- a/mllm/core/TensorStorage.cpp
+++ b/mllm/core/TensorStorage.cpp
@@ -1,13 +1,6 @@
-/**
- * @file TensorStorage.cpp
- * @author chenghua Wang (chenghua.wang.edu@gmail.com)
- * @brief
- * @version 0.1
- * @date 2025-07-21
- *
- * @copyright Copyright (c) 2025
- *
- */
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
+
 #include "mllm/utils/Common.hpp"
 #include "mllm/core/DataTypes.hpp"
 #include "mllm/core/TensorStorage.hpp"

--- a/mllm/core/TensorStorage.hpp
+++ b/mllm/core/TensorStorage.hpp
@@ -1,13 +1,6 @@
-/**
- * @file TensorStorage.hpp
- * @author chenghua Wang (chenghua.wang.edu@gmail.com)
- * @brief
- * @version 0.1
- * @date 2025-07-21
- *
- * @copyright Copyright (c) 2025
- *
- */
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
+
 #pragma once
 
 #include <cstdint>

--- a/mllm/core/TensorViewImpl.cpp
+++ b/mllm/core/TensorViewImpl.cpp
@@ -1,11 +1,6 @@
-/**
- * @file TensorImpl.cpp
- * @author chenghua Wang (chenghua.wang.edu@gmail.com)
- * @brief
- * @version 0.1
- * @date 2025-07-21
- *
- */
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
+
 #include "mllm/core/TensorViewImpl.hpp"
 
 namespace mllm {

--- a/mllm/core/TensorViewImpl.hpp
+++ b/mllm/core/TensorViewImpl.hpp
@@ -1,11 +1,6 @@
-/**
- * @file TensorImpl.hpp
- * @author chenghua Wang (chenghua.wang.edu@gmail.com)
- * @brief
- * @version 0.1
- * @date 2025-07-21
- *
- */
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
+
 #pragma once
 
 #define MLLM_TENSOR_SHAPE_MAX_LEN 16

--- a/mllm/core/aops/ElewiseOps.cpp
+++ b/mllm/core/aops/ElewiseOps.cpp
@@ -1,11 +1,6 @@
-/**
- * @file ElewiseOps.cpp
- * @author chenghua wang (chenghua.wang.edu@gmail.com)
- * @brief
- * @version 0.1
- * @date 2025-07-31
- *
- */
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
+
 #include "mllm/core/aops/ElewiseOps.hpp"
 
 #define __MLLM_ELEWISE_OP_IMPL(types, name)                                                                \

--- a/mllm/core/aops/ElewiseOps.hpp
+++ b/mllm/core/aops/ElewiseOps.hpp
@@ -1,11 +1,6 @@
-/**
- * @file ElewiseOps.hpp
- * @author chenghua wang (chenghua.wang.edu@gmail.com)
- * @brief
- * @version 0.1
- * @date 2025-07-31
- *
- */
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
+
 #pragma once
 #include "mllm/core/BaseOp.hpp"
 #include "mllm/compile/ir/linalg/Op.hpp"

--- a/mllm/core/aops/FillOp.cpp
+++ b/mllm/core/aops/FillOp.cpp
@@ -1,15 +1,11 @@
-/**
- * @file FillOp.cpp
- * @author chenghua wang (chenghua.wang.edu@gmail.com)
- * @brief
- * @version 0.1
- * @date 2025-07-26
- *
- */
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
+
 #include "mllm/core/aops/FillOp.hpp"
 #include "mllm/core/BaseOp.hpp"
 #include "mllm/core/Tensor.hpp"
 #include "mllm/utils/Common.hpp"
+#include "mllm/compile/ir/linalg/Op.hpp"
 
 namespace mllm::aops {
 
@@ -18,7 +14,10 @@ FillOp::FillOp(const FillOpOptions& options) : BaseOp(OpTypes::kFill), options_(
 void FillOp::load(const ParameterFile::ptr_t& ploader) { MLLM_EMPTY_SCOPE; }
 
 void FillOp::trace(void* trace_context, const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) {
-  NYI("FillOp::trace not implemented");
+  auto ir_ctx = (ir::IRContext*)trace_context;
+  auto i_irs = ir::tensor::wrapTensors2TensorIR(ir_ctx, inputs);
+  auto o_irs = ir::tensor::wrapTensors2TensorIR(ir_ctx, outputs);
+  ir_ctx->create<ir::linalg::FillOp>(shared_from_this(), i_irs, o_irs);
 }
 
 void FillOp::forward(const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) {

--- a/mllm/core/aops/GraphOps.cpp
+++ b/mllm/core/aops/GraphOps.cpp
@@ -1,11 +1,6 @@
-/**
- * @file GraphOps.cpp
- * @author chenghua wang (chenghua.wang.edu@gmail.com)
- * @brief
- * @version 0.1
- * @date 2025-07-28
- *
- */
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
+
 #include "mllm/utils/Common.hpp"
 #include "mllm/core/aops/GraphOps.hpp"
 

--- a/mllm/core/aops/GraphOps.hpp
+++ b/mllm/core/aops/GraphOps.hpp
@@ -1,11 +1,6 @@
-/**
- * @file GraphOps.hpp
- * @author chenghua wang (chenghua.wang.edu@gmail.com)
- * @brief
- * @version 0.1
- * @date 2025-07-28
- *
- */
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
+
 #pragma once
 
 #include <string>

--- a/mllm/core/aops/LinearOp.cpp
+++ b/mllm/core/aops/LinearOp.cpp
@@ -1,11 +1,6 @@
-/**
- * @file LinearOp.cpp
- * @author chenghua wang (chenghua.wang.edu@gmail.com)
- * @brief
- * @version 0.1
- * @date 2025-07-23
- *
- */
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
+
 #include "mllm/core/aops/LinearOp.hpp"
 #include "mllm/compile/ir/Node.hpp"
 #include "mllm/compile/ir/graph/Op.hpp"

--- a/mllm/core/aops/LinearOp.hpp
+++ b/mllm/core/aops/LinearOp.hpp
@@ -1,11 +1,6 @@
-/**
- * @file LinearOp.hpp
- * @author your name (you@domain.com)
- * @brief
- * @version 0.1
- * @date 2025-07-23
- *
- */
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
+
 #pragma once
 
 #include "mllm/core/BaseOp.hpp"

--- a/mllm/core/aops/PermuteOp.cpp
+++ b/mllm/core/aops/PermuteOp.cpp
@@ -1,0 +1,41 @@
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
+
+#include "mllm/core/aops/PermuteOp.hpp"
+#include "mllm/core/BaseOp.hpp"
+#include "mllm/core/Tensor.hpp"
+#include "mllm/utils/Common.hpp"
+#include "mllm/compile/ir/linalg/Op.hpp"
+
+namespace mllm::aops {
+
+PermuteOp::PermuteOp(const PermuteOpOptions& options) : BaseOp(OpTypes::kPermute), options_(options) {}
+
+void PermuteOp::load(const ParameterFile::ptr_t& ploader) { MLLM_EMPTY_SCOPE; }
+
+void PermuteOp::trace(void* trace_context, const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) {
+  auto ir_ctx = (ir::IRContext*)trace_context;
+  auto i_irs = ir::tensor::wrapTensors2TensorIR(ir_ctx, inputs);
+  auto o_irs = ir::tensor::wrapTensors2TensorIR(ir_ctx, outputs);
+  ir_ctx->create<ir::linalg::PermuteOp>(shared_from_this(), i_irs, o_irs);
+}
+
+void PermuteOp::forward(const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) {
+  NYI("PermuteOp::forward not implemented in aops base.");
+}
+
+void PermuteOp::reshape(const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) {
+  auto& input = inputs[0];
+  auto& output = outputs[0];
+
+  auto input_shape = input.shape();
+  std::vector<int32_t> output_shape(input_shape.size());
+
+  for (int i = 0; i < input_shape.size(); ++i) { output_shape[i] = input_shape[options_.axis[i]]; }
+
+  outputs.emplace_back(Tensor::empty(output_shape, input.dtype(), input.device()));
+}
+
+void PermuteOp::setup(const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) { BaseOp::setup(inputs, outputs); }
+
+}  // namespace mllm::aops

--- a/mllm/core/aops/PermuteOp.hpp
+++ b/mllm/core/aops/PermuteOp.hpp
@@ -8,28 +8,13 @@
 
 namespace mllm::aops {
 
-enum class FillOpTypes : int32_t {
-  kFillOpTypes_Start = 0,
-  kZeros,
-  kOnes,
-  kSpecific,
-  kRandom,
-  kArange,
-  kFillOpTypes_End,
+struct PermuteOpOptions : public BaseOpOptions<PermuteOpOptions> {
+  std::vector<int> axis;
 };
 
-struct FillOpOptions : public BaseOpOptions<FillOpOptions> {
-  FillOpTypes type = FillOpTypes::kFillOpTypes_Start;
-  float value = 0.f;
-  float start = 0.f;
-  float end = 0.f;
-  float step = 0.f;
-  uint64_t seed = 42;
-};
-
-class FillOp : public BaseOp {
+class PermuteOp : public BaseOp {
  public:
-  explicit FillOp(const FillOpOptions& cargo);
+  explicit PermuteOp(const PermuteOpOptions& cargo);
 
   void load(const ParameterFile::ptr_t& ploader) override;
 
@@ -42,7 +27,7 @@ class FillOp : public BaseOp {
   void setup(const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) override;
 
  protected:
-  FillOpOptions options_;
+  PermuteOpOptions options_;
 };
 
 }  // namespace mllm::aops

--- a/mllm/core/aops/ReduceOps.cpp
+++ b/mllm/core/aops/ReduceOps.cpp
@@ -1,0 +1,172 @@
+/**
+ * @file ReduceOps.cpp
+ * @author chenghua wang (chenghua.wang.edu@gmail.com)
+ * @brief
+ * @version 0.1
+ * @date 2025-08-01
+ *
+ */
+#include "mllm/core/BaseOp.hpp"
+#include "mllm/core/OpTypes.hpp"
+#include "mllm/core/aops/ReduceOps.hpp"
+#include "mllm/compile/ir/linalg/Op.hpp"
+
+namespace mllm::aops {
+
+ReduceMaxOp::ReduceMaxOp(const ReduceMaxOpOptions& options) : BaseOp(OpTypes::kReduceMax), options_(options) {}
+
+void ReduceMaxOp::load(const ParameterFile::ptr_t& ploader) { MLLM_EMPTY_SCOPE; }
+
+void ReduceMaxOp::trace(void* trace_context, const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) {
+  auto ir_ctx = (ir::IRContext*)trace_context;
+  auto i_irs = ir::tensor::wrapTensors2TensorIR(ir_ctx, inputs);
+  auto o_irs = ir::tensor::wrapTensors2TensorIR(ir_ctx, outputs);
+  ir_ctx->create<ir::linalg::ReduceMaxOp>(shared_from_this(), i_irs, o_irs);
+}
+
+void ReduceMaxOp::forward(const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) {
+  NYI("ReduceMaxOp::forward not implemented in aops base.");
+}
+
+void ReduceMaxOp::reshape(const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) {
+  auto& input = inputs[0];
+
+  if (!input.isNil()) {
+    auto input_shape = input.shape();
+    std::vector<int32_t> output_shape;
+
+    if (options_.dim == 0x7fffffff) {
+      // Reduce over all dimensions, result is a scalar
+      if (options_.keep_dim) {
+        output_shape.resize(input_shape.size(), 1);
+      } else {
+        output_shape = {1};
+      }
+    } else {
+      int32_t dim = options_.dim;
+      // Handle negative dimension index
+      if (dim < 0) { dim += input_shape.size(); }
+
+      if (options_.keep_dim) {
+        // Keep dimensions, so the reduced dimension becomes 1
+        output_shape = input_shape;
+        output_shape[dim] = 1;
+      } else {
+        // Don't keep dimensions, so remove the reduced dimension
+        for (int i = 0; i < input_shape.size(); ++i) {
+          if (i != dim) { output_shape.push_back(input_shape[i]); }
+        }
+      }
+    }
+
+    outputs.emplace_back(Tensor::empty(output_shape, input.dtype(), input.device()));
+  }
+}
+
+void ReduceMaxOp::setup(const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) { BaseOp::setup(inputs, outputs); }
+
+ReduceMinOp::ReduceMinOp(const ReduceMinOpOptions& options) : BaseOp(OpTypes::kReduceMin), options_(options) {}
+
+void ReduceMinOp::load(const ParameterFile::ptr_t& ploader) { MLLM_EMPTY_SCOPE; }
+
+void ReduceMinOp::trace(void* trace_context, const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) {
+  auto ir_ctx = (ir::IRContext*)trace_context;
+  auto i_irs = ir::tensor::wrapTensors2TensorIR(ir_ctx, inputs);
+  auto o_irs = ir::tensor::wrapTensors2TensorIR(ir_ctx, outputs);
+  ir_ctx->create<ir::linalg::ReduceMinOp>(shared_from_this(), i_irs, o_irs);
+}
+
+void ReduceMinOp::forward(const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) {
+  NYI("ReduceMinOp::forward not implemented in aops base.");
+}
+
+void ReduceMinOp::reshape(const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) {
+  auto& input = inputs[0];
+
+  if (!input.isNil()) {
+    auto input_shape = input.shape();
+    std::vector<int32_t> output_shape;
+
+    if (options_.dim == 0x7fffffff) {
+      // Reduce over all dimensions, result is a scalar
+      if (options_.keep_dim) {
+        output_shape.resize(input_shape.size(), 1);
+      } else {
+        output_shape = {1};
+      }
+    } else {
+      int32_t dim = options_.dim;
+      // Handle negative dimension index
+      if (dim < 0) { dim += input_shape.size(); }
+
+      if (options_.keep_dim) {
+        // Keep dimensions, so the reduced dimension becomes 1
+        output_shape = input_shape;
+        output_shape[dim] = 1;
+      } else {
+        // Don't keep dimensions, so remove the reduced dimension
+        for (int i = 0; i < input_shape.size(); ++i) {
+          if (i != dim) { output_shape.push_back(input_shape[i]); }
+        }
+      }
+    }
+
+    outputs.emplace_back(Tensor::empty(output_shape, input.dtype(), input.device()));
+  }
+}
+
+void ReduceMinOp::setup(const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) { BaseOp::setup(inputs, outputs); }
+
+ReduceSumOp::ReduceSumOp(const ReduceSumOpOptions& options) : BaseOp(OpTypes::kReduceSum), options_(options) {}
+
+void ReduceSumOp::load(const ParameterFile::ptr_t& ploader) { MLLM_EMPTY_SCOPE; }
+
+void ReduceSumOp::trace(void* trace_context, const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) {
+  auto ir_ctx = (ir::IRContext*)trace_context;
+  auto i_irs = ir::tensor::wrapTensors2TensorIR(ir_ctx, inputs);
+  auto o_irs = ir::tensor::wrapTensors2TensorIR(ir_ctx, outputs);
+  ir_ctx->create<ir::linalg::ReduceSumOp>(shared_from_this(), i_irs, o_irs);
+}
+
+void ReduceSumOp::forward(const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) {
+  NYI("ReduceSumOp::forward not implemented in aops base.");
+}
+
+void ReduceSumOp::reshape(const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) {
+  auto& input = inputs[0];
+
+  if (!input.isNil()) {
+    auto input_shape = input.shape();
+    std::vector<int32_t> output_shape;
+
+    if (options_.dim == 0x7fffffff) {
+      // Reduce over all dimensions, result is a scalar
+      if (options_.keep_dim) {
+        output_shape.resize(input_shape.size(), 1);
+      } else {
+        output_shape = {1};
+      }
+    } else {
+      int32_t dim = options_.dim;
+      // Handle negative dimension index
+      if (dim < 0) { dim += input_shape.size(); }
+
+      if (options_.keep_dim) {
+        // Keep dimensions, so the reduced dimension becomes 1
+        output_shape = input_shape;
+        output_shape[dim] = 1;
+      } else {
+        // Don't keep dimensions, so remove the reduced dimension
+        for (int i = 0; i < input_shape.size(); ++i) {
+          if (i != dim) { output_shape.push_back(input_shape[i]); }
+        }
+      }
+    }
+
+    outputs.emplace_back(Tensor::empty(output_shape, input.dtype(), input.device()));
+  }
+}
+
+void ReduceSumOp::setup(const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) { BaseOp::setup(inputs, outputs); }
+
+}  // namespace mllm::aops

--- a/mllm/core/aops/ReduceOps.hpp
+++ b/mllm/core/aops/ReduceOps.hpp
@@ -1,0 +1,85 @@
+/**
+ * @file ReduceOps.hpp
+ * @author chenghua wang (chenghua.wang.edu@gmail.com)
+ * @brief
+ * @version 0.1
+ * @date 2025-08-01
+ *
+ */
+#pragma once
+
+#include "mllm/core/BaseOp.hpp"
+#include "mllm/core/ParameterFile.hpp"
+
+namespace mllm::aops {
+
+struct ReduceMaxOpOptions : public BaseOpOptions<ReduceMaxOpOptions> {
+  int32_t dim = 0x7fffffff;
+  bool keep_dim = false;
+};
+
+class ReduceMaxOp : public BaseOp {
+ public:
+  explicit ReduceMaxOp(const ReduceMaxOpOptions& cargo);
+
+  void load(const ParameterFile::ptr_t& ploader) override;
+
+  void trace(void* trace_context, const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) override;
+
+  void forward(const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) override;
+
+  void reshape(const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) override;
+
+  void setup(const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) override;
+
+ protected:
+  ReduceMaxOpOptions options_;
+};
+
+struct ReduceMinOpOptions : public BaseOpOptions<ReduceMinOpOptions> {
+  int32_t dim = -1;
+  bool keep_dim = false;
+};
+
+class ReduceMinOp : public BaseOp {
+ public:
+  explicit ReduceMinOp(const ReduceMinOpOptions& cargo);
+
+  void load(const ParameterFile::ptr_t& ploader) override;
+
+  void trace(void* trace_context, const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) override;
+
+  void forward(const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) override;
+
+  void reshape(const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) override;
+
+  void setup(const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) override;
+
+ protected:
+  ReduceMinOpOptions options_;
+};
+
+struct ReduceSumOpOptions : public BaseOpOptions<ReduceSumOpOptions> {
+  int32_t dim = -1;
+  bool keep_dim = false;
+};
+
+class ReduceSumOp : public BaseOp {
+ public:
+  explicit ReduceSumOp(const ReduceSumOpOptions& cargo);
+
+  void load(const ParameterFile::ptr_t& ploader) override;
+
+  void trace(void* trace_context, const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) override;
+
+  void forward(const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) override;
+
+  void reshape(const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) override;
+
+  void setup(const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) override;
+
+ protected:
+  ReduceSumOpOptions options_;
+};
+
+}  // namespace mllm::aops

--- a/mllm/core/aops/TransposeOp.cpp
+++ b/mllm/core/aops/TransposeOp.cpp
@@ -1,0 +1,51 @@
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
+
+#include "mllm/core/aops/TransposeOp.hpp"
+#include "mllm/core/BaseOp.hpp"
+#include "mllm/core/Tensor.hpp"
+#include "mllm/utils/Common.hpp"
+#include "mllm/compile/ir/linalg/Op.hpp"
+
+namespace mllm::aops {
+
+TransposeOp::TransposeOp(const TransposeOpOptions& options) : BaseOp(OpTypes::kTranspose), options_(options) {}
+
+void TransposeOp::load(const ParameterFile::ptr_t& ploader) { MLLM_EMPTY_SCOPE; }
+
+void TransposeOp::trace(void* trace_context, const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) {
+  auto ir_ctx = (ir::IRContext*)trace_context;
+  auto i_irs = ir::tensor::wrapTensors2TensorIR(ir_ctx, inputs);
+  auto o_irs = ir::tensor::wrapTensors2TensorIR(ir_ctx, outputs);
+  ir_ctx->create<ir::linalg::TransposeOp>(shared_from_this(), i_irs, o_irs);
+}
+
+void TransposeOp::forward(const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) {
+  NYI("TransposeOp::forward not implemented in aops base.");
+}
+
+void TransposeOp::reshape(const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) {
+  auto& input = inputs[0];
+  auto input_shape = input.shape();
+
+  // Handle negative indices
+  int dim0 = options_.dim0;
+  int dim1 = options_.dim1;
+
+  if (dim0 < 0) dim0 += input_shape.size();
+  if (dim1 < 0) dim1 += input_shape.size();
+
+  // Validate dimensions
+  MLLM_RT_ASSERT(dim0 >= 0 && dim0 < (int)input_shape.size());
+  MLLM_RT_ASSERT(dim1 >= 0 && dim1 < (int)input_shape.size());
+
+  // Create output shape by swapping dimensions
+  auto output_shape = input_shape;
+  std::swap(output_shape[dim0], output_shape[dim1]);
+
+  outputs.emplace_back(Tensor::empty(output_shape, input.dtype(), input.device()));
+}
+
+void TransposeOp::setup(const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) { BaseOp::setup(inputs, outputs); }
+
+}  // namespace mllm::aops

--- a/mllm/core/aops/TransposeOp.hpp
+++ b/mllm/core/aops/TransposeOp.hpp
@@ -8,28 +8,14 @@
 
 namespace mllm::aops {
 
-enum class FillOpTypes : int32_t {
-  kFillOpTypes_Start = 0,
-  kZeros,
-  kOnes,
-  kSpecific,
-  kRandom,
-  kArange,
-  kFillOpTypes_End,
+struct TransposeOpOptions : public BaseOpOptions<TransposeOpOptions> {
+  int dim0;
+  int dim1;
 };
 
-struct FillOpOptions : public BaseOpOptions<FillOpOptions> {
-  FillOpTypes type = FillOpTypes::kFillOpTypes_Start;
-  float value = 0.f;
-  float start = 0.f;
-  float end = 0.f;
-  float step = 0.f;
-  uint64_t seed = 42;
-};
-
-class FillOp : public BaseOp {
+class TransposeOp : public BaseOp {
  public:
-  explicit FillOp(const FillOpOptions& cargo);
+  explicit TransposeOp(const TransposeOpOptions& options);
 
   void load(const ParameterFile::ptr_t& ploader) override;
 
@@ -42,7 +28,7 @@ class FillOp : public BaseOp {
   void setup(const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) override;
 
  protected:
-  FillOpOptions options_;
+  TransposeOpOptions options_;
 };
 
 }  // namespace mllm::aops

--- a/mllm/engine/Context.cpp
+++ b/mllm/engine/Context.cpp
@@ -147,4 +147,6 @@ uint64_t Context::curTime() {
   return std::chrono::duration_cast<std::chrono::microseconds>(duration).count();
 }
 
+std::unordered_map<std::thread::id, SessionTCB::ptr_t> Context::refSessionThreads() { return session_threads_; }
+
 }  // namespace mllm

--- a/mllm/engine/Context.hpp
+++ b/mllm/engine/Context.hpp
@@ -100,6 +100,8 @@ class Context {
 
   uint64_t curTime();
 
+  std::unordered_map<std::thread::id, SessionTCB::ptr_t> refSessionThreads();
+
  private:
   bool perf_mode_ = false;
   PerfFile::ptr_t perf_file_ = nullptr;

--- a/mllm/mllm.cpp
+++ b/mllm/mllm.cpp
@@ -14,7 +14,17 @@
 namespace mllm {
 
 void shutdownContext() {
-  // TODO
+  auto all_threads = Context::instance().refSessionThreads();
+  auto this_thread = Context::instance().thisThread();
+  for (auto& tcb : all_threads) {
+    if (tcb.first != this_thread->system_tid) {
+      tcb.second->attached_contexts._ref_raw_data().clear();
+      tcb.second->layer_ops_table._ref_raw_data().clear();
+      tcb.second->ir_context = nullptr;
+      tcb.second->trace_mode = false;
+    }
+  }
+  ::mllm::cleanThisThread();
 }
 
 void setRandomSeed(uint64_t seed) { Context::instance().setRandomSeed(seed); }


### PR DESCRIPTION
- Implement CPU kernels for transpose and permute operations
- Register new operations in the CPU backend
- Update Kernels.hpp to include new operation headers
- Refactor existing elementwise and reduce kernels for better code organization