### PR TITLE
feat(lazy_vlm, 🍬🍬🍬nn::sequential): add lazy VLM support for Qwen-2.5VL.

### DIFF
--- a/algorithms/lazy_vlm/AttnAnalyze.cpp
+++ b/algorithms/lazy_vlm/AttnAnalyze.cpp
@@ -1,0 +1,44 @@
+#include "AttnAnalyze.hpp"
+
+#include <cmath>
+#include <mllm/nn/Functional.hpp>
+
+std::vector<int32_t> analyzePrefillAttn(mllm::Tensor attn, int32_t img_token_start, int32_t img_token_end,
+                                        float pruning_ratio) {
+  // Prefill attention inputs is [B=1, H, S_all, S_all]
+  attn = attn.mean(1);     // [B=1, S_all, S_all]
+  attn = attn.squeeze(0);  // [S_all, S_all]
+
+  // [S_text, S_img]
+  auto text_2_visual = attn[{{img_token_end, mllm::kAll}, {img_token_start, img_token_end}}].contiguous();
+  text_2_visual = text_2_visual.sum(0);  // [S_img]
+
+  // Calculate the topk tokens number
+  MLLM_RT_ASSERT_EQ(text_2_visual.rank(), 1);
+  auto S_img_tokens = text_2_visual.shape()[0];
+  int32_t left_tokens = (int32_t)std::ceil(S_img_tokens * (1 - pruning_ratio));
+
+  auto [_, indices] = mllm::nn::functional::topk(text_2_visual, left_tokens, /*dim*/ -1, /*largest*/ true, /*sorted*/ false);
+
+  return indices.toVector<int32_t>();
+}
+
+std::vector<int32_t> analyzeDecodeAttn(mllm::Tensor attn, int32_t img_token_start, int32_t img_token_end, float pruning_ratio) {
+  // Decode attention inputs is [B=1, H, 1, S_kv]
+  // For decode phase, we have attention from current token to all previous tokens including visual tokens
+  attn = attn.mean(1);    // [B=1, 1, S_kv]
+  attn = attn.squeeze();  // [S_kv]
+
+  // Extract attention from current token to visual tokens
+  // [S_img]
+  auto text_2_visual = attn[{{img_token_start, img_token_end}}].contiguous();
+
+  // Calculate the topk tokens number
+  MLLM_RT_ASSERT_EQ(text_2_visual.rank(), 1);
+  auto S_img_tokens = text_2_visual.shape()[0];
+  int32_t left_tokens = (int32_t)std::ceil(S_img_tokens * (1 - pruning_ratio));
+
+  auto [_, indices] = mllm::nn::functional::topk(text_2_visual, left_tokens, /*dim*/ -1, /*largest*/ true, /*sorted*/ false);
+
+  return indices.toVector<int32_t>();
+}

--- a/algorithms/lazy_vlm/AttnAnalyze.hpp
+++ b/algorithms/lazy_vlm/AttnAnalyze.hpp
@@ -1,0 +1,10 @@
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <mllm/core/Tensor.hpp>
+
+std::vector<int32_t> analyzePrefillAttn(mllm::Tensor attn);
+
+std::vector<int32_t> analyzeDecodeAttn(mllm::Tensor attn);

--- a/algorithms/lazy_vlm/HKVCache.hpp
+++ b/algorithms/lazy_vlm/HKVCache.hpp
@@ -31,9 +31,9 @@ class HKVCache {
   [[nodiscard]] int32_t getCurrentSeqCnt(int32_t layer_idx) const;
 
   std::array<mllm::Tensor, 2> updateKVCache(int32_t layer_idx, mllm::Tensor k, mllm::Tensor v, KVCacheUpdateRule rule,
-                                            std::unordered_map<std::string, mllm::AnyValue>& args);
+                                            const std::unordered_map<std::string, mllm::AnyValue>& args = {});
 
-  void initHiddenStateCache(int32_t batch_size, int32_t seq_len, int32_t head_nums, int32_t hs_dims);
+  void initHiddenStateCache(int32_t batch_size, int32_t seq_len, int32_t hs_dims);
 
   mllm::Tensor getHiddenStateCache(int32_t layer_idx, const std::vector<int32_t>& pos);
 

--- a/algorithms/lazy_vlm/models/qwen2_5vl/lazy_vlm_cfg.hpp
+++ b/algorithms/lazy_vlm/models/qwen2_5vl/lazy_vlm_cfg.hpp
@@ -1,0 +1,40 @@
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <unordered_map>
+#include <mllm/mllm.hpp>
+
+struct LazyVLMConfig {
+  bool decode_callback = true;
+  // clang-format off
+  std::unordered_map<int32_t, float> pruning_settings = {
+    {3, 0.15},
+    {6, 0.15},
+    {9, 0.2},
+    {12, 0.2},
+    {15, 0.2},
+    {18, 0.2},
+  };
+  // clang-format on
+};
+
+struct LazyVLMState {
+  // AR Generation info
+  int32_t cur_step = -1;
+
+  // You can get visual tokens by doing [self.first_img_token_pos:self.last_img_token_pos]
+  int32_t first_img_token_pos = 0;
+  int32_t last_img_token_pos = 0;
+
+  mllm::Tensor llm_prefill_sin = mllm::Tensor::nil();
+  mllm::Tensor llm_prefill_cos = mllm::Tensor::nil();
+
+  mllm::Tensor llm_current_sin = mllm::Tensor::nil();
+  mllm::Tensor llm_current_cos = mllm::Tensor::nil();
+
+  // Record the chosen position in each layer in each step.
+  std::vector<std::vector<int>> chosen_pos_in_each;
+  std::vector<std::vector<int>> chosen_pos_to_delay_compute;
+};

--- a/algorithms/lazy_vlm/models/qwen2_vl/lazy_vlm_cfg.hpp
+++ b/algorithms/lazy_vlm/models/qwen2_vl/lazy_vlm_cfg.hpp
@@ -1,0 +1,22 @@
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <unordered_map>
+
+struct LazyVLMConfig {
+  bool decode_callback = true;
+  // clang-format off
+  std::unordered_map<int32_t, float> pruning_settings = {
+    {3, 0.15},
+    {6, 0.15},
+    {9, 0.2},
+    {12, 0.2},
+    {15, 0.2},
+    {18, 0.2},
+  };
+  // clang-format on
+};
+
+struct LazyVLMSate {};

--- a/docker/Dockerfile.cu124
+++ b/docker/Dockerfile.cu124
@@ -1,0 +1,40 @@
+FROM nvcr.io/nvidia/pytorch:24.05-py3
+
+WORKDIR /root
+
+RUN echo "LC_ALL=en_US.UTF-8" >> /etc/environment
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    build-essential \
+    git \
+    wget \
+    unzip \
+    doxygen \
+    graphviz \
+    llvm-dev \
+    ninja-build \
+    libtinfo-dev \
+    zlib1g-dev \
+    libedit-dev \
+    libxml2-dev \
+    ca-certificates \
+    android-tools-adb \
+    && apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Install Miniconda
+RUN wget https://repo.anaconda.com/miniconda/Miniconda3-py310_23.5.2-0-Linux-x86_64.sh -O miniconda.sh && \
+    bash miniconda.sh -b -p /opt/conda && \
+    rm miniconda.sh
+
+# Install conda packages
+RUN conda install -y pip cmake && \
+    conda install -c conda-forge libstdcxx-ng=12 && \
+    conda clean --all
+
+RUN git clone --recursive https://github.com/UbiquitousLearning/mllm.git
+
+CMD bash

--- a/examples/qwen2vl_tracer/main.cpp
+++ b/examples/qwen2vl_tracer/main.cpp
@@ -9,7 +9,7 @@
 #include <mllm/compile/passes/LLMCanonicalizationPipeline.hpp>
 #include <mllm/compile/passes/ProgramLoweringPipeline.hpp>
 #include <mllm/compile/jit/binary/IRSerialization.hpp>
-#include "mllm/compile/jit/interpreter/IRInterpreter.hpp"
+#include <mllm/compile/jit/interpreter/IRInterpreter.hpp>
 
 using mllm::Argparse;
 

--- a/mllm/compile/ir/Node.cpp
+++ b/mllm/compile/ir/Node.cpp
@@ -289,14 +289,18 @@ void IRWriter::removeOp(const op_ptr_t& op) {
   for (auto& input : op->inputs()) { input->outputs().remove(op); }
   for (auto& output : op->outputs()) { output->inputs().remove(op); }
 
-  cur_op_iter_ = ops.erase(std::find(ops.begin(), ops.end(), op));
+  auto it = std::find(ops.begin(), ops.end(), op);
+  MLLM_RT_ASSERT(it != ops.end());
+  cur_op_iter_ = ops.erase(it);
 
   is_iterator_modified_ = true;
 }
 
 void IRWriter::removeOpWithoutEdgeCut(const op_ptr_t& op) {
   auto& ops = cur_region_->ops();
-  cur_op_iter_ = ops.erase(std::find(ops.begin(), ops.end(), op));
+  auto it = std::find(ops.begin(), ops.end(), op);
+  MLLM_RT_ASSERT(it != ops.end());
+  cur_op_iter_ = ops.erase(it);
   is_iterator_modified_ = true;
 }
 
@@ -323,14 +327,14 @@ void IRWriter::insertOpAtPos(const op_ptr_t& pos_op, Position pos, const op_ptr_
   // find the pos_op iter in region
   auto& ops = cur_region_->ops();
   auto pos_op_iter = std::find(ops.begin(), ops.end(), pos_op);
-
+  MLLM_RT_ASSERT(pos_op_iter != ops.end());
   new_op->setBelongsTo(pos_op->belongsTo());
 
   switch (pos) {
     case AFTER: {
       auto pre_op = *pos_op_iter;
       pos_op_iter++;
-      auto next_op = *pos_op_iter;
+      auto next_op = (pos_op_iter != ops.end()) ? *pos_op_iter : nullptr;
 
       pre_op->setNextOp(new_op);
       new_op->setPrevOp(pre_op);

--- a/mllm/compile/ir/Node.hpp
+++ b/mllm/compile/ir/Node.hpp
@@ -271,7 +271,8 @@ class IRContext : public std::enable_shared_from_this<IRContext> {
       // set device
       created_node->template cast_<Op>()->setDevice(getDevice());
 
-      auto prev_op = cur_insert_region_->ops().back();
+      auto& ops = cur_insert_region_->ops();
+      op_ptr_t prev_op = ops.empty() ? nullptr : ops.back();
 
       cur_insert_region_->ops().push_back(created_node->template cast_<Op>());
 
@@ -378,7 +379,8 @@ class IRWriter {
       // set device
       created_node->template cast_<Op>()->setDevice(ctx_->getDevice());
 
-      auto prev_op = cur_region_->ops().back();
+      auto& ops = cur_region_->ops();
+      op_ptr_t prev_op = ops.empty() ? nullptr : ops.back();
 
       cur_region_->ops().push_back(created_node->template cast_<Op>());
 
@@ -430,7 +432,7 @@ class IRWriter {
         case AFTER: {
           auto pre_op = *pos_op_iter;
           pos_op_iter++;
-          auto next_op = *pos_op_iter;
+          auto next_op = (pos_op_iter != ops.end()) ? *pos_op_iter : nullptr;
 
           pre_op->setNextOp(created_node);
           created_node->setPrevOp(pre_op);

--- a/mllm/core/Tensor.hpp
+++ b/mllm/core/Tensor.hpp
@@ -246,7 +246,7 @@ class Tensor {
    * @param dim if dim == 0x7fffffff, return a scalar value.
    * @return Tensor
    */
-  Tensor min(bool keep_dim = false, int32_t dim = 0x7fffffff);
+  Tensor min(int32_t dim = 0x7fffffff, bool keep_dim = false);
 
   /**
    * @brief Get max
@@ -254,7 +254,7 @@ class Tensor {
    * @param dim if dim == 0x7fffffff, return a scalar value.
    * @return Tensor
    */
-  Tensor max(bool keep_dim = false, int32_t dim = 0x7fffffff);
+  Tensor max(int32_t dim = 0x7fffffff, bool keep_dim = false);
 
   /**
    * @brief Get sum
@@ -262,7 +262,7 @@ class Tensor {
    * @param dim if dim == 0x7fffffff, return a scalar value.
    * @return Tensor
    */
-  Tensor sum(bool keep_dim = false, int32_t dim = 0x7fffffff);
+  Tensor sum(int32_t dim = 0x7fffffff, bool keep_dim = false);
 
   /**
    * @brief Get mean
@@ -270,7 +270,7 @@ class Tensor {
    * @param dim if dim == 0x7fffffff, return a scalar value.
    * @return Tensor
    */
-  Tensor mean(bool keep_dim = false, int32_t dim = 0x7fffffff);
+  Tensor mean(int32_t dim = 0x7fffffff, bool keep_dim = false);
 
   /**
    * @brief Negative
@@ -365,6 +365,13 @@ class Tensor {
   [[nodiscard]] shape_t shape() const;
 
   /**
+   * @brief  Gets tensor rank.
+   *
+   * @return size_t
+   */
+  [[nodiscard]] size_t rank() const;
+
+  /**
    * @brief Gets tensor strides.
    *
    * @return stride_t
@@ -432,6 +439,14 @@ class Tensor {
    * @return Tensor
    */
   Tensor unsqueeze(int32_t dim);
+
+  /**
+   * @brief
+   *
+   * @param dim
+   * @return Tensor
+   */
+  Tensor squeeze(int32_t dim = 0x7fffffff);
 
   /**
    * @brief clone a tensor

--- a/mllm/engine/BuddyMemPool.cpp
+++ b/mllm/engine/BuddyMemPool.cpp
@@ -101,8 +101,8 @@ void BuddyMemPool::report() const {
   fmt::print("| Object Memory Cached Times: {:<24} |\n", obj_cached_times_);
   fmt::print("+------------------------------------------------------+\n");
   for (auto& seg : context_.segments) {
-    fmt::print("| address: {:#010x}, cap: {:>4}MB, used: {:>4}MB   |\n", (uintptr_t)seg.first, seg.second->cap / (1024 * 1024),
-               seg.second->used / (1024 * 1024));
+    fmt::print("| address: {:#010x}, cap: {:>4}MB, used: {:>4}MB      |\n", (uintptr_t)seg.first,
+               seg.second->cap / (1024 * 1024), seg.second->used / (1024 * 1024));
   }
   fmt::print("+------------------------------------------------------+\n");
 }

--- a/tests/nn/FooNetTest.cpp
+++ b/tests/nn/FooNetTest.cpp
@@ -1,4 +1,3 @@
-#include "mllm/engine/Context.hpp"
 #include "mllm/mllm.hpp"
 
 using namespace mllm;  // NOLINT
@@ -8,22 +7,22 @@ class FooNet final : public nn::Module {
   nn::Linear linear_1;
   nn::Linear linear_2;
   nn::Linear linear_3;
+  nn::Sequential seq;
 
  public:
   explicit FooNet(const std::string& name) : nn::Module(name) {
-    linear_0 = reg<nn::Linear>("linear_0", /*in_channels*/ 1024, /*out_channels*/ 2048);
-    linear_1 = reg<nn::Linear>("linear_1", /*in_channels*/ 1024, /*out_channels*/ 2048);
-    linear_2 = reg<nn::Linear>("linear_2", /*in_channels*/ 1024, /*out_channels*/ 2048);
-    linear_3 = reg<nn::Linear>("linear_3", /*in_channels*/ 1024, /*out_channels*/ 2048);
+    linear_0 = reg<nn::Linear>("linear_0", /*in_channels*/ 64, /*out_channels*/ 64);
+    linear_1 = reg<nn::Linear>("linear_1", /*in_channels*/ 64, /*out_channels*/ 64);
+    linear_2 = reg<nn::Linear>("linear_2", /*in_channels*/ 64, /*out_channels*/ 64);
+    linear_3 = reg<nn::Linear>("linear_3", /*in_channels*/ 64, /*out_channels*/ 64);
+    seq = reg<nn::Sequential>("activation")
+              .add<nn::SiLU>()
+              .add<nn::Linear>(/*in_channels*/ 64, /*out_channels*/ 64)
+              .add<nn::SiLU>();
   }
 
   std::vector<Tensor> forward(const std::vector<Tensor>& inputs, const std::vector<AnyValue>& args) override {
-    return {
-        linear_0(inputs[0]),
-        linear_1(inputs[0]),
-        linear_2(inputs[0]),
-        linear_3(inputs[0]),
-    };
+    return seq(linear_3(linear_2(linear_1(linear_0(inputs[0])))));
   }
 };
 
@@ -31,12 +30,23 @@ int main() {
   mllm::initializeContext();
   {
     auto net = FooNet("foo_net");
+    auto params = ParameterFile::create();
+
+    for (int i = 0; i < 4; ++i) {
+      auto name = "foo_net.linear_" + std::to_string(i);
+      auto w = Tensor::empty({64, 64}).setMemType(kParamsNormal).setName(name + ".weight").alloc();
+      auto b = Tensor::empty({64}).setMemType(kParamsNormal).setName(name + ".bias").alloc();
+      params->push(w.name(), w);
+      params->push(b.name(), b);
+    }
+    auto w1 = Tensor::empty({64, 64}).setMemType(kParamsNormal).setName("foo_net.activation.1.weight").alloc();
+    auto b1 = Tensor::empty({64}).setMemType(kParamsNormal).setName("foo_net.activation.1.bias").alloc();
+    params->push(w1.name(), w1);
+    params->push(b1.name(), b1);
+    net.load(params);
     print(net);
-    auto o = net(Tensor::empty({1, 12, 1024, 1024}, kFloat32).alloc());
+    auto o = net(Tensor::empty({1, 12, 64, 64}, kFloat32).alloc());
     print(o[0].shape(), o[0].dtype(), o[0].device());
-    print(o[1].shape(), o[1].dtype(), o[1].device());
-    print(o[2].shape(), o[2].dtype(), o[2].device());
-    print(o[3].shape(), o[3].dtype(), o[3].device());
     mllm::memoryReport();
   }
   mllm::memoryReport();


### PR DESCRIPTION
- Implement AttnAnalyze module for attention analysis
- Add LazyVLMConfig and LazyVLMState structures
- Modify Qwen2_5VL model to support lazy VLM inference
- Update HKVCache for lazy VLM caching strategy
- Adjust Tensor class to support new operations
- 🍬🍬🍬 nn::sequential !