### PR TITLE
test(cpu): add GELU kernel test and update related files

### DIFF
--- a/rsmllm/Cargo.toml
+++ b/rsmllm/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "rsmllm"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]

--- a/rsmllm/src/main.rs
+++ b/rsmllm/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/tasks/adb_push.yaml
+++ b/tasks/adb_push.yaml
@@ -5,5 +5,6 @@ Tasks:
         - "build-android-arm64-v8a/bin/libMllmCPUBackend.so"
         - "build-android-arm64-v8a/bin/mllm-params-inspector"
         - "build-android-arm64-v8a/bin/mllm-qwen2-vl-runner"
+        - "build-android-arm64-v8a/bin/Mllm-Test-CPUKernel"
 
       to_path: "/data/local/tmp/mllm-v2/bin/"

--- a/tests/cpu/GELUKernelTest.hpp
+++ b/tests/cpu/GELUKernelTest.hpp
@@ -1,0 +1,44 @@
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
+#pragma once
+
+#include <string>
+#include <unordered_map>
+
+#include "mllm/mllm.hpp"
+#include "mllm/backends/cpu/kernels/arm/gelu.hpp"
+
+#include "KernelTestHelper.hpp"
+
+class GELUKernelTest : public KernelTest {
+ public:
+  GELUKernelTest() = default;
+  ~GELUKernelTest() override = default;
+
+  bool cmp(std::unordered_map<std::string, int32_t>& vars) {
+    int S = vars["S"];
+
+    auto A = mllm::Tensor::random({S}, mllm::kFloat32, mllm::kCPU);
+    auto refDst = mllm::Tensor::ones({S}, mllm::kFloat32, mllm::kCPU);
+    auto Dst = mllm::Tensor::ones({S}, mllm::kFloat32, mllm::kCPU);
+
+#if defined(MLLM_HOST_ARCH_ARM64) || defined(MLLM_HOST_ARCH_ARM)
+    mllm::cpu::arm::gelu_fp32(refDst.ptr<float>(), A.ptr<float>(), S, 1);
+    mllm::cpu::arm::gelu_fp32(Dst.ptr<float>(), A.ptr<float>(), S, 4);
+
+    auto result = mllm::test::allClose(refDst, Dst);
+    if (!result.is_close) {
+      mllm::print(result);
+      return false;
+    }
+#endif
+    return true;
+  }
+
+  bool test_cmp(const std::vector<std::unordered_map<std::string, int32_t>>& vars) {
+    for (auto v : vars) {
+      if (!cmp(v)) { return false; }
+    }
+    return true;
+  }
+};

--- a/tests/cpu/KernelTest.cpp
+++ b/tests/cpu/KernelTest.cpp
@@ -570,6 +570,20 @@ TEST_F(ElementwiseKernelTest, DivScalarInt32) {
 }
 
 //===----------------------------------------------------------------------===//
+// GELU
+//===----------------------------------------------------------------------===//
+#include "tests/cpu/GELUKernelTest.hpp"
+TEST_F(GELUKernelTest, test_precision_bt_1threads_4threads) {
+  EXPECT_EQ(test_cmp({
+                {{"S", 10}},
+                {{"S", 128}},
+                {{"S", 256}},
+                {{"S", 18}},
+            }),
+            true);
+}
+
+//===----------------------------------------------------------------------===//
 // HPC Arm SGEMV Tests
 //
 // D is always multiple of 32.


### PR DESCRIPTION
- Add GELUKernelTest class and test cases for GELU (Gaussian Error Linear Unit)
- Create new test file GELUKernelTest.hpp in tests/cpu directory
- Update KernelTest.cpp to include and run GELU tests
- Add new binary to adb_push.yaml for Android testing
- Create basic structure for rsmllm package with Cargo.toml and main.rs