### PR TITLE
feat(vision): add VisionRoPE (Rotary Position Embedding) support

### DIFF
--- a/mllm/backends/cpu/CPUBackend.cpp
+++ b/mllm/backends/cpu/CPUBackend.cpp
@@ -29,6 +29,7 @@
 #include "mllm/backends/cpu/ops/SplitOp.hpp"
 #include "mllm/backends/cpu/ops/TransposeOp.hpp"
 #include "mllm/backends/cpu/ops/ViewOp.hpp"
+#include "mllm/backends/cpu/ops/VisionRoPEOp.hpp"
 #include "mllm/backends/cpu/ops/X2XOp.hpp"
 
 namespace mllm::cpu {
@@ -40,7 +41,7 @@ CPUBackend::CPUBackend() : Backend(kCPU, createCPUAllocator()) {
                CPUContiguousOpFactory, CPUCopyOpFactory, CPUEmbeddingOpFactory, CPUSplitOpFactory, CPUViewOpFactory,
                CPULayerNormOpFactory, CPURepeatOpFactory, CPUX2XOpFactory, CPUSoftmaxOpFactory, CPUSiLUOpFactory,
                CPURMSNormOpFactory, CPUGELUOpFactory, CPUQuickGELUOpFactory, CPUMatMulOpFactory, CPUFlashAttention2OpFactory,
-               CPUSliceOpFactory>();
+               CPUSliceOpFactory, CPUVisionRoPEOpFactory>();
 }
 
 std::shared_ptr<CPUBackend> createCPUBackend() { return std::make_shared<CPUBackend>(); }

--- a/mllm/backends/cpu/kernels/arm/linear/ggml/gemm_aarch64.cpp
+++ b/mllm/backends/cpu/kernels/arm/linear/ggml/gemm_aarch64.cpp
@@ -10,12 +10,15 @@
 #include "mllm/backends/cpu/kernels/arm/linear/ggml/gemm_aarch64.hpp"
 #include "mllm/backends/cpu/kernels/common/quantize/ggml/quantize.hpp"
 #include "mllm/backends/cpu/kernels/common/quantize/ggml/quantize_q4.hpp"
+#include "mllm/utils/CPUArchHelper.hpp"
 #include "mllm/core/DataTypes.hpp"
 #include "mllm/utils/Common.hpp"
 
 namespace mllm::cpu::arm {
 
 namespace MLLM_ANONYMOUS_NAMESPACE {
+int mllm_cpu_has_neon() { return hasNEON(); }
+
 int mllm_cpu_has_sve() {
 #if defined(__ARM_FEATURE_SVE)
   return 1;

--- a/mllm/backends/cpu/ops/CopyOp.cpp
+++ b/mllm/backends/cpu/ops/CopyOp.cpp
@@ -12,8 +12,7 @@ void CPUCopyOp::forward(const std::vector<Tensor>& inputs, std::vector<Tensor>& 
   auto& i0 = inputs[0];
   auto& i1 = inputs[1];
 
-  // Only Support Contiguous Tensor
-  MLLM_RT_ASSERT(i0.isContiguous());
+  // FIXME: Maybe we should handle contiguous issues here.
 
   std::memcpy(i1.ptr<char>(), i0.ptr<char>(), i0.bytes());
 }

--- a/mllm/backends/cpu/ops/VisionRoPEOp.cpp
+++ b/mllm/backends/cpu/ops/VisionRoPEOp.cpp
@@ -1,0 +1,324 @@
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
+
+#include <cstring>
+#include <algorithm>
+#include <cmath>
+#include <arm_neon.h>
+
+#include "mllm/utils/Common.hpp"
+#include "mllm/backends/cpu/ops/VisionRoPEOp.hpp"
+
+namespace mllm::cpu {
+
+Tensor Qwen2VLVisionRoPEOpImpl::computeInvFreq(const aops::Qwen2VLRoPEOpOptions& options) {
+  const int half_dim = options.dims / (2 * 2);
+  Tensor inv_freq = Tensor::empty({half_dim}, kFloat32).alloc();
+  float* inv_freq_ptr = inv_freq.ptr<float>();
+
+  const float theta = options.theta;
+  const float dims_inv = 1.0f / static_cast<float>(options.dims / 2);
+
+  for (int i = 0; i < half_dim; ++i) {
+    const float exponent = (2.0f * i) * dims_inv;
+    inv_freq_ptr[i] = 1.0f / std::pow(theta, exponent);
+  }
+
+  return inv_freq;
+}
+
+Tensor Qwen2VLVisionRoPEOpImpl::getRotaryPosEmbIds(Tensor& grid_thw, const aops::Qwen2VLRoPEOpOptions& options) {
+  MLLM_RT_ASSERT_EQ(grid_thw.shape().size(), 2);
+
+  auto img_nums = grid_thw.shape()[0];
+  const int spatial_merge_size = options.spatial_merge_size;
+
+  int total_positions = 0;
+  for (int row = 0; row < img_nums; ++row) {
+    const int* dims = grid_thw.offsettedPtr<int>({row, 0});
+    const int t = dims[0];
+    const int h = dims[1];
+    const int w = dims[2];
+    total_positions += t * h * w;
+  }
+
+  Tensor out = Tensor::empty({total_positions, 2}, kInt32).alloc();
+  int* out_ptr = out.ptr<int>();
+  int out_offset = 0;
+
+  const int32_t neon_steps_arr[4] = {0, 1, 2, 3};
+  const int32x4_t neon_steps = vld1q_s32(neon_steps_arr);
+
+  for (int row = 0; row < img_nums; ++row) {
+    const int* dims = grid_thw.offsettedPtr<int>({row, 0});
+
+    const int t = dims[0];
+    const int h = dims[1];
+    const int w = dims[2];
+
+    const int num_h_blocks = h / spatial_merge_size;
+    const int num_w_blocks = w / spatial_merge_size;
+    const int total_blocks = num_h_blocks * num_w_blocks;
+    const int block_area = spatial_merge_size * spatial_merge_size;
+    const int grid_size = h * w;
+
+    std::vector<int> flatten_hpos(grid_size);
+    std::vector<int> flatten_wpos(grid_size);
+
+    for (int block_idx = 0; block_idx < total_blocks; ++block_idx) {
+      const int i_h = block_idx / num_w_blocks;
+      const int i_w = block_idx % num_w_blocks;
+      const int start_idx = block_idx * block_area;
+
+      const int base_h = i_h * spatial_merge_size;
+      const int base_w = i_w * spatial_merge_size;
+
+      for (int j_h = 0; j_h < spatial_merge_size; ++j_h) {
+        const int global_h = base_h + j_h;
+        const int row_start = start_idx + j_h * spatial_merge_size;
+
+        int j_w = 0;
+        for (; j_w <= spatial_merge_size - 4; j_w += 4) {
+          const int32x4_t jw_offset = vaddq_s32(vdupq_n_s32(j_w), neon_steps);
+          const int32x4_t global_w = vaddq_s32(vdupq_n_s32(base_w), jw_offset);
+          const int pos = row_start + j_w;
+          vst1q_s32(&flatten_wpos[pos], global_w);
+          vst1_s32(&flatten_hpos[pos], vdup_n_s32(global_h));
+        }
+        for (; j_w < spatial_merge_size; ++j_w) {
+          const int pos = row_start + j_w;
+          flatten_hpos[pos] = global_h;
+          flatten_wpos[pos] = base_w + j_w;
+        }
+      }
+    }
+
+    for (int frame = 0; frame < t; ++frame) {
+      const int frame_offset = frame * grid_size * 2;
+      for (int pos = 0; pos < grid_size; ++pos) {
+        const int out_idx = out_offset + frame_offset + pos * 2;
+        out_ptr[out_idx] = flatten_hpos[pos];
+        out_ptr[out_idx + 1] = flatten_wpos[pos];
+      }
+    }
+    out_offset += t * grid_size * 2;
+  }
+
+  return out;
+}
+
+Tensor Qwen2VLVisionRoPEOpImpl::computeRotaryPosEmb(Tensor& rotary_pos_emb_full, Tensor& pos_ids, Tensor& grid_thw,
+                                                    const aops::Qwen2VLRoPEOpOptions& options) {
+  const int* grid_dims = grid_thw.offsettedPtr<int>({0, 0});
+  const int t = grid_dims[0];
+  const int h = grid_dims[1];
+  const int w = grid_dims[2];
+
+  const int32_t num_positions = rotary_pos_emb_full.shape()[0];
+  const int32_t dim = rotary_pos_emb_full.shape()[1];
+  const int32_t batch_size = pos_ids.shape()[0];
+  const int32_t seq_len = pos_ids.shape()[1];
+
+  // [batch_size, dim]
+  Tensor out = Tensor::empty({batch_size, seq_len * dim}, kFloat32, kCPU).alloc();
+
+  auto rotary_pos_emb_full_ptr = rotary_pos_emb_full.ptr<float>();
+  auto pos_ids_ptr = pos_ids.ptr<int>();
+  auto out_ptr = out.ptr<float>();
+
+  if (num_positions <= 0 || dim <= 0 || batch_size <= 0) { MLLM_ERROR_EXIT(ExitCode::kSliceOB, "Invalid tensor dimensions"); }
+
+  if (t * h * w != batch_size) { MLLM_ERROR_EXIT(ExitCode::kSliceOB, "Grid dimensions mismatch with batch size"); }
+
+  for (int i = 0; i < batch_size; ++i) {
+    for (int j = 0; j < seq_len; ++j) {
+      if ((*pos_ids.offsettedPtr<int>({i, j})) < 0 || (*pos_ids.offsettedPtr<int>({i, j})) >= num_positions) {
+        MLLM_ERROR_EXIT(ExitCode::kSliceOB, "Position index out of bounds");
+      }
+    }
+  }
+
+  for (int i = 0; i < batch_size; ++i) {
+    auto batch_ptr = out.offsettedPtr<float>({i, 0});
+    size_t offset = 0;
+    for (int j = 0; j < seq_len; ++j) {
+      auto emb_ptr = rotary_pos_emb_full.offsettedPtr<float>({(*pos_ids.offsettedPtr<int>({i, j})), 0});
+      std::copy(emb_ptr, emb_ptr + dim, batch_ptr + offset);
+      offset += dim;
+    }
+  }
+
+  return out;
+}
+
+Tensor Qwen2VLVisionRoPEOpImpl::rotaryPosEmb(Tensor& inv_freq, int seq_len, const aops::Qwen2VLRoPEOpOptions& options) {
+  MLLM_RT_ASSERT(seq_len > 0);
+  const int32_t dim = inv_freq.shape()[0];
+  Tensor freqs = Tensor::empty({seq_len, dim}, kFloat32, kCPU).alloc();
+
+  float* inv_freq_ptr = inv_freq.ptr<float>();
+  float* freqs_ptr = freqs.ptr<float>();
+
+  for (int i = 0; i < seq_len; ++i) {
+    const float i_val = static_cast<float>(i);
+    float* row_ptr = freqs_ptr + i * dim;
+
+    size_t j = 0;
+    const float32x4_t v_i = vdupq_n_f32(i_val);
+
+    for (; j + 3 < dim; j += 4) {
+      const float32x4_t v_inv = vld1q_f32(inv_freq_ptr + j);
+      const float32x4_t v_res = vmulq_f32(v_i, v_inv);
+      vst1q_f32(row_ptr + j, v_res);
+    }
+
+    for (; j < dim; ++j) { row_ptr[j] = i_val * inv_freq_ptr[j]; }
+  }
+
+  return freqs;
+}
+
+std::pair<Tensor, Tensor> Qwen2VLVisionRoPEOpImpl::getSinCos(Tensor& rotary_pos_emb) {
+  auto seq = rotary_pos_emb.shape()[0];
+  auto dim = rotary_pos_emb.shape()[1];
+
+  auto rotary_pos_emb_ptr = rotary_pos_emb.ptr<float>();
+
+  Tensor sin_pos_emb = Tensor::empty({seq, dim}, kFloat32, kCPU).alloc();
+  Tensor cos_pos_emb = Tensor::empty({seq, dim}, kFloat32, kCPU).alloc();
+
+  auto sin_pos_emb_ptr = sin_pos_emb.ptr<float>();
+  auto cos_pos_emb_ptr = cos_pos_emb.ptr<float>();
+
+  for (int i = 0; i < seq; i++) {
+    for (int j = 0; j < dim; j++) {
+      sin_pos_emb_ptr[i * dim + j] = std::sin(rotary_pos_emb_ptr[i * dim + j]);
+      cos_pos_emb_ptr[i * dim + j] = std::cos(rotary_pos_emb_ptr[i * dim + j]);
+    }
+  }
+
+  return {sin_pos_emb, cos_pos_emb};
+}
+
+void Qwen2VLVisionRoPEOpImpl::forward(const Tensor& activation, const Tensor& sin, const Tensor& cos, Tensor& out) {
+  // [B, S, H, D]
+  MLLM_RT_ASSERT_EQ(activation.shape().size(), 4);
+
+  switch (activation.dtype()) {
+    case kFloat16: {
+      auto B = activation.shape()[0];
+      auto S = activation.shape()[1];
+      auto H = activation.shape()[2];
+      auto D = activation.shape()[3];
+      auto activation_ptr = activation.ptr<float16_t>();
+      auto output_ptr = out.ptr<float16_t>();
+      auto sin_ptr = sin.ptr<float16_t>();
+      auto cos_ptr = cos.ptr<float16_t>();
+
+      auto half_dim = D / 2;
+
+      for (int b = 0; b < B; ++b) {
+        for (int s = 0; s < S; ++s) {
+          for (int h = 0; h < H; ++h) {
+            auto act_base = activation_ptr + b * S * H * D + s * H * D + h * D;
+            auto out_base = output_ptr + b * S * H * D + s * H * D + h * D;
+
+            auto sin_base = sin_ptr + s * half_dim;  // sin shape is [S, half_dim]
+            auto cos_base = cos_ptr + s * half_dim;  // cos shape is [S, half_dim]
+
+            int d = 0;
+            for (; d + 3 < half_dim; d += 4) {
+              float16x4_t a = vld1_f16(act_base + d);
+              float16x4_t b = vld1_f16(act_base + d + half_dim);
+
+              float16x4_t cos_val = vld1_f16(cos_base + d);
+              float16x4_t sin_val = vld1_f16(sin_base + d);
+
+              // part1 = a * cos_val - b * sin_val
+              // part2 = a * sin_val + b * cos_val
+              float16x4_t part1 = vsub_f16(vmul_f16(a, cos_val), vmul_f16(b, sin_val));
+              float16x4_t part2 = vadd_f16(vmul_f16(a, sin_val), vmul_f16(b, cos_val));
+
+              vst1_f16(out_base + d, part1);
+              vst1_f16(out_base + d + half_dim, part2);
+            }
+
+            for (; d < half_dim; ++d) {
+              const auto a = act_base[d];
+              const auto b = act_base[d + half_dim];
+              const auto cos_val = cos_base[d];
+              const auto sin_val = sin_base[d];
+              out_base[d] = a * cos_val - b * sin_val;
+              out_base[d + half_dim] = a * sin_val + b * cos_val;
+            }
+          }
+        }
+      }
+      break;
+    }
+    case kFloat32: {
+      const auto B = activation.shape()[0];
+      const auto S = activation.shape()[1];
+      const auto H = activation.shape()[2];
+      const auto D = activation.shape()[3];
+      const auto half_dim = D / 2;
+
+      auto activation_ptr = activation.ptr<float>();
+      auto output_ptr = out.ptr<float>();
+      auto sin_ptr = sin.ptr<float>();
+      auto cos_ptr = cos.ptr<float>();
+
+      for (int b = 0; b < B; ++b) {
+        for (int s = 0; s < S; ++s) {
+          for (int h = 0; h < H; ++h) {
+            auto act_base = activation_ptr + b * S * H * D + s * H * D + h * D;
+            auto out_base = output_ptr + b * S * H * D + s * H * D + h * D;
+
+            auto sin_base = sin_ptr + s * half_dim;  // sin shape is [S, half_dim]
+            auto cos_base = cos_ptr + s * half_dim;  // cos shape is [S, half_dim]
+
+            int d = 0;
+            for (; d + 3 < half_dim; d += 4) {
+              float32x4_t a_front = vld1q_f32(act_base + d);
+              float32x4_t a_back = vld1q_f32(act_base + d + half_dim);
+
+              float32x4_t cos_val = vld1q_f32(cos_base + d);
+              float32x4_t sin_val = vld1q_f32(sin_base + d);
+
+              // out_front = a_front * cos_val - a_back * sin_val
+              // out_back  = a_front * sin_val + a_back * cos_val
+              float32x4_t out_front = vmlsq_f32(vmulq_f32(a_front, cos_val), a_back, sin_val);
+              float32x4_t out_back = vmlaq_f32(vmulq_f32(a_front, sin_val), a_back, cos_val);
+
+              vst1q_f32(out_base + d, out_front);
+              vst1q_f32(out_base + d + half_dim, out_back);
+            }
+
+            for (; d < half_dim; ++d) {
+              const float a_front = act_base[d];
+              const float a_back = act_base[d + half_dim];
+              const float cos_val = cos_base[d];
+              const float sin_val = sin_base[d];
+              out_base[d] = a_front * cos_val - a_back * sin_val;
+              out_base[d + half_dim] = a_front * sin_val + a_back * cos_val;
+            }
+          }
+        }
+      }
+      break;
+    }
+    default: {
+      NYI("Unsupported activation type");
+    }
+  }
+}
+
+CPUVisionRoPEOp::CPUVisionRoPEOp(const aops::VisionRoPEOpOptions& options) : aops::VisionRoPEOp(options) {
+  // TODO
+}
+
+void CPUVisionRoPEOp::forward(const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) {
+  // TODO
+}
+
+}  // namespace mllm::cpu

--- a/mllm/backends/cpu/ops/VisionRoPEOp.hpp
+++ b/mllm/backends/cpu/ops/VisionRoPEOp.hpp
@@ -1,0 +1,41 @@
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "mllm/core/BaseOp.hpp"
+#include "mllm/core/aops/VisionRoPEOp.hpp"
+
+namespace mllm::cpu {
+
+struct Qwen2VLVisionRoPEOpImpl {
+  Tensor computeInvFreq(const aops::Qwen2VLRoPEOpOptions& cargo);
+
+  // Get Position ids.
+  Tensor getRotaryPosEmbIds(Tensor& grid_thw, const aops::Qwen2VLRoPEOpOptions& cargo);
+
+  Tensor computeRotaryPosEmb(Tensor& rotary_pos_emb_full, Tensor& pos_ids, Tensor& grid_thw,
+                             const aops::Qwen2VLRoPEOpOptions& cargo);
+
+  Tensor rotaryPosEmb(Tensor& inv_freq, int seq_len, const aops::Qwen2VLRoPEOpOptions& cargo);
+
+  std::pair<Tensor, Tensor> getSinCos(Tensor& rotary_pos_emb);
+
+  void forward(const Tensor& activation, const Tensor& sin, const Tensor& cos, Tensor& out);
+};
+
+class CPUVisionRoPEOp final : public aops::VisionRoPEOp {
+ public:
+  explicit CPUVisionRoPEOp(const aops::VisionRoPEOpOptions& options);
+
+  void forward(const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) override;
+};
+
+class CPUVisionRoPEOpFactory : public TypedOpFactory<OpTypes::kVisionRoPE, aops::VisionRoPEOpOptions> {
+ public:
+  std::shared_ptr<BaseOp> createOpImpl(const aops::VisionRoPEOpOptions& options) override {
+    return std::make_shared<CPUVisionRoPEOp>(options);
+  }
+};
+
+}  // namespace mllm::cpu

--- a/mllm/core/Tensor.cpp
+++ b/mllm/core/Tensor.cpp
@@ -12,6 +12,7 @@
 #include "mllm/core/aops/ReduceOps.hpp"
 #include "mllm/core/aops/RepeatOp.hpp"
 #include "mllm/core/aops/ReshapeOp.hpp"
+#include "mllm/core/aops/SliceOp.hpp"
 #include "mllm/core/aops/TransposeOp.hpp"
 #include "mllm/core/aops/ViewOp.hpp"
 #include "mllm/core/aops/X2XOp.hpp"
@@ -20,8 +21,11 @@
 namespace mllm {
 
 Tensor Tensor::operator[](const SliceIndices& slice_index) {
-  // TODO
-  return Tensor::nil();
+  return Context::instance().buildOpAndSubmitTask(OpTypes::kSlice,
+                                                  aops::SliceOpOptions{
+                                                      .indices_ = slice_index,
+                                                  },
+                                                  {*this})[0];
 }
 
 Tensor& Tensor::alloc() {

--- a/mllm/core/aops/VisionRoPEOp.cpp
+++ b/mllm/core/aops/VisionRoPEOp.cpp
@@ -1,0 +1,34 @@
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
+
+#include "mllm/core/aops/VisionRoPEOp.hpp"
+#include "mllm/core/BaseOp.hpp"
+#include "mllm/core/Tensor.hpp"
+#include "mllm/utils/Common.hpp"
+#include "mllm/compile/ir/linalg/Op.hpp"
+
+namespace mllm::aops {
+
+VisionRoPEOp::VisionRoPEOp(const VisionRoPEOpOptions& options) : BaseOp(OpTypes::kSiLU), options_(options) {}
+
+void VisionRoPEOp::load(const ParameterFile::ptr_t& ploader) { MLLM_EMPTY_SCOPE; }
+
+void VisionRoPEOp::trace(void* trace_context, const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) {
+  auto ir_ctx = (ir::IRContext*)trace_context;
+  auto i_irs = ir::tensor::wrapTensors2TensorIR(ir_ctx, inputs);
+  auto o_irs = ir::tensor::wrapTensors2TensorIR(ir_ctx, outputs);
+  ir_ctx->create<ir::linalg::VisionRoPEOp>(shared_from_this(), i_irs, o_irs);
+}
+
+void VisionRoPEOp::forward(const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) {
+  NYI("VisionRoPEOp::forward not implemented in aops base.");
+}
+
+void VisionRoPEOp::reshape(const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) {
+  const auto& i = inputs[0];
+  outputs.emplace_back(Tensor::empty(i.shape(), i.dtype(), i.device()));
+}
+
+void VisionRoPEOp::setup(const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) { BaseOp::setup(inputs, outputs); }
+
+}  // namespace mllm::aops

--- a/mllm/core/aops/VisionRoPEOp.hpp
+++ b/mllm/core/aops/VisionRoPEOp.hpp
@@ -1,0 +1,48 @@
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "mllm/core/BaseOp.hpp"
+#include "mllm/core/ParameterFile.hpp"
+
+namespace mllm::aops {
+
+enum class VisionRoPEOpOptionsType : uint8_t {
+  kStart = 0,
+  kQwen2VL,
+  kEnd,
+};
+
+struct Qwen2VLRoPEOpOptions {
+  int32_t dims;
+  int32_t spatial_merge_size = 2;
+  float theta;
+};
+
+struct VisionRoPEOpOptions : public BaseOpOptions<VisionRoPEOpOptions> {
+  VisionRoPEOpOptionsType type;
+  union {
+    Qwen2VLRoPEOpOptions qwen2vl_rope_op_Options;
+  };
+};
+
+class VisionRoPEOp : public BaseOp {
+ public:
+  explicit VisionRoPEOp(const VisionRoPEOpOptions& options);
+
+  void load(const ParameterFile::ptr_t& ploader) override;
+
+  void trace(void* trace_context, const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) override;
+
+  void forward(const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) override;
+
+  void reshape(const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) override;
+
+  void setup(const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) override;
+
+ protected:
+  VisionRoPEOpOptions options_;
+};
+
+}  // namespace mllm::aops

--- a/mllm/models/qwen2vl/configuration_qwen2vl.hpp
+++ b/mllm/models/qwen2vl/configuration_qwen2vl.hpp
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 #pragma once
 
+#include "mllm/core/aops/LinearOp.hpp"
 #include "mllm/engine/ConfigFile.hpp"
 
 namespace mllm::models {
@@ -61,6 +62,8 @@ struct Qwen2VLConfig : protected ConfigFile {
   int64_t eos_token_id = 151645;
   int32_t end_of_text_token_id = 151643;
   float rope_theta = 1000000.0;
+
+  aops::LinearImplTypes linear_impl_type;
 };
 
 }  // namespace mllm::models

--- a/mllm/models/qwen2vl/modeling_qwen2vl.hpp
+++ b/mllm/models/qwen2vl/modeling_qwen2vl.hpp
@@ -1,10 +1,45 @@
 // Copyright (c) MLLM Team.
 // Licensed under the MIT License.
 
+#include "mllm/nn/Module.hpp"
 #include "mllm/nn/Nn.hpp"
+#include "mllm/nn/Functional.hpp"
 #include "mllm/models/qwen2vl/configuration_qwen2vl.hpp"
 
-namespace mllm::models {
+namespace mllm::models::qwen2vl {
+
+class PatchMerger final : public nn::Module {
+  int32_t hidden_size_;
+  int32_t spatial_merge_size_;
+  int32_t context_dim_;
+
+  nn::LayerNorm ln_q_;
+  nn::Linear mlp_0_;
+  nn::Linear mlp_2_;
+  nn::GELU mlp_gelu_;
+
+ public:
+  PatchMerger() = default;
+
+  inline explicit PatchMerger(const std::string& name, const Qwen2VLConfig& cfg) : nn::Module(name) {
+    context_dim_ = cfg.visual_embed_dim;
+    spatial_merge_size_ = cfg.visual_spatial_merge_size;
+    hidden_size_ = context_dim_ * spatial_merge_size_ * spatial_merge_size_;
+
+    ln_q_ = reg<nn::LayerNorm>("ln_q", std::vector<int32_t>{context_dim_}, true, true, 1e-6);
+    mlp_0_ = reg<nn::Linear>("mlp.0", hidden_size_, hidden_size_, true);
+    mlp_gelu_ = reg<nn::GELU>("mlp.gelu");
+    mlp_2_ = reg<nn::Linear>("mlp.2", hidden_size_, cfg.hidden_size, true);
+  }
+
+  std::vector<Tensor> forward(const std::vector<Tensor>& inputs) override {
+    auto o = ln_q_(inputs[0]).view({-1, hidden_size_});
+    o = mlp_0_(o);
+    o = mlp_gelu_(o);
+    o = mlp_2_(o);
+    return {o};
+  }
+};
 
 class VisionMlp final : public nn::Module {
   int32_t dim_;
@@ -17,7 +52,7 @@ class VisionMlp final : public nn::Module {
  public:
   VisionMlp() = default;
 
-  inline explicit VisionMlp(const std::string& name, const Qwen2VLConfig& cfg) {
+  inline explicit VisionMlp(const std::string& name, const Qwen2VLConfig& cfg) : nn::Module(name) {
     dim_ = cfg.visual_embed_dim;
     hidden_dim_ = cfg.visual_embed_dim * cfg.visual_mlp_ratio;
 
@@ -29,4 +64,109 @@ class VisionMlp final : public nn::Module {
   std::vector<Tensor> forward(const std::vector<Tensor>& inputs) override { return {fc_2_(act_(fc_1_(inputs[0])))}; }
 };
 
-}  // namespace mllm::models
+class VisionAttention final : public nn::Module {
+  int32_t dim_;
+  int32_t num_heads_;
+  int32_t head_dim_;
+  int32_t num_key_value_groups = 1;
+  float scaling = 0.f;
+
+  nn::Linear qkv_;
+  nn::Linear proj_;
+  nn::Softmax softmax_;
+  nn::VisionRoPE vision_rope_q_;
+  nn::VisionRoPE vision_rope_k_;
+
+ public:
+  VisionAttention() = default;
+
+  inline explicit VisionAttention(const std::string& name, const Qwen2VLConfig& cfg) : nn::Module(name) {
+    dim_ = cfg.visual_embed_dim;
+    num_heads_ = cfg.visual_num_heads;
+    head_dim_ = dim_ / num_heads_;
+    scaling = std::sqrt(head_dim_);
+
+    qkv_ = reg<nn::Linear>("qkv", dim_, dim_ * 3, true, cfg.linear_impl_type);
+    proj_ = reg<nn::Linear>("proj", dim_, dim_, true, cfg.linear_impl_type);
+    softmax_ = reg<nn::Softmax>("softmax", -1);
+
+    vision_rope_q_ = reg<nn::VisionRoPE>("vision_rope_q", aops::VisionRoPEOpOptionsType::kQwen2VL,
+                                         aops::Qwen2VLRoPEOpOptions{
+                                             .dims = head_dim_,
+                                             .spatial_merge_size = cfg.visual_spatial_merge_size,
+                                             .theta = 10000.0,
+                                         });
+    vision_rope_k_ = reg<nn::VisionRoPE>("vision_rope_k", aops::VisionRoPEOpOptionsType::kQwen2VL,
+                                         aops::Qwen2VLRoPEOpOptions{
+                                             .dims = head_dim_,
+                                             .spatial_merge_size = cfg.visual_spatial_merge_size,
+                                             .theta = 10000.0,
+                                         });
+  }
+
+  std::vector<Tensor> forward(const std::vector<Tensor>& inputs) override {
+    // hidden_states shape is [seq_length, dim]
+    auto hidden_states = inputs[0];
+    auto& grid_thw = inputs[1];
+
+    auto seq_length = hidden_states.shape()[0];
+
+    auto [query_states, key_states, value_states] =
+        nn::functional::split<3>(qkv_(hidden_states).view({seq_length, 3, num_heads_, -1}).permute({1, 0, 2, 3}), 1, 0);
+
+    // Input to Vision ROPE must be BSHD format
+    // grid_thw shape is [n, 3], n is always 1 in this case.
+    query_states = vision_rope_q_(query_states, grid_thw);
+    key_states = vision_rope_k_(key_states, grid_thw);
+
+    // [B, H, S, D]
+    query_states = query_states.transpose(1, 2);
+    key_states = key_states.transpose(1, 2);
+    value_states = value_states.transpose(1, 2);
+
+    // attention weight
+    // [B=1, H, S, S]
+    auto attn = nn::functional::matmul(query_states, key_states, false, true) * (1.f / sqrtf(head_dim_));
+    attn = softmax_(attn);
+
+    // attn output
+    // [B=1, H, S, S] @ [B=1, H, S, D] -> [B=1, H, S, D]
+    auto attn_output = nn::functional::matmul(attn, value_states);
+
+    // [B=1, H, S, D] -> [B=1, S, H, D] -> [S, H * D]
+    attn_output = attn_output.transpose(1, 2).view({seq_length, -1});
+    attn_output = proj_(attn_output);
+    return {attn_output};
+  }
+};
+
+class Qwen2VLVisionBlock final : public nn::Module {
+  int mlp_hidden_dim_;
+
+  nn::LayerNorm norm1_;
+  nn::LayerNorm norm2_;
+
+  VisionAttention attn_;
+  VisionMlp mlp_;
+
+ public:
+  Qwen2VLVisionBlock() = default;
+
+  inline explicit Qwen2VLVisionBlock(const std::string& name, const Qwen2VLConfig& cfg) : nn::Module(name) {
+    mlp_hidden_dim_ = cfg.visual_mlp_ratio * cfg.visual_embed_dim;
+    norm1_ = reg<nn::LayerNorm>("norm1", std::vector<int32_t>{cfg.visual_embed_dim}, true, true, 1e-6);
+    norm2_ = reg<nn::LayerNorm>("norm2", std::vector<int32_t>{cfg.visual_embed_dim}, true, true, 1e-6);
+    attn_ = reg<VisionAttention>("attn", cfg);
+    mlp_ = reg<VisionMlp>("mlp", cfg);
+  }
+
+  std::vector<Tensor> forward(const std::vector<Tensor>& inputs) override {
+    auto hidden_states = inputs[0];
+    auto grid_thw = inputs[1];
+    hidden_states = hidden_states + attn_(norm1_(hidden_states), grid_thw)[0];
+    hidden_states = hidden_states + mlp_(norm2_(hidden_states))[0];
+    return {hidden_states};
+  }
+};
+
+}  // namespace mllm::models::qwen2vl

--- a/mllm/nn/Nn.hpp
+++ b/mllm/nn/Nn.hpp
@@ -7,11 +7,13 @@
 #include "mllm/nn/Functional.hpp"  // IWYU pragma: export
 #include "mllm/nn/Layer.hpp"       // IWYU pragma: export
 
-#include "mllm/nn/layers/Linear.hpp"     // IWYU pragma: export
-#include "mllm/nn/layers/RMSNorm.hpp"    // IWYU pragma: export
-#include "mllm/nn/layers/SiLU.hpp"       // IWYU pragma: export
-#include "mllm/nn/layers/Embedding.hpp"  // IWYU pragma: export
-#include "mllm/nn/layers/GELU.hpp"       // IWYU pragma: export
-#include "mllm/nn/layers/QuickGELU.hpp"  // IWYU pragma: export
-#include "mllm/nn/layers/ReLU.hpp"       // IWYU pragma: export
-#include "mllm/nn/layers/LayerNorm.hpp"  // IWYU pragma: export
+#include "mllm/nn/layers/Linear.hpp"      // IWYU pragma: export
+#include "mllm/nn/layers/RMSNorm.hpp"     // IWYU pragma: export
+#include "mllm/nn/layers/SiLU.hpp"        // IWYU pragma: export
+#include "mllm/nn/layers/Embedding.hpp"   // IWYU pragma: export
+#include "mllm/nn/layers/GELU.hpp"        // IWYU pragma: export
+#include "mllm/nn/layers/QuickGELU.hpp"   // IWYU pragma: export
+#include "mllm/nn/layers/ReLU.hpp"        // IWYU pragma: export
+#include "mllm/nn/layers/LayerNorm.hpp"   // IWYU pragma: export
+#include "mllm/nn/layers/Softmax.hpp"     // IWYU pragma: export
+#include "mllm/nn/layers/VisionRoPE.hpp"  // IWYU pragma: export

--- a/mllm/nn/layers/Softmax.cpp
+++ b/mllm/nn/layers/Softmax.cpp
@@ -1,0 +1,15 @@
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
+
+#include "mllm/core/aops/SoftmaxOp.hpp"
+#include "mllm/nn/layers/Softmax.hpp"
+
+namespace mllm::nn {
+
+Softmax::Softmax() : Layer(OpTypes::kSoftmax, aops::SoftmaxOpOptions{}) {}
+
+Softmax::Softmax(const aops::SoftmaxOpOptions& options) : Layer(OpTypes::kSoftmax, options) {}
+
+Softmax::Softmax(int32_t dim) : Layer(OpTypes::kSoftmax, aops::SoftmaxOpOptions{.axis = dim}) {}
+
+}  // namespace mllm::nn

--- a/mllm/nn/layers/Softmax.hpp
+++ b/mllm/nn/layers/Softmax.hpp
@@ -1,0 +1,20 @@
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "mllm/nn/Layer.hpp"
+#include "mllm/core/aops/SoftmaxOp.hpp"
+
+namespace mllm::nn {
+
+class Softmax : public Layer {
+ public:
+  Softmax();
+
+  explicit Softmax(const aops::SoftmaxOpOptions& options);
+
+  explicit Softmax(int32_t dim);
+};
+
+}  // namespace mllm::nn

--- a/mllm/nn/layers/VisionRoPE.cpp
+++ b/mllm/nn/layers/VisionRoPE.cpp
@@ -1,0 +1,16 @@
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
+
+#include "mllm/core/aops/VisionRoPEOp.hpp"
+#include "mllm/nn/layers/VisionRoPE.hpp"
+
+namespace mllm::nn {
+
+VisionRoPE::VisionRoPE() : Layer(OpTypes::kVisionRoPE, aops::VisionRoPEOpOptions{}) {}
+
+VisionRoPE::VisionRoPE(const aops::VisionRoPEOpOptions& options) : Layer(OpTypes::kVisionRoPE, options) {}
+
+VisionRoPE::VisionRoPE(const aops::VisionRoPEOpOptionsType type, const aops::Qwen2VLRoPEOpOptions& Options)
+    : Layer(OpTypes::kVisionRoPE, aops::VisionRoPEOpOptions{.type = type, Options}) {}
+
+}  // namespace mllm::nn

--- a/mllm/nn/layers/VisionRoPE.hpp
+++ b/mllm/nn/layers/VisionRoPE.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "mllm/nn/Layer.hpp"
+#include "mllm/core/aops/VisionRoPEOp.hpp"
+
+namespace mllm::nn {
+
+class VisionRoPE : public Layer {
+ public:
+  VisionRoPE();
+
+  explicit VisionRoPE(const aops::VisionRoPEOpOptions& Options);
+
+  VisionRoPE(const aops::VisionRoPEOpOptionsType type, const aops::Qwen2VLRoPEOpOptions& Options);
+};
+
+}  // namespace mllm::nn

--- a/pymllm/__init__.py
+++ b/pymllm/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from ._C import *
 from . import utils
 from . import nn
+from . import quantize
 
 float32 = DataTypes.Float32
 float16 = DataTypes.Float16

--- a/tasks/build_osx_apple_silicon_dbg.yaml
+++ b/tasks/build_osx_apple_silicon_dbg.yaml
@@ -1,0 +1,10 @@
+Tasks:
+  - CMakeConfigTask:
+      cmake_cfg_path: "build-osx-dbg"
+      cmake_build_type: "Debug"
+      cmake_extra_args:
+        - "-DMLLM_BUILD_ARM_BACKEND=ON"
+        - '-DMLLM_CPU_BACKEND_COMPILE_OPTIONS="-march=native+fp16+fp16fml+dotprod+i8mm+sme;-ffast-math;-Wno-nan-infinity-disabled"'
+
+  - CMakeBuildTask:
+      cmake_cfg_path: "build-osx-dbg"

--- a/tests/cpu/KernelTest.cpp
+++ b/tests/cpu/KernelTest.cpp
@@ -575,8 +575,8 @@ TEST_F(ElementwiseKernelTest, DivScalarInt32) {
 // D is always multiple of 32.
 //===----------------------------------------------------------------------===//
 #if defined(MLLM_HOST_ARCH_ARM64) || defined(MLLM_HOST_ARCH_ARM)
-#include "HpcArmSgemvKernelTest.hpp"
-TEST_F(HpcArmSgemvKernelTest, matmul_fp32_gemv_nt_t_decode_small_d_qk) {
+#include "MllmBlasArmSgemvKernelTest.hpp"
+TEST_F(MllmBlasArmSgemvKernelTest, matmul_fp32_gemv_nt_t_decode_small_d_qk) {
   EXPECT_EQ(test_mllm_blas_matmul_fp32_gemv_nt_t_decode_small_d_qk({
                 {{"D", 64}, {"S", 1}},
                 {{"D", 64}, {"S", 3}},

--- a/tests/cpu/MllmBlasArmSgemvKernelTest.hpp
+++ b/tests/cpu/MllmBlasArmSgemvKernelTest.hpp
@@ -9,10 +9,10 @@
 
 #include "KernelTestHelper.hpp"
 
-class HpcArmSgemvKernelTest : public KernelTest {
+class MllmBlasArmSgemvKernelTest : public KernelTest {
  public:
-  HpcArmSgemvKernelTest() = default;
-  ~HpcArmSgemvKernelTest() override = default;
+  MllmBlasArmSgemvKernelTest() = default;
+  ~MllmBlasArmSgemvKernelTest() override = default;
 
   bool cmp_mllm_blas_matmul_fp32_gemv_nt_t_decode_small_d_qk(std::unordered_map<std::string, int32_t>& vars) {
     int D = vars["D"];

--- a/tests/nn/StaticCacheTest.cpp
+++ b/tests/nn/StaticCacheTest.cpp
@@ -10,7 +10,7 @@ using namespace mllm;  // NOLINT
 int main() {
   mllm::initializeContext();
 
-  constexpr int max_cache_length = 6;
+  constexpr int max_cache_length = 32;
   constexpr int layer_nums = 12;
   constexpr int q_heads = 4;
   constexpr int kv_heads = 2;
@@ -19,6 +19,32 @@ int main() {
   nn::StaticCache cache(max_cache_length, layer_nums, q_heads, kv_heads, kv_dim, kFloat32, kFloat32, kCPU, false);
 
   for (int i = 0; i < layer_nums; ++i) { MLLM_RT_ASSERT_EQ(cache.getCurrentSeqCnt(i), 0); }
+
+  // 1. Insert KV, [B, H, S=1, D]
+  {
+    print("Insert KV, [B, H, S=1, D]");
+    auto k = Tensor::random({1, kv_heads, 1, kv_dim});
+    auto v = Tensor::random({1, kv_heads, 1, kv_dim});
+
+    auto [key, value] = cache.updateKVCache(0, k, v);
+
+    print(key.shape(), value.shape());
+    print(key);
+    print(value);
+  }
+
+  // 1. Insert KV, [B, H, S=2, D]
+  {
+    print("Insert KV, [B, H, S=2, D]");
+    auto k = Tensor::random({1, kv_heads, 2, kv_dim});
+    auto v = Tensor::random({1, kv_heads, 2, kv_dim});
+
+    auto [key, value] = cache.updateKVCache(0, k, v);
+
+    print(key.shape(), value.shape());
+    print(key);
+    print(value);
+  }
 
   mllm::shutdownContext();
 }


### PR DESCRIPTION
- Implement VisionRoPEOp and CPUVisionRoPEOp for vision transformers
- Add support for Qwen2VL model's visual attention mechanism
- Introduce new layers in nn module: Softmax and VisionRoPE
- Update CPU backend to include VisionRoPE operation
- Modify qwen2vl model implementation to use new VisionRoPE layers