### PR TITLE
feat(core): implement tensor operations and add functional API

### DIFF
--- a/mllm/core/Tensor.cpp
+++ b/mllm/core/Tensor.cpp
@@ -2,14 +2,18 @@
 // Licensed under the MIT License.
 
 #include "mllm/core/Tensor.hpp"
+#include "mllm/core/aops/CastTypeOp.hpp"
 #include "mllm/core/aops/CloneOp.hpp"
+#include "mllm/core/aops/ContiguousOp.hpp"
 #include "mllm/core/aops/ElewiseOps.hpp"
 #include "mllm/core/aops/FillOp.hpp"
 #include "mllm/core/aops/PermuteOp.hpp"
 #include "mllm/core/aops/ReduceOps.hpp"
 #include "mllm/core/aops/RepeatOp.hpp"
+#include "mllm/core/aops/ReshapeOp.hpp"
 #include "mllm/core/aops/TransposeOp.hpp"
 #include "mllm/core/aops/ViewOp.hpp"
+#include "mllm/core/aops/X2XOp.hpp"
 #include "mllm/engine/Context.hpp"
 
 namespace mllm {
@@ -163,26 +167,22 @@ Tensor Tensor::T() { return transpose(-1, -2); }
 
 Tensor Tensor::to(DeviceTypes device) {
   if (device == impl_->device()) { return *this; }
-  // TODO
-  return Tensor::nil();
+  return Context::instance().buildOpAndSubmitTask(OpTypes::kX2X, aops::X2XOpOptions{.device = device}, {*this})[0];
 }
 
 Tensor Tensor::to(DataTypes dtype) {
   if (dtype == impl_->dtype()) { return *this; }
-  // TODO
-  return Tensor::nil();
+  return Context::instance().buildOpAndSubmitTask(OpTypes::kCastType, aops::CastTypeOpOptions{.dtype = dtype}, {*this})[0];
 }
 
 Tensor Tensor::cpu() {
   if (kCPU == impl_->device()) { return *this; }
-  // TODO
-  return Tensor::nil();
+  return to(kCPU);
 }
 
 Tensor Tensor::cuda() {
   if (kCUDA == impl_->device()) { return *this; }
-  // TODO
-  return Tensor::nil();
+  return to(kCUDA);
 }
 
 std::string Tensor::name() const { return impl()->name(); }
@@ -222,13 +222,11 @@ uint32_t Tensor::uuid() const { return impl()->uuid(); }
 bool Tensor::isContiguous() const { return impl()->isContiguous(); }
 
 Tensor Tensor::contiguous() {
-  // TODO
-  return Tensor::nil();
+  return Context::instance().buildOpAndSubmitTask(OpTypes::kContiguous, aops::ContiguousOpOptions{}, {*this})[0];
 }
 
 Tensor Tensor::reshape(const Tensor::shape_t& shape) {
-  // TODO
-  return Tensor::nil();
+  return Context::instance().buildOpAndSubmitTask(OpTypes::kReshape, aops::ReshapeOpOptions{.shape = shape}, {*this})[0];
 }
 
 Tensor Tensor::view(const Tensor::shape_t& indicies) {

--- a/mllm/core/aops/ContiguousOp.cpp
+++ b/mllm/core/aops/ContiguousOp.cpp
@@ -1,2 +1,34 @@
 // Copyright (c) MLLM Team.
 // Licensed under the MIT License.
+
+#include "mllm/core/aops/ContiguousOp.hpp"
+#include "mllm/core/BaseOp.hpp"
+#include "mllm/core/Tensor.hpp"
+#include "mllm/utils/Common.hpp"
+#include "mllm/compile/ir/linalg/Op.hpp"
+
+namespace mllm::aops {
+
+ContiguousOp::ContiguousOp(const ContiguousOpOptions& options) : BaseOp(OpTypes::kContiguous), options_(options) {}
+
+void ContiguousOp::load(const ParameterFile::ptr_t& ploader) { MLLM_EMPTY_SCOPE; }
+
+void ContiguousOp::trace(void* trace_context, const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) {
+  auto ir_ctx = (ir::IRContext*)trace_context;
+  auto i_irs = ir::tensor::wrapTensors2TensorIR(ir_ctx, inputs);
+  auto o_irs = ir::tensor::wrapTensors2TensorIR(ir_ctx, outputs);
+  ir_ctx->create<ir::linalg::ContiguousOp>(shared_from_this(), i_irs, o_irs);
+}
+
+void ContiguousOp::forward(const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) {
+  NYI("ContiguousOp::forward not implemented in aops base.");
+}
+
+void ContiguousOp::reshape(const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) {
+  const auto& i = inputs[0];
+  outputs.emplace_back(Tensor::empty(i.shape(), i.dtype(), i.device()));
+}
+
+void ContiguousOp::setup(const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) { BaseOp::setup(inputs, outputs); }
+
+}  // namespace mllm::aops

--- a/mllm/core/aops/ContiguousOp.hpp
+++ b/mllm/core/aops/ContiguousOp.hpp
@@ -2,3 +2,30 @@
 // Licensed under the MIT License.
 
 #pragma once
+
+#include "mllm/core/BaseOp.hpp"
+#include "mllm/core/ParameterFile.hpp"
+
+namespace mllm::aops {
+
+struct ContiguousOpOptions : public BaseOpOptions<ContiguousOpOptions> {};
+
+class ContiguousOp : public BaseOp {
+ public:
+  explicit ContiguousOp(const ContiguousOpOptions& options);
+
+  void load(const ParameterFile::ptr_t& ploader) override;
+
+  void trace(void* trace_context, const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) override;
+
+  void forward(const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) override;
+
+  void reshape(const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) override;
+
+  void setup(const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) override;
+
+ protected:
+  ContiguousOpOptions options_;
+};
+
+}  // namespace mllm::aops

--- a/mllm/nn/Functional.cpp
+++ b/mllm/nn/Functional.cpp
@@ -7,5 +7,35 @@
  *
  */
 #include "mllm/nn/Functional.hpp"
+#include "mllm/core/aops/ConcatOp.hpp"
+#include "mllm/core/aops/MatMulOp.hpp"
+#include "mllm/core/aops/SplitOp.hpp"
+#include "mllm/core/aops/ViewOp.hpp"
+#include "mllm/engine/Context.hpp"
 
-namespace mllm::nn::functional {}
+namespace mllm::nn::functional {
+
+Tensor matmul(const Tensor& A, const Tensor& B, bool transpose_A, bool transpose_B) {
+  return Context::instance().buildOpAndSubmitTask(
+      OpTypes::kMatMul, aops::MatMulOpOptions{.transpose_a = transpose_A, .transpose_b = transpose_B}, {A, B})[0];
+}
+
+Tensor view(const Tensor& x, const std::vector<int32_t>& shape) {
+  return Context::instance().buildOpAndSubmitTask(OpTypes::kView, aops::ViewOpOptions{.to_shape = shape}, {x})[0];
+}
+
+std::vector<Tensor> split(const Tensor& x, int32_t split_size_or_sections, int32_t dim) {
+  return Context::instance().buildOpAndSubmitTask(
+      OpTypes::kSplit, aops::SplitOpOptions{.dim = dim, .split_size_or_sections = {split_size_or_sections}}, {x});
+}
+
+std::vector<Tensor> split(const Tensor& x, const std::vector<int32_t>& split_size_or_sections, int32_t dim) {
+  return Context::instance().buildOpAndSubmitTask(
+      OpTypes::kSplit, aops::SplitOpOptions{.dim = dim, .split_size_or_sections = split_size_or_sections}, {x});
+}
+
+Tensor concat(const std::vector<Tensor>& ins, int32_t dim) {
+  return Context::instance().buildOpAndSubmitTask(OpTypes::kConcat, aops::ConcatOpOptions{.dim = dim}, ins)[0];
+}
+
+}  // namespace mllm::nn::functional

--- a/mllm/nn/Functional.hpp
+++ b/mllm/nn/Functional.hpp
@@ -8,4 +8,55 @@
  */
 #pragma once
 
-namespace mllm::nn::functional {}
+#include <vector>
+#include <cstdint>
+
+#include "mllm/core/Tensor.hpp"
+#include "mllm/core/aops/SplitOp.hpp"
+#include "mllm/engine/Context.hpp"
+
+namespace mllm::nn::functional {
+
+Tensor matmul(const Tensor& A, const Tensor& B, bool transpose_A = false, bool transpose_B = false);
+
+Tensor view(const Tensor& x, const std::vector<int32_t>& shape);
+
+std::vector<Tensor> split(const Tensor& x, int32_t split_size_or_sections, int32_t dim);
+
+std::vector<Tensor> split(const Tensor& x, const std::vector<int32_t>& split_size_or_sections, int32_t dim);
+
+// For structure binding usage. But will increase compile time.
+// e.g.:
+// Tensor x = Tensor::ones({10, 2, 1024}, kFp32, kCPU);
+// auto [x1, x2, x3, x4] = split<4>(x, 256, -1);
+// assert(x1.shape()[2] == 1024 / 4)
+// assert(x2.shape()[2] == 1024 / 4)
+// assert(x3.shape()[2] == 1024 / 4)
+// assert(x4.shape()[2] == 1024 / 4)
+template<int32_t RET_NUM>
+std::array<Tensor, RET_NUM> split(const Tensor& x, int32_t split_size_or_sections, int32_t dim) {
+  auto outputs = Context::instance().buildOpAndSubmitTask(
+      OpTypes::kSplit, aops::SplitOpOptions{.dim = dim, .split_size_or_sections = {split_size_or_sections}}, {x});
+  std::array<Tensor, RET_NUM> ret;
+
+#pragma unroll
+  for (int i = 0; i < RET_NUM; ++i) { ret[i] = outputs[i]; }
+
+  return ret;
+}
+
+template<int32_t RET_NUM>
+std::array<Tensor, RET_NUM> split(const Tensor& x, const std::vector<int32_t>& split_size_or_sections, int32_t dim) {
+  auto outputs = Context::instance().buildOpAndSubmitTask(
+      OpTypes::kSplit, aops::SplitOpOptions{.dim = dim, .split_size_or_sections = split_size_or_sections}, {x});
+  std::array<Tensor, RET_NUM> ret;
+
+#pragma unroll
+  for (int i = 0; i < RET_NUM; ++i) { ret[i] = outputs[i]; }
+
+  return ret;
+}
+
+Tensor concat(const std::vector<Tensor>& ins, int32_t dim);
+
+}  // namespace mllm::nn::functional


### PR DESCRIPTION
- Implement ContiguousOp for tensor contiguous operation
- Add tensor methods: to(DeviceTypes), to(DataTypes), cpu(), cuda(), contiguous(), reshape()
- Implement functional API for common tensor operations:
  - matmul()
  - view()
  - split()
  - concat()
- Update Tensor class to use new operations