### PR TITLE
feat(unsafe macros, qa): add Unsafe Macros and add FAQ section on pre…

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -192,6 +192,11 @@ Documents
 
 .. toctree::
    :maxdepth: 2
+
+   qa/index
+
+.. toctree::
+   :maxdepth: 2
    :caption: C++ API
 
    CppAPI/library_root

--- a/docs/qa/index.rst
+++ b/docs/qa/index.rst
@@ -1,0 +1,11 @@
+FAQ
+=====
+
+Precision Issues Caused by ffast-math Flag
+------------------------------------------
+
+Precision issues in computations may be caused by the ``ffast-math`` compiler flag which is enabled by default in some tasks. This flag allows the compiler to violate strict IEEE 754 compliance for floating-point operations, potentially resulting in faster execution but less accurate results.
+
+If you encounter precision-related issues, users can remove this flag from their task configuration files. For kernel developers, you can manually specify compilation flags using UnsafeMacros to control the behavior of specific kernels.
+
+For more detailed information about the implications of the fast-math optimizations, please refer to: https://simonbyrne.github.io/notes/fastmath/

--- a/mllm/backends/cpu/kernels/arm/mllm_blas/mllm_blas_sgemm.cpp
+++ b/mllm/backends/cpu/kernels/arm/mllm_blas/mllm_blas_sgemm.cpp
@@ -280,6 +280,7 @@ static inline void dispatch_tile(int rm, int rn, const float* a, int64_t lda, co
     KERNEL(4, 8)
     KERNEL(4, 12)
     default: {
+      __MLLM_UNSAFE_OPT_BEGIN_O3_FAST_MATH
       auto _rm = std::min(rm, 8);
       auto _rn = std::min(rn, 16);
       for (int i = 0; i < _rm; ++i) {
@@ -291,6 +292,7 @@ static inline void dispatch_tile(int rm, int rn, const float* a, int64_t lda, co
           for (int j = 0; j < _rn; ++j) { c[i * ldc + j] += ai * b[l * ldb + j]; }
         }
       }
+      __MLLM_UNSAFE_OPT_END
       break;
     }
   }

--- a/mllm/backends/cpu/kernels/arm/mllm_blas/mllm_blas_sgemm.hpp
+++ b/mllm/backends/cpu/kernels/arm/mllm_blas/mllm_blas_sgemm.hpp
@@ -4,6 +4,7 @@
 
 #include "mllm/core/DataTypes.hpp"
 #include "mllm/core/Parallel.hpp"
+#include "mllm/utils/UnsafeMacros.hpp"
 
 namespace mllm::cpu::arm {
 
@@ -379,6 +380,7 @@ template<int RM, int RN>
 struct MicroKernel {
   static inline void accumulate(const float* a, int64_t lda, const float* b, int64_t ldb, float* c, int64_t ldc,
                                 int64_t k) noexcept {
+    __MLLM_UNSAFE_OPT_BEGIN_O3_FAST_MATH
     for (int i = 0; i < RM; ++i) {
       for (int j = 0; j < RN; ++j) { c[i * ldc + j] = 0; }
     }
@@ -388,6 +390,7 @@ struct MicroKernel {
         for (int j = 0; j < RN; ++j) { c[i * ldc + j] += ai * b[l * ldb + j]; }
       }
     }
+    __MLLM_UNSAFE_OPT_END
   }
 };
 

--- a/mllm/utils/UnsafeMacros.hpp
+++ b/mllm/utils/UnsafeMacros.hpp
@@ -1,0 +1,35 @@
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
+
+#pragma once
+
+#if defined(__GNUC__) || defined(__clang__)
+#define __MLLM_UNSAFE_COMPILER_GCC_OR_CLANG 1
+#elif defined(_MSC_VER)
+#define __MLLM_UNSAFE_COMPILER_GCC_OR_CLANG 1
+#endif
+
+#if defined(__MLLM_UNSAFE_COMPILER_GCC_OR_CLANG)
+#define __MLLM_UNSAFE_OPT_BEGIN_O3 _Pragma("GCC push_options") _Pragma("GCC optimize (\"O3\")")
+#define __MLLM_UNSAFE_OPT_BEGIN_FAST_MATH _Pragma("GCC push_options") _Pragma("GCC optimize (\"fast-math\")")
+#define __MLLM_UNSAFE_OPT_BEGIN_O3_FAST_MATH \
+  _Pragma("GCC push_options") _Pragma("GCC optimize (\"O3\")") _Pragma("GCC optimize (\"fast-math\")")
+
+#define __MLLM_UNSAFE_OPT_END _Pragma("GCC pop_options")
+
+#elif defined(__MLLM_UNSAFE_COMPILER_GCC_OR_CLANG)
+
+#define __MLLM_UNSAFE_OPT_BEGIN_O3 __pragma(optimize("", off)) __pragma(optimize("tgy", on))
+#define __MLLM_UNSAFE_OPT_BEGIN_FAST_MATH \
+  __pragma(optimize("", off)) __pragma(float_control(except, off)) __pragma(fp_contract(on))
+#define __MLLM_UNSAFE_OPT_BEGIN_O3_FAST_MATH \
+  __pragma(optimize("", off)) __pragma(optimize("tgy", on)) __pragma(float_control(except, off)) __pragma(fp_contract(on))
+#define __MLLM_UNSAFE_OPT_END __pragma(optimize("", on))
+
+#else
+#define __MLLM_UNSAFE_OPT_BEGIN_O3
+#define __MLLM_UNSAFE_OPT_BEGIN_FAST_MATH
+#define __MLLM_UNSAFE_OPT_BEGIN_O3_FAST_MATH
+#define __MLLM_UNSAFE_OPT_END
+#pragma message("Warning: Unknown compiler - optimization macros will have no effect")
+#endif


### PR DESCRIPTION
…cision issues with ffast-math flag

- Create new QA section in documentation to address precision issues caused by the ffast-math compiler flag
- Add detailed information on the implications of fast-math optimizations and how to control them
- Update mllm_blas_sgemm kernel to demonstrate the use of UnsafeMacros for controlling optimizations
- Create UnsafeMacros.hpp utility file to manage compiler-specific optimization flags