### PR TITLE
refactor(pymllm): update API and add new classes

### DIFF
--- a/mllm/nn/Module.cpp
+++ b/mllm/nn/Module.cpp
@@ -76,10 +76,6 @@ ModuleImpl::ptr_t Module::impl() const { return impl_; }
 
 void Module::to(DeviceTypes device_type) { impl()->to(device_type); }
 
-void Module::reg_(const std::string& name, const AbstractNnNode::ptr_t& node) {
-  // TODO
-}
-
 void Module::load(const ParameterFile::ptr_t& param_file) { impl_->load(param_file); }
 
 void Module::__fmt_print(std::stringstream& ss) const { impl()->__fmt_print(ss); }

--- a/mllm/nn/Module.hpp
+++ b/mllm/nn/Module.hpp
@@ -59,6 +59,7 @@ class Module {
     if constexpr (std::is_base_of_v<Module, T>) {
       auto ret = T(impl_->getAbsoluteName() + "." + name, std::forward<Args>(args)...);
       impl_->regChildNode(ret.impl());
+      ret.impl()->setName(name);
       return ret;
     }
 
@@ -67,6 +68,7 @@ class Module {
       auto ret = T(std::forward<Args>(args)...);
       impl_->regChildNode(ret.impl());
       ret.impl()->setAbsoluteName(impl_->getAbsoluteName() + "." + name);
+      ret.impl()->setName(name);
 
       auto& ctx = Context::instance();
 
@@ -79,16 +81,6 @@ class Module {
       return ret;
     }
   }
-
-  /**
-   * @brief This function is used to register a node to the module.
-   *
-   * @note This function is for python API binding specially. Do not use this function in C++ code.
-   *
-   * @param name
-   * @param node
-   */
-  void reg_(const std::string& name, const AbstractNnNode::ptr_t& node);
 
   template<typename... Args>
   std::vector<Tensor> operator()(Args&&... args) {

--- a/pymllm/_C.pyi
+++ b/pymllm/_C.pyi
@@ -1,38 +1,64 @@
 from __future__ import annotations
+import collections.abc
 import typing
 import typing_extensions
-__all__ = ['AbstractNnNode', 'ConfigFile', 'Context', 'DataTypes', 'DeviceTypes', 'Dispatcher', 'DispatcherManager', 'DispatcherManagerOptions', 'LayerImpl', 'MemoryManager', 'MemoryManagerOptions', 'ModelFileVersion', 'ModuleImpl', 'PerfFile', 'SessionTCB', 'Task', 'TaskTypes', 'Tensor', 'clean_this_thread', 'get_perf_file', 'initialize_context', 'is_opencl_available', 'is_qnn_available', 'load', 'memory_report', 'perf_end', 'perf_start', 'save', 'set_maximum_num_threads', 'set_random_seed', 'shutdown_context', 'this_thread']
+__all__ = ['AbstractNnNode', 'BaseOp', 'BaseOpOptionsBase', 'ConfigFile', 'Context', 'DataTypes', 'DeviceTypes', 'Dispatcher', 'DispatcherManager', 'DispatcherManagerOptions', 'LayerImpl', 'LinearImplTypes', 'LinearOp', 'LinearOpOptions', 'MemoryManager', 'MemoryManagerOptions', 'ModelFileVersion', 'ModuleImpl', 'OpTypes', 'ParameterFile', 'PerfFile', 'SessionTCB', 'Task', 'TaskTypes', 'Tensor', 'TensorMemTypes', 'clean_this_thread', 'get_perf_file', 'initialize_context', 'is_opencl_available', 'is_qnn_available', 'load', 'memory_report', 'perf_end', 'perf_start', 'save', 'set_maximum_num_threads', 'set_random_seed', 'shutdown_context', 'this_thread']
 class AbstractNnNode:
-    def depthDecrease(self) -> None:
+    def depth_decrease(self) -> None:
         ...
-    def depthIncrease(self) -> None:
+    def depth_increase(self) -> None:
         ...
-    def getAbsoluteName(self) -> str:
+    def get_absolute_name(self) -> str:
         ...
-    def getDepth(self) -> int:
+    def get_depth(self) -> int:
         ...
-    def getDevice(self) -> DeviceTypes:
+    def get_device(self) -> DeviceTypes:
         ...
-    def getName(self) -> str:
+    def get_name(self) -> str:
         ...
-    def getType(self) -> ...:
+    def get_type(self) -> ...:
         ...
-    def isCompiledAsObj(self) -> bool:
+    def is_compiled_as_obj(self) -> bool:
         ...
-    def refChildNodes(self) -> list[AbstractNnNode]:
+    def ref_child_nodes(self) -> list[AbstractNnNode]:
         ...
-    def refParentNode(self) -> ...:
+    def ref_parent_node(self) -> ...:
         ...
-    def regChildNode(self, arg0: AbstractNnNode) -> None:
+    def reg_child_node(self, arg0: AbstractNnNode) -> None:
         ...
-    def setAbsoluteName(self, arg0: str) -> None:
+    def set_absolute_name(self, arg0: str) -> None:
         ...
-    def setCompiledAsObj(self, arg0: bool) -> None:
+    def set_compiled_as_obj(self, arg0: bool) -> None:
         ...
-    def setDepth(self, arg0: typing.SupportsInt) -> None:
+    def set_depth(self, arg0: typing.SupportsInt) -> None:
         ...
-    def setName(self, arg0: str) -> None:
+    def set_name(self, arg0: str) -> None:
         ...
+class BaseOp:
+    def forward(self, arg0: collections.abc.Sequence[Tensor], arg1: collections.abc.Sequence[Tensor]) -> None:
+        ...
+    def get_device(self) -> DeviceTypes:
+        ...
+    def get_name(self) -> str:
+        ...
+    def get_op_type(self) -> OpTypes:
+        ...
+    def get_params(self) -> ParameterFile:
+        ...
+    def load(self, arg0: ParameterFile) -> None:
+        ...
+    def reshape(self, arg0: collections.abc.Sequence[Tensor], arg1: collections.abc.Sequence[Tensor]) -> None:
+        ...
+    def set_device_type(self, arg0: DeviceTypes) -> None:
+        ...
+    def set_name(self, arg0: str) -> None:
+        ...
+    def setup(self, arg0: collections.abc.Sequence[Tensor], arg1: collections.abc.Sequence[Tensor]) -> None:
+        ...
+    def trace(self, arg0: typing_extensions.CapsuleType, arg1: collections.abc.Sequence[Tensor], arg2: collections.abc.Sequence[Tensor]) -> None:
+        ...
+class BaseOpOptionsBase:
+    pass
 class ConfigFile:
     @typing.overload
     def __init__(self) -> None:
@@ -46,7 +72,7 @@ class ConfigFile:
         ...
     def load(self, arg0: str) -> None:
         ...
-    def loadString(self, arg0: str) -> None:
+    def loadS_string(self, arg0: str) -> None:
         ...
     def save(self, arg0: str) -> None:
         ...
@@ -54,27 +80,27 @@ class Context:
     @staticmethod
     def instance() -> Context:
         ...
-    def dispatcherManager(self) -> DispatcherManager:
+    def dispatcher_manager(self) -> DispatcherManager:
         ...
-    def getPerfFile(self) -> PerfFile:
+    def get_perf_file(self) -> PerfFile:
         ...
-    def getRandomSeed(self) -> int:
+    def get_random_seed(self) -> int:
         ...
-    def getUUID(self) -> int:
+    def get_uuid(self) -> int:
         ...
-    def isPerfMode(self) -> bool:
+    def is_perf_mode(self) -> bool:
         ...
-    def mainThread(self) -> SessionTCB:
+    def main_thread(self) -> SessionTCB:
         ...
-    def memoryManager(self) -> MemoryManager:
+    def memory_manager(self) -> MemoryManager:
         ...
-    def refSessionThreads(self) -> ...:
+    def ref_session_threads(self) -> dict[..., SessionTCB]:
         ...
-    def setPerfMode(self, arg0: bool) -> None:
+    def set_perf_mode(self, arg0: bool) -> None:
         ...
-    def setRandomSeed(self, arg0: typing.SupportsInt) -> None:
+    def set_random_seed(self, arg0: typing.SupportsInt) -> None:
         ...
-    def thisThread(self) -> SessionTCB:
+    def this_thread(self) -> SessionTCB:
         ...
 class DataTypes:
     """
@@ -253,7 +279,7 @@ class Dispatcher:
 class DispatcherManager:
     def submit(self, arg0: typing.SupportsInt, arg1: Task) -> None:
         ...
-    def syncWait(self, arg0: typing.SupportsInt) -> None:
+    def sync_wait(self, arg0: typing.SupportsInt) -> None:
         ...
 class DispatcherManagerOptions:
     numa_policy: bool
@@ -266,20 +292,116 @@ class DispatcherManagerOptions:
     def num_threads(self, arg0: typing.SupportsInt) -> None:
         ...
 class LayerImpl(AbstractNnNode):
-    def getInstancedOp(self) -> ...:
+    def __init__(self, op_type: OpTypes, options: LinearOpOptions) -> None:
         ...
-    def load(self, arg0: ...) -> None:
+    def get_instanced_op(self) -> BaseOp:
         ...
-    def opType(self) -> ...:
+    def load(self, arg0: ParameterFile) -> None:
         ...
-    def refOptions(self) -> ...:
+    def op_type(self) -> OpTypes:
         ...
-    def setInstancedOp(self, arg0: ...) -> None:
+    def ref_options(self) -> BaseOpOptionsBase:
+        ...
+    def set_instanced_op(self, arg0: BaseOp) -> None:
         ...
     def to(self, arg0: DeviceTypes) -> None:
         ...
+class LinearImplTypes:
+    """
+    Members:
+    
+      LinearImplTypes_Start
+    
+      Default
+    
+      Kleidiai_Start
+    
+      Kleidiai_End
+    
+      GGUF_Start
+    
+      GGUF_End
+    
+      LinearImplTypes_End
+    """
+    Default: typing.ClassVar[LinearImplTypes]  # value = <LinearImplTypes.Default: 1>
+    GGUF_End: typing.ClassVar[LinearImplTypes]  # value = <LinearImplTypes.GGUF_End: 5>
+    GGUF_Start: typing.ClassVar[LinearImplTypes]  # value = <LinearImplTypes.GGUF_Start: 4>
+    Kleidiai_End: typing.ClassVar[LinearImplTypes]  # value = <LinearImplTypes.Kleidiai_End: 3>
+    Kleidiai_Start: typing.ClassVar[LinearImplTypes]  # value = <LinearImplTypes.Kleidiai_Start: 2>
+    LinearImplTypes_End: typing.ClassVar[LinearImplTypes]  # value = <LinearImplTypes.LinearImplTypes_End: 6>
+    LinearImplTypes_Start: typing.ClassVar[LinearImplTypes]  # value = <LinearImplTypes.LinearImplTypes_Start: 0>
+    __members__: typing.ClassVar[dict[str, LinearImplTypes]]  # value = {'LinearImplTypes_Start': <LinearImplTypes.LinearImplTypes_Start: 0>, 'Default': <LinearImplTypes.Default: 1>, 'Kleidiai_Start': <LinearImplTypes.Kleidiai_Start: 2>, 'Kleidiai_End': <LinearImplTypes.Kleidiai_End: 3>, 'GGUF_Start': <LinearImplTypes.GGUF_Start: 4>, 'GGUF_End': <LinearImplTypes.GGUF_End: 5>, 'LinearImplTypes_End': <LinearImplTypes.LinearImplTypes_End: 6>}
+    def __eq__(self, other: typing.Any) -> bool:
+        ...
+    def __getstate__(self) -> int:
+        ...
+    def __hash__(self) -> int:
+        ...
+    def __index__(self) -> int:
+        ...
+    def __init__(self, value: typing.SupportsInt) -> None:
+        ...
+    def __int__(self) -> int:
+        ...
+    def __ne__(self, other: typing.Any) -> bool:
+        ...
+    def __repr__(self) -> str:
+        ...
+    def __setstate__(self, state: typing.SupportsInt) -> None:
+        ...
+    def __str__(self) -> str:
+        ...
+    @property
+    def name(self) -> str:
+        ...
+    @property
+    def value(self) -> int:
+        ...
+class LinearOp(BaseOp):
+    def __init__(self, arg0: LinearOpOptions) -> None:
+        ...
+    def bias(self) -> Tensor:
+        ...
+    def forward(self, arg0: collections.abc.Sequence[Tensor], arg1: collections.abc.Sequence[Tensor]) -> None:
+        ...
+    def load(self, arg0: ParameterFile) -> None:
+        ...
+    def options(self) -> LinearOpOptions:
+        ...
+    def reshape(self, arg0: collections.abc.Sequence[Tensor], arg1: collections.abc.Sequence[Tensor]) -> None:
+        ...
+    def setup(self, arg0: collections.abc.Sequence[Tensor], arg1: collections.abc.Sequence[Tensor]) -> None:
+        ...
+    def weight(self) -> Tensor:
+        ...
+class LinearOpOptions:
+    bias: bool
+    impl_type: LinearImplTypes
+    @typing.overload
+    def __init__(self) -> None:
+        ...
+    @typing.overload
+    def __init__(self, in_channels: typing.SupportsInt = 0, out_channels: typing.SupportsInt = 0, bias: bool = True, impl_type: LinearImplTypes = ...) -> None:
+        ...
+    def set_inputs_dtype(self, arg0: typing.SupportsInt, arg1: DataTypes) -> LinearOpOptions:
+        ...
+    def set_outputs_dtype(self, arg0: typing.SupportsInt, arg1: DataTypes) -> LinearOpOptions:
+        ...
+    @property
+    def in_channels(self) -> int:
+        ...
+    @in_channels.setter
+    def in_channels(self, arg0: typing.SupportsInt) -> None:
+        ...
+    @property
+    def out_channels(self) -> int:
+        ...
+    @out_channels.setter
+    def out_channels(self, arg0: typing.SupportsInt) -> None:
+        ...
 class MemoryManager:
-    def clearAll(self) -> None:
+    def clear_all(self) -> None:
         ...
     def report(self) -> None:
         ...
@@ -336,12 +458,180 @@ class ModelFileVersion:
 class ModuleImpl(AbstractNnNode):
     def __init__(self) -> None:
         ...
-    def load(self, arg0: ...) -> None:
+    def load(self, arg0: ParameterFile) -> None:
         ...
-    def params(self, arg0: ModelFileVersion) -> ...:
+    def params(self, arg0: ModelFileVersion) -> ParameterFile:
         ...
     def to(self, arg0: DeviceTypes) -> None:
         ...
+class OpTypes:
+    """
+    Members:
+    
+      OpType_Start
+    
+      Fill
+    
+      Add
+    
+      Sub
+    
+      Mul
+    
+      Div
+    
+      MatMul
+    
+      Embedding
+    
+      Linear
+    
+      RoPE
+    
+      Softmax
+    
+      Transpose
+    
+      RMSNorm
+    
+      SiLU
+    
+      KVCache
+    
+      CausalMask
+    
+      CastType
+    
+      X2X
+    
+      Split
+    
+      View
+    
+      FlashAttention2
+    
+      Repeat
+    
+      Permute
+    
+      Conv3D
+    
+      Conv2D
+    
+      Conv1D
+    
+      GELU
+    
+      LayerNorm
+    
+      MultimodalRoPE
+    
+      VisionRoPE
+    
+      QuickGELU
+    
+      Copy
+    
+      Clone
+    
+      Neg
+    
+      Concat
+    
+      ReLU
+    
+      ReLU2
+    
+      ReduceMax
+    
+      ReduceMin
+    
+      ReduceSum
+    
+      Contiguous
+    
+      Reshape
+    
+      GraphBegin
+    
+      GraphEnd
+    
+      OpType_End
+    """
+    Add: typing.ClassVar[OpTypes]  # value = <OpTypes.Add: 2>
+    CastType: typing.ClassVar[OpTypes]  # value = <OpTypes.CastType: 16>
+    CausalMask: typing.ClassVar[OpTypes]  # value = <OpTypes.CausalMask: 15>
+    Clone: typing.ClassVar[OpTypes]  # value = <OpTypes.Clone: 32>
+    Concat: typing.ClassVar[OpTypes]  # value = <OpTypes.Concat: 34>
+    Contiguous: typing.ClassVar[OpTypes]  # value = <OpTypes.Contiguous: 40>
+    Conv1D: typing.ClassVar[OpTypes]  # value = <OpTypes.Conv1D: 25>
+    Conv2D: typing.ClassVar[OpTypes]  # value = <OpTypes.Conv2D: 24>
+    Conv3D: typing.ClassVar[OpTypes]  # value = <OpTypes.Conv3D: 23>
+    Copy: typing.ClassVar[OpTypes]  # value = <OpTypes.Copy: 31>
+    Div: typing.ClassVar[OpTypes]  # value = <OpTypes.Div: 5>
+    Embedding: typing.ClassVar[OpTypes]  # value = <OpTypes.Embedding: 7>
+    Fill: typing.ClassVar[OpTypes]  # value = <OpTypes.Fill: 1>
+    FlashAttention2: typing.ClassVar[OpTypes]  # value = <OpTypes.FlashAttention2: 20>
+    GELU: typing.ClassVar[OpTypes]  # value = <OpTypes.GELU: 26>
+    GraphBegin: typing.ClassVar[OpTypes]  # value = <OpTypes.GraphBegin: 42>
+    GraphEnd: typing.ClassVar[OpTypes]  # value = <OpTypes.GraphEnd: 43>
+    KVCache: typing.ClassVar[OpTypes]  # value = <OpTypes.KVCache: 14>
+    LayerNorm: typing.ClassVar[OpTypes]  # value = <OpTypes.LayerNorm: 27>
+    Linear: typing.ClassVar[OpTypes]  # value = <OpTypes.Linear: 8>
+    MatMul: typing.ClassVar[OpTypes]  # value = <OpTypes.MatMul: 6>
+    Mul: typing.ClassVar[OpTypes]  # value = <OpTypes.Mul: 4>
+    MultimodalRoPE: typing.ClassVar[OpTypes]  # value = <OpTypes.MultimodalRoPE: 28>
+    Neg: typing.ClassVar[OpTypes]  # value = <OpTypes.Neg: 33>
+    OpType_End: typing.ClassVar[OpTypes]  # value = <OpTypes.OpType_End: 44>
+    OpType_Start: typing.ClassVar[OpTypes]  # value = <OpTypes.OpType_Start: 0>
+    Permute: typing.ClassVar[OpTypes]  # value = <OpTypes.Permute: 22>
+    QuickGELU: typing.ClassVar[OpTypes]  # value = <OpTypes.QuickGELU: 30>
+    RMSNorm: typing.ClassVar[OpTypes]  # value = <OpTypes.RMSNorm: 12>
+    ReLU: typing.ClassVar[OpTypes]  # value = <OpTypes.ReLU: 35>
+    ReLU2: typing.ClassVar[OpTypes]  # value = <OpTypes.ReLU2: 36>
+    ReduceMax: typing.ClassVar[OpTypes]  # value = <OpTypes.ReduceMax: 37>
+    ReduceMin: typing.ClassVar[OpTypes]  # value = <OpTypes.ReduceMin: 38>
+    ReduceSum: typing.ClassVar[OpTypes]  # value = <OpTypes.ReduceSum: 39>
+    Repeat: typing.ClassVar[OpTypes]  # value = <OpTypes.Repeat: 21>
+    Reshape: typing.ClassVar[OpTypes]  # value = <OpTypes.Reshape: 41>
+    RoPE: typing.ClassVar[OpTypes]  # value = <OpTypes.RoPE: 9>
+    SiLU: typing.ClassVar[OpTypes]  # value = <OpTypes.SiLU: 13>
+    Softmax: typing.ClassVar[OpTypes]  # value = <OpTypes.Softmax: 10>
+    Split: typing.ClassVar[OpTypes]  # value = <OpTypes.Split: 18>
+    Sub: typing.ClassVar[OpTypes]  # value = <OpTypes.Sub: 3>
+    Transpose: typing.ClassVar[OpTypes]  # value = <OpTypes.Transpose: 11>
+    View: typing.ClassVar[OpTypes]  # value = <OpTypes.View: 19>
+    VisionRoPE: typing.ClassVar[OpTypes]  # value = <OpTypes.VisionRoPE: 29>
+    X2X: typing.ClassVar[OpTypes]  # value = <OpTypes.X2X: 17>
+    __members__: typing.ClassVar[dict[str, OpTypes]]  # value = {'OpType_Start': <OpTypes.OpType_Start: 0>, 'Fill': <OpTypes.Fill: 1>, 'Add': <OpTypes.Add: 2>, 'Sub': <OpTypes.Sub: 3>, 'Mul': <OpTypes.Mul: 4>, 'Div': <OpTypes.Div: 5>, 'MatMul': <OpTypes.MatMul: 6>, 'Embedding': <OpTypes.Embedding: 7>, 'Linear': <OpTypes.Linear: 8>, 'RoPE': <OpTypes.RoPE: 9>, 'Softmax': <OpTypes.Softmax: 10>, 'Transpose': <OpTypes.Transpose: 11>, 'RMSNorm': <OpTypes.RMSNorm: 12>, 'SiLU': <OpTypes.SiLU: 13>, 'KVCache': <OpTypes.KVCache: 14>, 'CausalMask': <OpTypes.CausalMask: 15>, 'CastType': <OpTypes.CastType: 16>, 'X2X': <OpTypes.X2X: 17>, 'Split': <OpTypes.Split: 18>, 'View': <OpTypes.View: 19>, 'FlashAttention2': <OpTypes.FlashAttention2: 20>, 'Repeat': <OpTypes.Repeat: 21>, 'Permute': <OpTypes.Permute: 22>, 'Conv3D': <OpTypes.Conv3D: 23>, 'Conv2D': <OpTypes.Conv2D: 24>, 'Conv1D': <OpTypes.Conv1D: 25>, 'GELU': <OpTypes.GELU: 26>, 'LayerNorm': <OpTypes.LayerNorm: 27>, 'MultimodalRoPE': <OpTypes.MultimodalRoPE: 28>, 'VisionRoPE': <OpTypes.VisionRoPE: 29>, 'QuickGELU': <OpTypes.QuickGELU: 30>, 'Copy': <OpTypes.Copy: 31>, 'Clone': <OpTypes.Clone: 32>, 'Neg': <OpTypes.Neg: 33>, 'Concat': <OpTypes.Concat: 34>, 'ReLU': <OpTypes.ReLU: 35>, 'ReLU2': <OpTypes.ReLU2: 36>, 'ReduceMax': <OpTypes.ReduceMax: 37>, 'ReduceMin': <OpTypes.ReduceMin: 38>, 'ReduceSum': <OpTypes.ReduceSum: 39>, 'Contiguous': <OpTypes.Contiguous: 40>, 'Reshape': <OpTypes.Reshape: 41>, 'GraphBegin': <OpTypes.GraphBegin: 42>, 'GraphEnd': <OpTypes.GraphEnd: 43>, 'OpType_End': <OpTypes.OpType_End: 44>}
+    def __eq__(self, other: typing.Any) -> bool:
+        ...
+    def __getstate__(self) -> int:
+        ...
+    def __hash__(self) -> int:
+        ...
+    def __index__(self) -> int:
+        ...
+    def __init__(self, value: typing.SupportsInt) -> None:
+        ...
+    def __int__(self) -> int:
+        ...
+    def __ne__(self, other: typing.Any) -> bool:
+        ...
+    def __repr__(self) -> str:
+        ...
+    def __setstate__(self, state: typing.SupportsInt) -> None:
+        ...
+    def __str__(self) -> str:
+        ...
+    @property
+    def name(self) -> str:
+        ...
+    @property
+    def value(self) -> int:
+        ...
+class ParameterFile:
+    pass
 class PerfFile:
     def finalize(self) -> None:
         ...
@@ -353,16 +643,16 @@ class Task:
     custom_context_ptr: typing_extensions.CapsuleType
     type: TaskTypes
     @property
-    def inputs(self) -> ...:
+    def inputs(self) -> list[Tensor]:
         ...
     @inputs.setter
-    def inputs(self, arg0: ..., std: ...) -> None:
+    def inputs(self, arg0: collections.abc.Sequence[Tensor]) -> None:
         ...
     @property
-    def outputs(self) -> ...:
+    def outputs(self) -> list[Tensor]:
         ...
     @outputs.setter
-    def outputs(self, arg0: ..., std: ...) -> None:
+    def outputs(self, arg0: collections.abc.Sequence[Tensor]) -> None:
         ...
 class TaskTypes:
     """
@@ -406,19 +696,19 @@ class Tensor:
     def arange(start: typing.SupportsFloat, end: typing.SupportsFloat, step: typing.SupportsFloat, dtype: DataTypes = ..., device: DeviceTypes = ...) -> Tensor:
         ...
     @staticmethod
-    def empty(shape: ..., std: ..., dtype: DataTypes = ..., device: DeviceTypes = ...) -> Tensor:
+    def empty(shape: collections.abc.Sequence[typing.SupportsInt], dtype: DataTypes = ..., device: DeviceTypes = ...) -> Tensor:
         ...
     @staticmethod
     def nil() -> Tensor:
         ...
     @staticmethod
-    def ones(shape: ..., std: ..., dtype: DataTypes = ..., device: DeviceTypes = ...) -> Tensor:
+    def ones(shape: collections.abc.Sequence[typing.SupportsInt], dtype: DataTypes = ..., device: DeviceTypes = ...) -> Tensor:
         ...
     @staticmethod
-    def random(shape: ..., std: ..., start: typing.SupportsFloat = -1.0, end: typing.SupportsFloat = 1.0, dtype: DataTypes = ..., device: DeviceTypes = ...) -> Tensor:
+    def random(shape: collections.abc.Sequence[typing.SupportsInt], start: typing.SupportsFloat = -1.0, end: typing.SupportsFloat = 1.0, dtype: DataTypes = ..., device: DeviceTypes = ...) -> Tensor:
         ...
     @staticmethod
-    def zeros(shape: ..., std: ..., dtype: DataTypes = ..., device: DeviceTypes = ...) -> Tensor:
+    def zeros(shape: collections.abc.Sequence[typing.SupportsInt], dtype: DataTypes = ..., device: DeviceTypes = ...) -> Tensor:
         ...
     def T(self) -> Tensor:
         ...
@@ -454,7 +744,7 @@ class Tensor:
         ...
     def alloc(self) -> Tensor:
         ...
-    def alloc_extra_tensor_view(self, extra_tensor_name: str, shape: ..., std: ..., dtype: DataTypes = ..., device: DeviceTypes = ...) -> Tensor:
+    def alloc_extra_tensor_view(self, extra_tensor_name: str, shape: collections.abc.Sequence[typing.SupportsInt], dtype: DataTypes = ..., device: DeviceTypes = ...) -> Tensor:
         ...
     def bytes(self) -> int:
         ...
@@ -478,7 +768,7 @@ class Tensor:
         ...
     def max(self, keep_dim: bool = False, dim: typing.SupportsInt = 2147483647) -> Tensor:
         ...
-    def mem_type(self) -> ...:
+    def mem_type(self) -> TensorMemTypes:
         ...
     def min(self, keep_dim: bool = False, dim: typing.SupportsInt = 2147483647) -> Tensor:
         ...
@@ -486,19 +776,19 @@ class Tensor:
         ...
     def numel(self) -> int:
         ...
-    def permute(self, arg0: ..., std: ...) -> Tensor:
+    def permute(self, arg0: collections.abc.Sequence[typing.SupportsInt]) -> Tensor:
         ...
     def repeat(self, arg0: typing.SupportsInt, arg1: typing.SupportsInt) -> Tensor:
         ...
-    def reshape(self, arg0: ..., std: ...) -> Tensor:
+    def reshape(self, arg0: collections.abc.Sequence[typing.SupportsInt]) -> Tensor:
         ...
-    def set_mem_type(self, arg0: ...) -> Tensor:
+    def set_mem_type(self, arg0: TensorMemTypes) -> Tensor:
         ...
     def set_name(self, arg0: str) -> Tensor:
         ...
-    def shape(self) -> ...:
+    def shape(self) -> list[int]:
         ...
-    def stride(self) -> ...:
+    def stride(self) -> list[int]:
         ...
     def sum(self, keep_dim: bool = False, dim: typing.SupportsInt = 2147483647) -> Tensor:
         ...
@@ -514,7 +804,80 @@ class Tensor:
         ...
     def uuid(self) -> int:
         ...
-    def view(self, arg0: ..., std: ...) -> Tensor:
+    def view(self, arg0: collections.abc.Sequence[typing.SupportsInt]) -> Tensor:
+        ...
+class TensorMemTypes:
+    """
+    Members:
+    
+      TensorMemTypes_Start
+    
+      Normal
+    
+      ExtraInput
+    
+      ExtraOutput
+    
+      Manual
+    
+      Global
+    
+      Params_Start
+    
+      ParamsMMAP
+    
+      ParamsNormal
+    
+      Params_End
+    
+      QnnAppRead
+    
+      QnnAppWrite
+    
+      QnnAppReadWrite
+    
+      TensorMemTypes_End
+    """
+    ExtraInput: typing.ClassVar[TensorMemTypes]  # value = <TensorMemTypes.ExtraInput: 2>
+    ExtraOutput: typing.ClassVar[TensorMemTypes]  # value = <TensorMemTypes.ExtraOutput: 3>
+    Global: typing.ClassVar[TensorMemTypes]  # value = <TensorMemTypes.Global: 5>
+    Manual: typing.ClassVar[TensorMemTypes]  # value = <TensorMemTypes.Manual: 4>
+    Normal: typing.ClassVar[TensorMemTypes]  # value = <TensorMemTypes.Normal: 1>
+    ParamsMMAP: typing.ClassVar[TensorMemTypes]  # value = <TensorMemTypes.ParamsMMAP: 7>
+    ParamsNormal: typing.ClassVar[TensorMemTypes]  # value = <TensorMemTypes.ParamsNormal: 8>
+    Params_End: typing.ClassVar[TensorMemTypes]  # value = <TensorMemTypes.Params_End: 9>
+    Params_Start: typing.ClassVar[TensorMemTypes]  # value = <TensorMemTypes.Params_Start: 6>
+    QnnAppRead: typing.ClassVar[TensorMemTypes]  # value = <TensorMemTypes.QnnAppRead: 10>
+    QnnAppReadWrite: typing.ClassVar[TensorMemTypes]  # value = <TensorMemTypes.QnnAppReadWrite: 12>
+    QnnAppWrite: typing.ClassVar[TensorMemTypes]  # value = <TensorMemTypes.QnnAppWrite: 11>
+    TensorMemTypes_End: typing.ClassVar[TensorMemTypes]  # value = <TensorMemTypes.TensorMemTypes_End: 13>
+    TensorMemTypes_Start: typing.ClassVar[TensorMemTypes]  # value = <TensorMemTypes.TensorMemTypes_Start: 0>
+    __members__: typing.ClassVar[dict[str, TensorMemTypes]]  # value = {'TensorMemTypes_Start': <TensorMemTypes.TensorMemTypes_Start: 0>, 'Normal': <TensorMemTypes.Normal: 1>, 'ExtraInput': <TensorMemTypes.ExtraInput: 2>, 'ExtraOutput': <TensorMemTypes.ExtraOutput: 3>, 'Manual': <TensorMemTypes.Manual: 4>, 'Global': <TensorMemTypes.Global: 5>, 'Params_Start': <TensorMemTypes.Params_Start: 6>, 'ParamsMMAP': <TensorMemTypes.ParamsMMAP: 7>, 'ParamsNormal': <TensorMemTypes.ParamsNormal: 8>, 'Params_End': <TensorMemTypes.Params_End: 9>, 'QnnAppRead': <TensorMemTypes.QnnAppRead: 10>, 'QnnAppWrite': <TensorMemTypes.QnnAppWrite: 11>, 'QnnAppReadWrite': <TensorMemTypes.QnnAppReadWrite: 12>, 'TensorMemTypes_End': <TensorMemTypes.TensorMemTypes_End: 13>}
+    def __eq__(self, other: typing.Any) -> bool:
+        ...
+    def __getstate__(self) -> int:
+        ...
+    def __hash__(self) -> int:
+        ...
+    def __index__(self) -> int:
+        ...
+    def __init__(self, value: typing.SupportsInt) -> None:
+        ...
+    def __int__(self) -> int:
+        ...
+    def __ne__(self, other: typing.Any) -> bool:
+        ...
+    def __repr__(self) -> str:
+        ...
+    def __setstate__(self, state: typing.SupportsInt) -> None:
+        ...
+    def __str__(self) -> str:
+        ...
+    @property
+    def name(self) -> str:
+        ...
+    @property
+    def value(self) -> int:
         ...
 def clean_this_thread() -> None:
     """
@@ -536,7 +899,7 @@ def is_qnn_available() -> bool:
     """
     Check if QNN is available
     """
-def load(file_name: str, version: ModelFileVersion = ..., map_2_device: DeviceTypes = ...) -> ...:
+def load(file_name: str, version: ModelFileVersion = ..., map_2_device: DeviceTypes = ...) -> ParameterFile:
     """
     Load parameter file
     """
@@ -552,7 +915,7 @@ def perf_start() -> None:
     """
     Start performance profiling
     """
-def save(file_name: str, parameter_file: ..., version: ModelFileVersion = ..., map_2_device: DeviceTypes = ...) -> None:
+def save(file_name: str, parameter_file: ParameterFile, version: ModelFileVersion = ..., map_2_device: DeviceTypes = ...) -> None:
     """
     Save parameter file
     """

--- a/pymllm/_C/Core.cpp
+++ b/pymllm/_C/Core.cpp
@@ -1,10 +1,60 @@
 // Copyright (c) MLLM Team.
 // Licensed under the MIT License.
 
+#include <pybind11/stl.h>
+
 #include "pymllm/_C/Core.hpp"
+
 #include "mllm/mllm.hpp"
 
 void registerCoreBinding(py::module_& m) {
+  py::enum_<mllm::OpTypes>(m, "OpTypes")
+      .value("OpType_Start", mllm::OpTypes::kOpType_Start)
+      .value("Fill", mllm::OpTypes::kFill)
+      .value("Add", mllm::OpTypes::kAdd)
+      .value("Sub", mllm::OpTypes::kSub)
+      .value("Mul", mllm::OpTypes::kMul)
+      .value("Div", mllm::OpTypes::kDiv)
+      .value("MatMul", mllm::OpTypes::kMatMul)
+      .value("Embedding", mllm::OpTypes::kEmbedding)
+      .value("Linear", mllm::OpTypes::kLinear)
+      .value("RoPE", mllm::OpTypes::kRoPE)
+      .value("Softmax", mllm::OpTypes::kSoftmax)
+      .value("Transpose", mllm::OpTypes::kTranspose)
+      .value("RMSNorm", mllm::OpTypes::kRMSNorm)
+      .value("SiLU", mllm::OpTypes::kSiLU)
+      .value("KVCache", mllm::OpTypes::kKVCache)
+      .value("CausalMask", mllm::OpTypes::kCausalMask)
+      .value("CastType", mllm::OpTypes::kCastType)
+      .value("X2X", mllm::OpTypes::kX2X)
+      .value("Split", mllm::OpTypes::kSplit)
+      .value("View", mllm::OpTypes::kView)
+      .value("FlashAttention2", mllm::OpTypes::kFlashAttention2)
+      .value("Repeat", mllm::OpTypes::kRepeat)
+      .value("Permute", mllm::OpTypes::kPermute)
+      .value("Conv3D", mllm::OpTypes::kConv3D)
+      .value("Conv2D", mllm::OpTypes::kConv2D)
+      .value("Conv1D", mllm::OpTypes::kConv1D)
+      .value("GELU", mllm::OpTypes::kGELU)
+      .value("LayerNorm", mllm::OpTypes::kLayerNorm)
+      .value("MultimodalRoPE", mllm::OpTypes::kMultimodalRoPE)
+      .value("VisionRoPE", mllm::OpTypes::kVisionRoPE)
+      .value("QuickGELU", mllm::OpTypes::kQuickGELU)
+      .value("Copy", mllm::OpTypes::kCopy)
+      .value("Clone", mllm::OpTypes::kClone)
+      .value("Neg", mllm::OpTypes::kNeg)
+      .value("Concat", mllm::OpTypes::kConcat)
+      .value("ReLU", mllm::OpTypes::kReLU)
+      .value("ReLU2", mllm::OpTypes::kReLU2)
+      .value("ReduceMax", mllm::OpTypes::kReduceMax)
+      .value("ReduceMin", mllm::OpTypes::kReduceMin)
+      .value("ReduceSum", mllm::OpTypes::kReduceSum)
+      .value("Contiguous", mllm::OpTypes::kContiguous)
+      .value("Reshape", mllm::OpTypes::kReshape)
+      .value("GraphBegin", mllm::OpTypes::kGraphBegin)
+      .value("GraphEnd", mllm::OpTypes::kGraphEnd)
+      .value("OpType_End", mllm::OpTypes::kOpType_End);
+
   py::enum_<mllm::DeviceTypes>(m, "DeviceTypes")
       .value("CPU", mllm::DeviceTypes::kCPU)
       .value("CUDA", mllm::DeviceTypes::kCUDA)
@@ -43,6 +93,22 @@ void registerCoreBinding(py::module_& m) {
       .value("Int64", mllm::DataTypes::kInt64)
       .value("UInt64", mllm::DataTypes::kUInt64)
       .value("Byte", mllm::DataTypes::kByte);
+
+  py::enum_<mllm::TensorMemTypes>(m, "TensorMemTypes")
+      .value("TensorMemTypes_Start", mllm::TensorMemTypes::kTensorMemTypes_Start)
+      .value("Normal", mllm::TensorMemTypes::kNormal)
+      .value("ExtraInput", mllm::TensorMemTypes::kExtraInput)
+      .value("ExtraOutput", mllm::TensorMemTypes::kExtraOutput)
+      .value("Manual", mllm::TensorMemTypes::kManual)
+      .value("Global", mllm::TensorMemTypes::kGlobal)
+      .value("Params_Start", mllm::TensorMemTypes::kParams_Start)
+      .value("ParamsMMAP", mllm::TensorMemTypes::kParamsMMAP)
+      .value("ParamsNormal", mllm::TensorMemTypes::kParamsNormal)
+      .value("Params_End", mllm::TensorMemTypes::kParams_End)
+      .value("QnnAppRead", mllm::TensorMemTypes::kQnnAppRead)
+      .value("QnnAppWrite", mllm::TensorMemTypes::kQnnAppWrite)
+      .value("QnnAppReadWrite", mllm::TensorMemTypes::kQnnAppReadWrite)
+      .value("TensorMemTypes_End", mllm::TensorMemTypes::kTensorMemTypes_End);
 
   py::class_<mllm::Tensor>(m, "Tensor")
       .def(py::init<>())
@@ -101,4 +167,68 @@ void registerCoreBinding(py::module_& m) {
       .def("clone", &mllm::Tensor::clone)
       .def("permute", &mllm::Tensor::permute)
       .def("bytes", &mllm::Tensor::bytes);
+
+  //===----------------------------------------------------------------------===//
+  // Parameter File
+  //===----------------------------------------------------------------------===//
+  py::class_<mllm::ParameterFile, std::shared_ptr<mllm::ParameterFile>>(m, "ParameterFile");
+
+  //===----------------------------------------------------------------------===//
+  // BaseOp
+  //===----------------------------------------------------------------------===//
+  py::class_<mllm::BaseOp, std::shared_ptr<mllm::BaseOp>>(m, "BaseOp")
+      .def("load", &mllm::BaseOp::load)
+      .def("trace", &mllm::BaseOp::trace)
+      .def("forward", &mllm::BaseOp::forward)
+      .def("reshape", &mllm::BaseOp::reshape)
+      .def("setup", &mllm::BaseOp::setup)
+      .def("get_params", &mllm::BaseOp::getParams)
+      .def("get_name", &mllm::BaseOp::getName)
+      .def("set_name", &mllm::BaseOp::setName)
+      .def("get_device", &mllm::BaseOp::getDevice)
+      .def("set_device_type", &mllm::BaseOp::setDeviceType)
+      .def("get_op_type", &mllm::BaseOp::getOpType);
+
+  py::class_<mllm::BaseOpOptionsBase>(m, "BaseOpOptionsBase");
+
+  //===----------------------------------------------------------------------===//
+  // Linear Options And LinearOp
+  //===----------------------------------------------------------------------===//
+  py::enum_<mllm::aops::LinearImplTypes>(m, "LinearImplTypes")
+      .value("LinearImplTypes_Start", mllm::aops::LinearImplTypes::kLinearImplTypes_Start)
+      .value("Default", mllm::aops::LinearImplTypes::kDefault)
+      .value("Kleidiai_Start", mllm::aops::LinearImplTypes::kKleidiai_Start)
+      .value("Kleidiai_End", mllm::aops::LinearImplTypes::kKleidiai_End)
+      .value("GGUF_Start", mllm::aops::LinearImplTypes::kGGUF_Start)
+      .value("GGUF_End", mllm::aops::LinearImplTypes::kGGUF_End)
+      .value("LinearImplTypes_End", mllm::aops::LinearImplTypes::kLinearImplTypes_End);
+
+  py::class_<mllm::aops::LinearOpOptions>(m, "LinearOpOptions")
+      .def(py::init<>())
+      .def(py::init([](int32_t in_channels, int32_t out_channels, bool bias, mllm::aops::LinearImplTypes impl_type) {
+             auto options = mllm::aops::LinearOpOptions{};
+             options.in_channels = in_channels;
+             options.out_channels = out_channels;
+             options.bias = bias;
+             options.impl_type = impl_type;
+             return options;
+           }),
+           py::arg("in_channels") = 0, py::arg("out_channels") = 0, py::arg("bias") = true,
+           py::arg("impl_type") = mllm::aops::LinearImplTypes::kDefault)
+      .def_readwrite("in_channels", &mllm::aops::LinearOpOptions::in_channels)
+      .def_readwrite("out_channels", &mllm::aops::LinearOpOptions::out_channels)
+      .def_readwrite("bias", &mllm::aops::LinearOpOptions::bias)
+      .def_readwrite("impl_type", &mllm::aops::LinearOpOptions::impl_type)
+      .def("set_inputs_dtype", &mllm::aops::LinearOpOptions::setInputsDtype, py::return_value_policy::reference_internal)
+      .def("set_outputs_dtype", &mllm::aops::LinearOpOptions::setOutputsDtype, py::return_value_policy::reference_internal);
+
+  py::class_<mllm::aops::LinearOp, mllm::BaseOp, std::shared_ptr<mllm::aops::LinearOp>>(m, "LinearOp")
+      .def(py::init<const mllm::aops::LinearOpOptions&>())
+      .def("weight", &mllm::aops::LinearOp::weight, py::return_value_policy::reference_internal)
+      .def("bias", &mllm::aops::LinearOp::bias, py::return_value_policy::reference_internal)
+      .def("options", &mllm::aops::LinearOp::options, py::return_value_policy::reference_internal)
+      .def("load", &mllm::aops::LinearOp::load)
+      .def("forward", &mllm::aops::LinearOp::forward)
+      .def("setup", &mllm::aops::LinearOp::setup)
+      .def("reshape", &mllm::aops::LinearOp::reshape);
 }

--- a/pymllm/_C/Engine.cpp
+++ b/pymllm/_C/Engine.cpp
@@ -1,6 +1,8 @@
 // Copyright (c) MLLM Team.
 // Licensed under the MIT License.
 
+#include <pybind11/stl.h>
+
 #include "mllm/mllm.hpp"
 
 #include "pymllm/_C/Engine.hpp"
@@ -34,7 +36,7 @@ void registerEngineBinding(py::module_& m) {
       .def_readwrite("using_buddy_mem_pool", &mllm::MemoryManagerOptions::using_buddy_mem_pool);
 
   pybind11::class_<mllm::MemoryManager, mllm::MemoryManager::ptr_t>(m, "MemoryManager")
-      .def("clearAll", &mllm::MemoryManager::clearAll)
+      .def("clear_all", &mllm::MemoryManager::clearAll)
       .def("report", &mllm::MemoryManager::report);
 
   pybind11::class_<mllm::DispatcherManagerOptions>(m, "DispatcherManagerOptions")
@@ -48,27 +50,27 @@ void registerEngineBinding(py::module_& m) {
       .def("syncWait", &mllm::Dispatcher::syncWait);
 
   pybind11::class_<mllm::DispatcherManager, mllm::DispatcherManager::ptr_t>(m, "DispatcherManager")
-      .def("syncWait", &mllm::DispatcherManager::syncWait)
+      .def("sync_wait", &mllm::DispatcherManager::syncWait)
       .def("submit", &mllm::DispatcherManager::submit);
 
   pybind11::class_<mllm::Context>(m, "Context")
       .def_static("instance", &mllm::Context::instance, py::return_value_policy::reference)
-      .def("memoryManager", &mllm::Context::memoryManager)
-      .def("dispatcherManager", &mllm::Context::dispatcherManager)
-      .def("getUUID", &mllm::Context::getUUID)
-      .def("thisThread", &mllm::Context::thisThread)
-      .def("mainThread", &mllm::Context::mainThread)
-      .def("setRandomSeed", &mllm::Context::setRandomSeed)
-      .def("getRandomSeed", &mllm::Context::getRandomSeed)
-      .def("setPerfMode", &mllm::Context::setPerfMode)
-      .def("isPerfMode", &mllm::Context::isPerfMode)
-      .def("getPerfFile", &mllm::Context::getPerfFile)
-      .def("refSessionThreads", &mllm::Context::refSessionThreads);
+      .def("memory_manager", &mllm::Context::memoryManager)
+      .def("dispatcher_manager", &mllm::Context::dispatcherManager)
+      .def("get_uuid", &mllm::Context::getUUID)
+      .def("this_thread", &mllm::Context::thisThread)
+      .def("main_thread", &mllm::Context::mainThread)
+      .def("set_random_seed", &mllm::Context::setRandomSeed)
+      .def("get_random_seed", &mllm::Context::getRandomSeed)
+      .def("set_perf_mode", &mllm::Context::setPerfMode)
+      .def("is_perf_mode", &mllm::Context::isPerfMode)
+      .def("get_perf_file", &mllm::Context::getPerfFile)
+      .def("ref_session_threads", &mllm::Context::refSessionThreads);
 
   pybind11::class_<mllm::ConfigFile>(m, "ConfigFile")
       .def(py::init<>())
       .def(py::init<const std::string&>())
-      .def("loadString", &mllm::ConfigFile::loadString)
+      .def("loadS_string", &mllm::ConfigFile::loadString)
       .def("load", &mllm::ConfigFile::load)
       .def("dump", &mllm::ConfigFile::dump)
       .def("save", &mllm::ConfigFile::save)

--- a/pymllm/_C/Nn.cpp
+++ b/pymllm/_C/Nn.cpp
@@ -5,6 +5,7 @@
 
 #include "mllm/nn/Layer.hpp"
 #include "mllm/nn/Module.hpp"
+#include "mllm/nn/Nn.hpp"
 
 #include "pymllm/_C/Nn.hpp"
 
@@ -19,30 +20,34 @@ void registerNnBinding(pybind11::module_& m) {
 
   // Bind AbstractNnNode class
   py::class_<AbstractNnNode, AbstractNnNode::ptr_t>(m, "AbstractNnNode")
-      .def("regChildNode", &AbstractNnNode::regChildNode)
-      .def("refParentNode", &AbstractNnNode::refParentNode, py::return_value_policy::reference_internal)
-      .def("refChildNodes", &AbstractNnNode::refChildNodes, py::return_value_policy::reference_internal)
-      .def("setName", &AbstractNnNode::setName)
-      .def("setAbsoluteName", &AbstractNnNode::setAbsoluteName)
-      .def("setDepth", &AbstractNnNode::setDepth)
-      .def("depthIncrease", &AbstractNnNode::depthIncrease)
-      .def("depthDecrease", &AbstractNnNode::depthDecrease)
-      .def("getName", &AbstractNnNode::getName)
-      .def("getAbsoluteName", &AbstractNnNode::getAbsoluteName)
-      .def("getDepth", &AbstractNnNode::getDepth)
-      .def("getType", &AbstractNnNode::getType)
-      .def("getDevice", &AbstractNnNode::getDevice)
-      .def("setCompiledAsObj", &AbstractNnNode::setCompiledAsObj)
-      .def("isCompiledAsObj", &AbstractNnNode::isCompiledAsObj);
+      .def("reg_child_node", &AbstractNnNode::regChildNode)
+      .def("ref_parent_node", &AbstractNnNode::refParentNode, py::return_value_policy::reference_internal)
+      .def("ref_child_nodes", &AbstractNnNode::refChildNodes, py::return_value_policy::reference_internal)
+      .def("set_name", &AbstractNnNode::setName)
+      .def("set_absolute_name", &AbstractNnNode::setAbsoluteName)
+      .def("set_depth", &AbstractNnNode::setDepth)
+      .def("depth_increase", &AbstractNnNode::depthIncrease)
+      .def("depth_decrease", &AbstractNnNode::depthDecrease)
+      .def("get_name", &AbstractNnNode::getName)
+      .def("get_absolute_name", &AbstractNnNode::getAbsoluteName)
+      .def("get_depth", &AbstractNnNode::getDepth)
+      .def("get_type", &AbstractNnNode::getType)
+      .def("get_device", &AbstractNnNode::getDevice)
+      .def("set_compiled_as_obj", &AbstractNnNode::setCompiledAsObj)
+      .def("is_compiled_as_obj", &AbstractNnNode::isCompiledAsObj);
 
   // Bind LayerImpl class
   py::class_<LayerImpl, LayerImpl::ptr_t, AbstractNnNode>(m, "LayerImpl")
+      .def(py::init([](OpTypes op_type, const mllm::aops::LinearOpOptions& options) {
+             return std::make_shared<LayerImpl>(op_type, options);
+           }),
+           py::arg("op_type"), py::arg("options"))
       .def("load", &LayerImpl::load)
       .def("to", &LayerImpl::to)
-      .def("opType", &LayerImpl::opType)
-      .def("refOptions", &LayerImpl::refOptions, py::return_value_policy::reference_internal)
-      .def("getInstancedOp", &LayerImpl::getInstancedOp)
-      .def("setInstancedOp", &LayerImpl::setInstancedOp);
+      .def("op_type", &LayerImpl::opType)
+      .def("ref_options", &LayerImpl::refOptions, py::return_value_policy::reference_internal)
+      .def("get_instanced_op", &LayerImpl::getInstancedOp)
+      .def("set_instanced_op", &LayerImpl::setInstancedOp);
 
   // Bind ModuleImpl class
   py::class_<ModuleImpl, ModuleImpl::ptr_t, AbstractNnNode>(m, "ModuleImpl")

--- a/pymllm/__init__.py
+++ b/pymllm/__init__.py
@@ -3,3 +3,26 @@ from __future__ import annotations
 from ._C import *
 from . import utils
 from . import nn
+
+float32 = DataTypes.Float32
+float16 = DataTypes.Float16
+int32 = DataTypes.Int32
+int16 = DataTypes.Int16
+int8 = DataTypes.Int8
+uint8 = DataTypes.UInt8
+bfloat16 = DataTypes.BFloat16
+
+cpu = DeviceTypes.CPU
+cuda = DeviceTypes.CUDA
+opencl = DeviceTypes.OpenCL
+
+
+def ones(shape, dtype=float32, device_type=cpu):
+    return Tensor.ones(shape, dtype, device_type)
+
+
+def zeros(shape, dtype=float32, device_type=cpu):
+    return Tensor.zeros(shape, dtype, device_type)
+
+
+initialize_context()

--- a/pymllm/nn/__init__.py
+++ b/pymllm/nn/__init__.py
@@ -1,0 +1,4 @@
+from .module import Module
+from .layer import Layer, Linear
+
+__all__ = ["Module", "Layer", "Linear"]

--- a/pymllm/nn/layer.py
+++ b/pymllm/nn/layer.py
@@ -1,0 +1,72 @@
+# Copyright (c) MLLM Team.
+# Licensed under the MIT License.
+
+from .._C import LayerImpl, OpTypes, LinearImplTypes, LinearOpOptions
+
+
+class Layer:
+    def __init__(self, op_type: OpTypes, options):
+        self.__cxx_impl = LayerImpl(op_type, options)
+
+    def set_name(self, name):
+        """
+        Set the name of the layer
+        """
+        self.__cxx_impl.set_name(name)
+
+    def set_absolute_name(self, name):
+        """
+        Set the absolute name of the layer
+        """
+        self.__cxx_impl.set_absolute_name(name)
+
+    def cxx_impl(self):
+        """
+        Get the underlying C++ implementation
+        """
+        return self.__cxx_impl
+
+    def forward(self, *args):
+        """
+        Forward pass of the layer
+        """
+        raise NotImplementedError("forward method must be implemented in subclass")
+
+    def __call__(self, *args, **kwargs):
+        """
+        Call the forward method
+        """
+        return self.forward(*args, **kwargs)
+
+    def __repr__(self):
+        """
+        Return a string representation of the Layer.
+        """
+        return f"{self.__class__.__name__}()"
+
+
+class Linear(Layer):
+    def __init__(
+        self,
+        in_channels,
+        out_channels,
+        bias=True,
+        impl_type: LinearImplTypes = LinearImplTypes.Default,
+    ):
+        super().__init__(
+            OpTypes.Linear, LinearOpOptions(in_channels, out_channels, bias, impl_type)
+        )
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+        self.bias = bias
+        self.impl_type = impl_type
+
+    def forward(self, *args):
+        # TODO: Impl details
+        return super().forward(*args)
+
+    def __repr__(self):
+        """
+        Return a string representation of the Layer.
+        """
+        return f"{self.__class__.__name__}(in_channels={self.in_channels}, out_channels={self.out_channels}, bias={self.bias}, impl_type={self.impl_type})"

--- a/pymllm/nn/module.py
+++ b/pymllm/nn/module.py
@@ -1,0 +1,98 @@
+# Copyright (c) MLLM Team.
+# Licensed under the MIT License.
+
+from .._C import ModuleImpl
+from .layer import Layer
+
+
+class Module:
+    def __init__(self):
+        self.__cxx_impl = ModuleImpl()
+        object.__setattr__(self, "_layers", {})
+        object.__setattr__(self, "_modules", {})
+
+        # Set self name as the class name by default
+        module_name = self.__class__.__name__
+        self.set_name(module_name)
+        self.set_absolute_name(module_name)
+
+    def __setattr__(self, name, value):
+        """
+        The __setattr__ method is used to intercept attribute assignments.
+        We will register module and layers here.
+        """
+        if isinstance(value, Layer):
+            value.set_name(name)
+            value.set_absolute_name(self.__cxx_impl.get_absolute_name() + "." + name)
+            self._layers[name] = value
+            self.__cxx_impl.reg_child_node(value.cxx_impl())
+        if isinstance(value, Module):
+            value.set_name(name)
+            value.set_absolute_name(self.__cxx_impl.get_absolute_name() + "." + name)
+            self._modules[name] = value
+            self.__cxx_impl.reg_child_node(value.cxx_impl())
+        object.__setattr__(self, name, value)
+
+    def set_name(self, name):
+        """
+        Set the name of the layer
+        """
+        self.__cxx_impl.set_name(name)
+
+    def set_absolute_name(self, name):
+        """
+        Set the absolute name of the layer
+        """
+        self.__cxx_impl.set_absolute_name(name)
+
+    def named_layers(self):
+        return self._layers.items()
+
+    def cxx_impl(self):
+        """
+        Get the underlying C++ implementation
+        """
+        return self.__cxx_impl
+
+    def load(self, param_file):
+        """
+        Load parameters from a ParameterFile
+        """
+        self.__cxx_impl.load(param_file)
+
+    def to(self, device_type):
+        """
+        Move the module to specified device
+        """
+        self.__cxx_impl.to(device_type)
+
+    def params(self, version):
+        """
+        Get parameters of the module
+        """
+        return self.__cxx_impl.params(version)
+
+    def forward(self, *args):
+        """
+        Forward pass of the layer
+        """
+        raise NotImplementedError("forward method must be implemented in subclass")
+
+    def __call__(self, *args, **kwargs):
+        """
+        Call the forward method
+        """
+        # TODO Dispatch Graph Begin and End Op
+        return self.forward(*args, **kwargs)
+
+    def __repr__(self, indent=0):
+        """
+        Pretty print the module structure.
+        """
+        s = " " * indent + self.__class__.__name__ + "(\n"
+        for name, module in self._modules.items():
+            s += " " * (indent + 2) + f"({name}): {module.__repr__(indent + 2)}"
+        for name, layer in self._layers.items():
+            s += " " * (indent + 2) + f"({name}): {layer.__repr__()}\n"
+        s += " " * indent + ")\n"
+        return s

--- a/pymllm/tests/test_nn.py
+++ b/pymllm/tests/test_nn.py
@@ -1,0 +1,26 @@
+import pymllm as torch
+import pymllm.nn as nn
+
+
+class FooNet(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linear_0 = nn.Linear(1024, 1024)
+        self.linear_1 = nn.Linear(1024, 1024)
+        self.linear_2 = nn.Linear(1024, 1024)
+
+    def forward(self, x: torch.Tensor):
+        return self.linear_0(self.linear_1(self.linear_2(x)))
+
+
+def test_foo_net():
+    net = FooNet()
+    print(net)
+    t = torch.zeros((1, 1024), torch.float16, torch.cpu)
+    print(t)
+    o = net(t)
+    print(o)
+
+
+if __name__ == "__main__":
+    test_foo_net()


### PR DESCRIPTION
- Remove unused `reg_` function from Module
- Add `setName` call for new modules and layers
- Update API to use more descriptive function names
- Add new classes: BaseOp, LinearOp, ParameterFile, etc.
- Improve type safety and clarity in function signatures