### PR TITLE
feat(qwen2vl): implement KV cache and reshape op

### DIFF
--- a/examples/qwen2_vl/main.cpp
+++ b/examples/qwen2_vl/main.cpp
@@ -9,11 +9,13 @@ int main(int argc, char** argv) {
 
   auto& help = Argparse::add<bool>("-h|--help").help("Show help message");
 
-  auto qwen2vl_cfg = mllm::models::qwen2vl::Qwen2VLConfig();
-  auto qwen2vl = mllm::models::qwen2vl::Qwen2VLForCausalLM(qwen2vl_cfg);
+  {
+    auto qwen2vl_cfg = mllm::models::qwen2vl::Qwen2VLConfig();
+    auto qwen2vl = mllm::models::qwen2vl::Qwen2VLForCausalLM(qwen2vl_cfg);
 
-  mllm::print(qwen2vl.llm);
-  mllm::print(qwen2vl.visual);
+    mllm::print(qwen2vl.llm);
+    mllm::print(qwen2vl.visual);
+  }
 
   mllm::memoryReport();
   mllm::shutdownContext();

--- a/mllm/backends/cpu/CPUDispatcher.cpp
+++ b/mllm/backends/cpu/CPUDispatcher.cpp
@@ -45,7 +45,7 @@ void CPUDispatcher::process(const Task::ptr_t& task) {
       break;
     }
     case TaskTypes::kExecuteModule: {
-      task->outputs = ((nn::Module*)(task->custom_context_ptr))->__main(task->inputs);
+      task->outputs = ((nn::Module*)(task->custom_context_ptr))->__main(task->inputs, task->args);
       break;
     }
     default: NYI("CPUDispatcher::process not supported task type");

--- a/mllm/backends/cpu/ops/ReshapeOp.cpp
+++ b/mllm/backends/cpu/ops/ReshapeOp.cpp
@@ -1,0 +1,17 @@
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
+
+#include <cstring>
+#include "mllm/utils/Common.hpp"
+#include "mllm/backends/cpu/ops/ReshapeOp.hpp"
+
+namespace mllm::cpu {
+
+CPUReshapeOp::CPUReshapeOp(const aops::ReshapeOpOptions& options) : aops::ReshapeOp(options) {}
+
+void CPUReshapeOp::forward(const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) {
+  // TODO
+  NYI("Pls use view instead. reshape is not implemented. If you want to reshape a un-contiguous tensor, please implement me.");
+}
+
+}  // namespace mllm::cpu

--- a/mllm/backends/cpu/ops/ReshapeOp.hpp
+++ b/mllm/backends/cpu/ops/ReshapeOp.hpp
@@ -1,0 +1,25 @@
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "mllm/core/BaseOp.hpp"
+#include "mllm/core/aops/ReshapeOp.hpp"
+
+namespace mllm::cpu {
+
+class CPUReshapeOp final : public aops::ReshapeOp {
+ public:
+  explicit CPUReshapeOp(const aops::ReshapeOpOptions& options);
+
+  void forward(const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) override;
+};
+
+class CPUReshapeOpFactory : public TypedOpFactory<OpTypes::kReshape, aops::ReshapeOpOptions> {
+ public:
+  std::shared_ptr<BaseOp> createOpImpl(const aops::ReshapeOpOptions& options) override {
+    return std::make_shared<CPUReshapeOp>(options);
+  }
+};
+
+}  // namespace mllm::cpu

--- a/mllm/compile/ir/Trace.cpp
+++ b/mllm/compile/ir/Trace.cpp
@@ -11,7 +11,7 @@
 
 namespace mllm::ir {
 
-IRContext::ptr_t trace_(nn::Module& module, const std::vector<Tensor>& ref_inputs) {
+IRContext::ptr_t trace_(nn::Module& module, const std::vector<Tensor>& ref_inputs, const std::vector<AnyValue>& args) {
   auto& ctx = Context::instance();
   auto this_session = ctx.thisThread();
 
@@ -38,7 +38,7 @@ IRContext::ptr_t trace_(nn::Module& module, const std::vector<Tensor>& ref_input
   this_session->ir_context = ir_context;
 
   // Forward
-  module.__trace(ref_inputs);
+  module.__trace(ref_inputs, args);
 
   // Mark this thread SessionTCB as normal mode.
   this_session->trace_mode = false;

--- a/mllm/compile/ir/Trace.hpp
+++ b/mllm/compile/ir/Trace.hpp
@@ -9,11 +9,24 @@
 namespace mllm::ir {
 
 // The function below is for python binding
-IRContext::ptr_t trace_(nn::Module& module, const std::vector<Tensor>& ref_inputs);
+IRContext::ptr_t trace_(nn::Module& module, const std::vector<Tensor>& ref_inputs, const std::vector<AnyValue>& args = {});
 
 template<typename... Args>
 IRContext::ptr_t trace(nn::Module& module, Args&&... args) {
-  return trace_(module, std::vector<Tensor>{args...});
+  std::vector<Tensor> tensors;
+  std::vector<AnyValue> others;
+  (..., [&] {
+    // The type must can be inference in compile time
+    using CleanType = std::decay_t<decltype(args)>;
+    if constexpr (std::is_convertible_v<CleanType, Tensor>) {
+      tensors.push_back(std::forward<Args>(args));
+    } else if constexpr (std::is_convertible_v<CleanType, AnyValue>) {
+      others.push_back(std::forward<Args>(args));
+    } else {
+      static_assert(false, "Unsupported argument type!");
+    }
+  }());
+  return trace_(module, tensors, others);
 }
 
 }  // namespace mllm::ir

--- a/mllm/core/BaseOp.hpp
+++ b/mllm/core/BaseOp.hpp
@@ -6,7 +6,6 @@
 #include <memory>
 #include <cstddef>
 #include <vector>
-#include <unordered_map>
 
 #include "mllm/core/Tensor.hpp"
 #include "mllm/core/OpTypes.hpp"

--- a/mllm/engine/Task.hpp
+++ b/mllm/engine/Task.hpp
@@ -7,6 +7,7 @@
 #include <memory>
 
 #include "mllm/core/BaseOp.hpp"
+#include "mllm/utils/AnyValue.hpp"
 #include <exec/any_sender_of.hpp>
 #include <stdexec/execution.hpp>
 
@@ -28,6 +29,7 @@ struct Task {
   BaseOp::ptr_t op;
   std::vector<Tensor> inputs;
   std::vector<Tensor> outputs;
+  std::vector<AnyValue> args;
   void* custom_context_ptr = nullptr;
 
   static Task::ptr_t createExecuteOpTask(const BaseOp::ptr_t& op, const std::vector<Tensor>& inputs,

--- a/mllm/nn/Module.cpp
+++ b/mllm/nn/Module.cpp
@@ -86,13 +86,13 @@ void Module::to(DeviceTypes device_type) { impl()->to(device_type); }
 
 void Module::load(const ParameterFile::ptr_t& param_file) { impl_->load(param_file); }
 
-std::vector<Tensor> Module::forward(const std::vector<Tensor>& inputs) { return {}; }
+std::vector<Tensor> Module::forward(const std::vector<Tensor>& inputs, const std::vector<AnyValue>& args) { return {}; }
 
 void Module::__fmt_print(std::stringstream& ss) const { impl()->__fmt_print(ss); }
 
-std::vector<Tensor> Module::__main(const std::vector<Tensor>& inputs) {
+std::vector<Tensor> Module::__main(const std::vector<Tensor>& inputs, const std::vector<AnyValue>& args) {
   __send_graph_begin(inputs);
-  auto o = forward(inputs);
+  auto o = forward(inputs, args);
   __send_graph_end(inputs);
   return o;
 }
@@ -112,7 +112,7 @@ void Module::__send_graph_end(const std::vector<Tensor>& inputs) {
   (void)ctx.buildOpAndSubmitTask(OpTypes::kGraphEnd, aops::GraphEndOpOptions{.graph_name = impl_->getAbsoluteName()}, inputs);
 }
 
-std::vector<Tensor> Module::__trace(const std::vector<Tensor>& inputs) {
+std::vector<Tensor> Module::__trace(const std::vector<Tensor>& inputs, const std::vector<AnyValue>& args) {
   auto ir_ctx = Context::instance().thisThread()->ir_context;
 
   // Create call graph.
@@ -141,7 +141,7 @@ std::vector<Tensor> Module::__trace(const std::vector<Tensor>& inputs) {
   {
     ir_ctx->setDevice(impl_->getDevice());
     auto guard = ir::IRWriterGuard(ir_ctx, this_graph_ir->getTopRegion());
-    outputs = forward(inputs);
+    outputs = forward(inputs, args);
   }
 
   // wrap the outputs to tensor ir.

--- a/mllm/nn/Module.hpp
+++ b/mllm/nn/Module.hpp
@@ -6,6 +6,7 @@
 #include <vector>
 #include <type_traits>
 
+#include "mllm/utils/AnyValue.hpp"
 #include "mllm/nn/AbstractNnNode.hpp"
 #include "mllm/nn/Layer.hpp"
 #include "mllm/core/ParameterFile.hpp"
@@ -95,23 +96,36 @@ class Module {
 
   template<typename... Args>
   std::vector<Tensor> operator()(Args&&... args) {
-    std::vector<Tensor> inputs = {std::forward<Args>(args)...};
-    return __main(inputs);
+    std::vector<Tensor> tensors;
+    std::vector<AnyValue> others;
+
+    (..., [&] {
+      // The type must can be inference in compile time
+      using CleanType = std::decay_t<decltype(args)>;
+      if constexpr (std::is_convertible_v<CleanType, Tensor>) {
+        tensors.push_back(std::forward<Args>(args));
+      } else if constexpr (std::is_convertible_v<CleanType, AnyValue>) {
+        others.push_back(std::forward<Args>(args));
+      } else {
+        static_assert(false, "Unsupported argument type!");
+      }
+    }());
+    return __main(tensors, others);
   }
 
   void load(const ParameterFile::ptr_t& param_file);
 
-  virtual std::vector<Tensor> forward(const std::vector<Tensor>& inputs);
+  virtual std::vector<Tensor> forward(const std::vector<Tensor>& inputs, const std::vector<AnyValue>& args);
 
   void __fmt_print(std::stringstream& ss) const;
 
-  std::vector<Tensor> __main(const std::vector<Tensor>& inputs);
+  std::vector<Tensor> __main(const std::vector<Tensor>& inputs, const std::vector<AnyValue>& args);
 
   void __send_graph_begin(const std::vector<Tensor>& inputs);
 
   void __send_graph_end(const std::vector<Tensor>& inputs);
 
-  std::vector<Tensor> __trace(const std::vector<Tensor>& inputs);
+  std::vector<Tensor> __trace(const std::vector<Tensor>& inputs, const std::vector<AnyValue>& args);
 
   ParameterFile::ptr_t params(ModelFileVersion v);
 
@@ -137,9 +151,9 @@ class ModuleList final : public Module {
     }
   };
 
-  std::vector<Tensor> forward(const std::vector<Tensor>& inputs) override {
+  std::vector<Tensor> forward(const std::vector<Tensor>& inputs, const std::vector<AnyValue>& args) override {
     std::vector<Tensor> o = inputs;
-    for (auto& layer : layers_) { o = layer.forward(o); }
+    for (auto& layer : layers_) { o = layer.forward(o, args); }
     return o;
   }
 
@@ -160,9 +174,9 @@ class ModuleListSuffixed final : public Module {
     }
   };
 
-  std::vector<Tensor> forward(const std::vector<Tensor>& inputs) override {
+  std::vector<Tensor> forward(const std::vector<Tensor>& inputs, const std::vector<AnyValue>& args) override {
     std::vector<Tensor> o = inputs;
-    for (auto& layer : layers_) { o = layer.forward(o); }
+    for (auto& layer : layers_) { o = layer.forward(o, args); }
     return o;
   }
 

--- a/mllm/nn/lmcache/StaticCache.hpp
+++ b/mllm/nn/lmcache/StaticCache.hpp
@@ -13,6 +13,8 @@ class StaticCache {
  public:
   ~StaticCache() = default;
 
+  StaticCache() = default;
+
   StaticCache(int32_t max_cache_length, int32_t layer_nums, int32_t q_heads, int32_t kv_heads, int32_t kv_dims,
               DataTypes k_dtype, DataTypes v_dtype, DeviceTypes device_type = kCPU, bool use_fa2 = true);
 

--- a/mllm/utils/AnyValue.hpp
+++ b/mllm/utils/AnyValue.hpp
@@ -1,0 +1,158 @@
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
+#pragma once
+
+#include <typeinfo>
+#include <utility>
+
+namespace mllm {
+
+class bad_any_value_cast : public std::bad_cast {
+ public:
+  [[nodiscard]] const char* what() const noexcept override { return "bad any_value_cast: failed type conversion"; }
+};
+
+struct copy_t {};
+inline constexpr copy_t any_copy_tag;
+
+class AnyValue {
+ private:
+  struct Manager_ {
+    void (*deleter)(void*);
+    void* (*cloner)(const void*);
+  };
+
+  void* data_ = nullptr;
+  const std::type_info* type_info_ = &typeid(void);
+  const Manager_* manager_ = nullptr;
+
+ public:
+  AnyValue() noexcept = default;
+
+  ~AnyValue() { reset(); }
+
+  template<typename T, typename DecayedT = std::decay_t<T>>
+  explicit AnyValue(T& value) noexcept
+    requires(!std::is_same_v<DecayedT, AnyValue>)
+  {
+    data_ = &value;
+    type_info_ = &typeid(T);
+    manager_ = nullptr;
+  }
+
+  template<typename T>
+  AnyValue(copy_t, const T& value) {
+    using OwnedType = std::decay_t<T>;
+    data_ = new OwnedType(value);
+    type_info_ = &typeid(T);
+    manager_ = manager_for_<OwnedType>();
+  }
+
+  template<typename T, typename DecayedT = std::decay_t<T>>
+  explicit AnyValue(T&& value) noexcept
+    requires(!std::is_same_v<DecayedT, AnyValue> && !std::is_const_v<T> && !std::is_reference_v<T>)
+  {
+    using OwnedType = DecayedT;
+    data_ = new OwnedType(std::move(value));
+    type_info_ = &typeid(T);
+    manager_ = manager_for_<OwnedType>();
+  }
+
+  AnyValue(const AnyValue& other) {
+    if (other.manager_) {
+      data_ = other.manager_->cloner(other.data_);
+      type_info_ = other.type_info_;
+      manager_ = other.manager_;
+    } else {
+      data_ = other.data_;
+      type_info_ = other.type_info_;
+      manager_ = nullptr;
+    }
+  }
+
+  AnyValue(AnyValue&& other) noexcept : data_(other.data_), type_info_(other.type_info_), manager_(other.manager_) {
+    other.data_ = nullptr;
+    other.type_info_ = &typeid(void);
+    other.manager_ = nullptr;
+  }
+
+  AnyValue& operator=(const AnyValue& other) {
+    AnyValue(other).swap(*this);
+    return *this;
+  }
+
+  AnyValue& operator=(AnyValue&& other) noexcept {
+    AnyValue(std::move(other)).swap(*this);
+    return *this;
+  }
+
+  template<typename T, typename DecayedT = std::decay_t<T>>
+  AnyValue& operator=(T&& value)
+    requires(!std::is_same_v<DecayedT, AnyValue>)
+  {
+    emplace<DecayedT>(std::forward<T>(value));
+    return *this;
+  }
+
+  void reset() noexcept {
+    if (manager_) { manager_->deleter(data_); }
+    data_ = nullptr;
+    type_info_ = &typeid(void);
+    manager_ = nullptr;
+  }
+
+  template<typename T, typename... Args>
+  T& emplace(Args&&... args) {
+    reset();
+    using OwnedType = std::decay_t<T>;
+    data_ = new OwnedType(std::forward<Args>(args)...);
+    type_info_ = &typeid(T);
+    manager_ = manager_for_<OwnedType>();
+    return *static_cast<OwnedType*>(data_);
+  }
+
+  void swap(AnyValue& other) noexcept {
+    std::swap(data_, other.data_);
+    std::swap(type_info_, other.type_info_);
+    std::swap(manager_, other.manager_);
+  }
+
+  [[nodiscard]] bool has_value() const noexcept { return data_ != nullptr; }
+
+  [[nodiscard]] bool is_reference() const noexcept { return has_value() && (manager_ == nullptr); }
+
+  [[nodiscard]] const std::type_info& type() const noexcept { return *type_info_; }
+
+  template<typename T>
+  T& get() {
+    if (typeid(T) != *type_info_) { throw bad_any_value_cast(); }
+    return *static_cast<T*>(data_);
+  }
+
+  template<typename T>
+  const T& get() const {
+    if (typeid(T) != *type_info_) { throw bad_any_value_cast(); }
+    return *static_cast<const T*>(data_);
+  }
+
+  template<typename T>
+  T* get_if() noexcept {
+    return (typeid(T) == *type_info_) ? static_cast<T*>(data_) : nullptr;
+  }
+
+  template<typename T>
+  const T* get_if() const noexcept {
+    return (typeid(T) == *type_info_) ? static_cast<const T*>(data_) : nullptr;
+  }
+
+ private:
+  template<typename T>
+  static const Manager_* manager_for_() noexcept {
+    static constexpr Manager_ manager = {
+        /* deleter */ [](void* data) { delete static_cast<T*>(data); },
+        /* cloner */ [](const void* data) -> void* { return new T(*static_cast<const T*>(data)); }};
+    return &manager;
+  }
+};
+
+}  // namespace mllm

--- a/mllm/utils/Enumerate.hpp
+++ b/mllm/utils/Enumerate.hpp
@@ -1,0 +1,218 @@
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
+#pragma once
+
+#include <iterator>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+
+namespace mllm {
+namespace detail {
+
+template<typename T_Index, typename T_Iterator>
+class EnumerateResult {
+ public:
+  using IteratorRef = typename std::iterator_traits<T_Iterator>::reference;
+
+  EnumerateResult(T_Index index, T_Iterator it) : index_(index), it_(it) {}
+
+  T_Index get_index() const { return index_; }
+  IteratorRef get_value() const { return *it_; }
+
+ private:
+  T_Index index_;
+  T_Iterator it_;
+
+ public:
+  template<std::size_t N>
+  decltype(auto) get() const {
+    if constexpr (N == 0) {
+      return get_index();
+    } else if constexpr (N == 1) {
+      return get_value();
+    }
+  }
+};
+
+template<typename T_Iterator>
+class EnumerateIterator {
+ public:
+  using iterator_category = typename std::iterator_traits<T_Iterator>::iterator_category;
+  using difference_type = typename std::iterator_traits<T_Iterator>::difference_type;
+  using value_type = EnumerateResult<difference_type, T_Iterator>;
+  using reference = value_type;
+  using pointer = void;
+
+  explicit EnumerateIterator(T_Iterator it, difference_type index = 0) : it_(it), index_(index) {}
+
+  reference operator*() const { return reference(index_, it_); }
+
+  EnumerateIterator& operator++() {
+    ++it_;
+    ++index_;
+    return *this;
+  }
+
+  EnumerateIterator operator++(int) {
+    EnumerateIterator temp = *this;
+    ++(*this);
+    return temp;
+  }
+
+  EnumerateIterator& operator--() {
+    if constexpr (std::is_base_of_v<std::bidirectional_iterator_tag, iterator_category>) {
+      --it_;
+      --index_;
+      return *this;
+    } else {
+      static_assert(std::is_base_of_v<std::bidirectional_iterator_tag, iterator_category>,
+                    "operator-- is only available for bidirectional or random-access iterators.");
+    }
+  }
+
+  EnumerateIterator operator--(int) {
+    if constexpr (std::is_base_of_v<std::bidirectional_iterator_tag, iterator_category>) {
+      EnumerateIterator temp = *this;
+      --(*this);
+      return temp;
+    } else {
+      static_assert(std::is_base_of_v<std::bidirectional_iterator_tag, iterator_category>,
+                    "operator-- is only available for bidirectional or random-access iterators.");
+    }
+  }
+
+  EnumerateIterator& operator+=(difference_type n) {
+    if constexpr (std::is_base_of_v<std::random_access_iterator_tag, iterator_category>) {
+      it_ += n;
+      index_ += n;
+      return *this;
+    } else {
+      static_assert(std::is_base_of_v<std::random_access_iterator_tag, iterator_category>,
+                    "operator+= is only available for random-access iterators.");
+    }
+  }
+
+  EnumerateIterator& operator-=(difference_type n) {
+    if constexpr (std::is_base_of_v<std::random_access_iterator_tag, iterator_category>) {
+      it_ -= n;
+      index_ -= n;
+      return *this;
+    } else {
+      static_assert(std::is_base_of_v<std::random_access_iterator_tag, iterator_category>,
+                    "operator-= is only available for random-access iterators.");
+    }
+  }
+
+  reference operator[](difference_type n) const {
+    if constexpr (std::is_base_of_v<std::random_access_iterator_tag, iterator_category>) {
+      return *(*this + n);
+    } else {
+      static_assert(std::is_base_of_v<std::random_access_iterator_tag, iterator_category>,
+                    "operator[] is only available for random-access iterators.");
+    }
+  }
+
+  bool operator!=(const EnumerateIterator& other) const { return it_ != other.it_; }
+  bool operator==(const EnumerateIterator& other) const { return it_ == other.it_; }
+  bool operator<(const EnumerateIterator& other) const { return it_ < other.it_; }
+  bool operator>(const EnumerateIterator& other) const { return it_ > other.it_; }
+  bool operator<=(const EnumerateIterator& other) const { return it_ <= other.it_; }
+  bool operator>=(const EnumerateIterator& other) const { return it_ >= other.it_; }
+
+  // --- Friend functions for arithmetic ---
+  template<typename U>
+  friend auto operator+(EnumerateIterator<U> it, typename EnumerateIterator<U>::difference_type n) -> EnumerateIterator<U>;
+  template<typename U>
+  friend auto operator+(typename EnumerateIterator<U>::difference_type n, EnumerateIterator<U> it) -> EnumerateIterator<U>;
+  template<typename U>
+  friend auto operator-(EnumerateIterator<U> it, typename EnumerateIterator<U>::difference_type n) -> EnumerateIterator<U>;
+  template<typename U>
+  friend auto operator-(const EnumerateIterator<U>& lhs, const EnumerateIterator<U>& rhs) ->
+      typename EnumerateIterator<U>::difference_type;
+
+ private:
+  T_Iterator it_;
+  difference_type index_;
+};
+
+template<typename T_Iterator>
+auto operator+(EnumerateIterator<T_Iterator> it, typename EnumerateIterator<T_Iterator>::difference_type n)
+    -> EnumerateIterator<T_Iterator> {
+  it += n;
+  return it;
+}
+template<typename T_Iterator>
+auto operator+(typename EnumerateIterator<T_Iterator>::difference_type n, EnumerateIterator<T_Iterator> it)
+    -> EnumerateIterator<T_Iterator> {
+  it += n;
+  return it;
+}
+template<typename T_Iterator>
+auto operator-(EnumerateIterator<T_Iterator> it, typename EnumerateIterator<T_Iterator>::difference_type n)
+    -> EnumerateIterator<T_Iterator> {
+  it -= n;
+  return it;
+}
+template<typename T_Iterator>
+auto operator-(const EnumerateIterator<T_Iterator>& lhs, const EnumerateIterator<T_Iterator>& rhs) ->
+    typename EnumerateIterator<T_Iterator>::difference_type {
+  return lhs.it_ - rhs.it_;
+}
+
+// 3. 包装器对象 (Wrapper Object)
+template<typename T_Iterable>
+class EnumerateObject {
+ public:
+  explicit EnumerateObject(T_Iterable&& iterable) : iterable_(std::forward<T_Iterable>(iterable)) {}
+
+  using iterator = decltype(std::begin(std::declval<T_Iterable&>()));
+  using const_iterator = decltype(std::cbegin(std::declval<T_Iterable&>()));
+
+  auto begin() { return EnumerateIterator(std::begin(iterable_)); }
+  auto end() { return EnumerateIterator(std::end(iterable_)); }
+
+  auto begin() const { return EnumerateIterator(std::cbegin(iterable_)); }
+  auto end() const { return EnumerateIterator(std::cend(iterable_)); }
+  auto cbegin() const { return EnumerateIterator(std::cbegin(iterable_)); }
+  auto cend() const { return EnumerateIterator(std::cend(iterable_)); }
+
+ private:
+  T_Iterable iterable_;
+};
+
+template<typename T>
+explicit EnumerateObject(T&&) -> EnumerateObject<T>;
+
+}  // namespace detail
+
+template<typename T_Iterable>
+auto enumerate(T_Iterable&& iterable) {
+  return detail::EnumerateObject(std::forward<T_Iterable>(iterable));
+}
+
+}  // namespace mllm
+
+namespace std {
+template<typename T_Index, typename T_Iterator>
+struct tuple_size<mllm::detail::EnumerateResult<T_Index, T_Iterator>> : std::integral_constant<std::size_t, 2> {};
+
+template<typename T_Index, typename T_Iterator>
+struct tuple_element<0, mllm::detail::EnumerateResult<T_Index, T_Iterator>> {
+  using type = T_Index;
+};
+
+template<typename T_Index, typename T_Iterator>
+struct tuple_element<1, mllm::detail::EnumerateResult<T_Index, T_Iterator>> {
+  using type = typename std::iterator_traits<T_Iterator>::reference;
+};
+
+template<std::size_t N, typename T_Index, typename T_Iterator>
+decltype(auto) get(const mllm::detail::EnumerateResult<T_Index, T_Iterator>& result) {
+  if constexpr (N == 0) {
+    return result.get_index();
+  } else if constexpr (N == 1) {
+    return result.get_value();
+  }
+}
+}  // namespace std

--- a/mllm/utils/IntrusivePtr.cpp
+++ b/mllm/utils/IntrusivePtr.cpp
@@ -1,0 +1,2 @@
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.

--- a/mllm/utils/IntrusivePtr.hpp
+++ b/mllm/utils/IntrusivePtr.hpp
@@ -1,0 +1,2 @@
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.

--- a/tests/compile/ir/ProgramLoweringTest.cpp
+++ b/tests/compile/ir/ProgramLoweringTest.cpp
@@ -21,7 +21,7 @@ class FooNet final : public nn::Module {
     linear_3 = reg<nn::Linear>("linear_3", /*in_channels*/ 1024, /*out_channels*/ 2048);
   }
 
-  std::vector<Tensor> forward(const std::vector<Tensor>& inputs) override {
+  std::vector<Tensor> forward(const std::vector<Tensor>& inputs, const std::vector<AnyValue>& args) override {
     return {
         linear_0(inputs[0]),
         linear_1(inputs[0]),

--- a/tests/compile/ir/TraceFooNetTest.cpp
+++ b/tests/compile/ir/TraceFooNetTest.cpp
@@ -18,7 +18,7 @@ class FooNet final : public nn::Module {
     linear_3 = reg<nn::Linear>("linear_3", /*in_channels*/ 1024, /*out_channels*/ 2048);
   }
 
-  std::vector<Tensor> forward(const std::vector<Tensor>& inputs) override {
+  std::vector<Tensor> forward(const std::vector<Tensor>& inputs, const std::vector<AnyValue>& args) override {
     return {
         linear_0(inputs[0]),
         linear_1(inputs[0]),

--- a/tests/engine/AsyncModuleTest.cpp
+++ b/tests/engine/AsyncModuleTest.cpp
@@ -18,7 +18,7 @@ class FooNet final : public nn::Module {
     linear_3 = reg<nn::Linear>("linear_3", /*in_channels*/ 1024, /*out_channels*/ 2048);
   }
 
-  std::vector<Tensor> forward(const std::vector<Tensor>& inputs) override {
+  std::vector<Tensor> forward(const std::vector<Tensor>& inputs, const std::vector<AnyValue>& args) override {
     return {
         linear_0(inputs[0]),
         linear_1(inputs[0]),

--- a/tests/engine/PerfMemTest.cpp
+++ b/tests/engine/PerfMemTest.cpp
@@ -18,7 +18,7 @@ class FooNet final : public nn::Module {
     linear_3 = reg<nn::Linear>("linear_3", /*in_channels*/ 1024, /*out_channels*/ 2048);
   }
 
-  std::vector<Tensor> forward(const std::vector<Tensor>& inputs) override {
+  std::vector<Tensor> forward(const std::vector<Tensor>& inputs, const std::vector<AnyValue>& args) override {
     return {
         linear_0(inputs[0]),
         linear_1(inputs[0]),

--- a/tests/nn/FooNetTest.cpp
+++ b/tests/nn/FooNetTest.cpp
@@ -17,7 +17,7 @@ class FooNet final : public nn::Module {
     linear_3 = reg<nn::Linear>("linear_3", /*in_channels*/ 1024, /*out_channels*/ 2048);
   }
 
-  std::vector<Tensor> forward(const std::vector<Tensor>& inputs) override {
+  std::vector<Tensor> forward(const std::vector<Tensor>& inputs, const std::vector<AnyValue>& args) override {
     return {
         linear_0(inputs[0]),
         linear_1(inputs[0]),


### PR DESCRIPTION
- Add CPUReshapeOp implementation for reshape operation
- Implement KV cache in Qwen2VLForCausalLM
- Update forward methods to support additional arguments
- Modify trace and async execution to handle new arguments