### PR TITLE
feat(pymllm): add support for accessing Linear layer weights and biases

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,11 @@
 [submodule "mllm/backends/cpu/vendors/kleidiai"]
 	path = mllm/backends/cpu/vendors/kleidiai
 	url = https://git.gitlab.arm.com/kleidi/kleidiai.git
+[submodule "mllm/backends/cuda/vendors/cccl"]
+	path = mllm/backends/cuda/vendors/cccl
+	url = https://github.com/NVIDIA/cccl.git
+	update = none
+[submodule "mllm/backends/cuda/vendors/cutlass"]
+	path = mllm/backends/cuda/vendors/cutlass
+	url = https://github.com/NVIDIA/cutlass.git
+	update = none

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,10 @@ option(MLLM_PERFETTO_ENABLE "Enable perfetto" OFF)
 message(STATUS "CXX Compiler=${CMAKE_CXX_COMPILER_ID}")
 message(STATUS "CXX Compiler version=${CMAKE_CXX_COMPILER_VERSION}")
 
+if(MLLM_ENABLE_PY_MLLM)
+  add_compile_definitions(MLLM_ENABLE_PY_MLLM=1)
+endif()
+
 include(cmake/CPM.cmake)
 set(STDEXEC_BUILD_EXAMPLES OFF)
 CPMAddPackage(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -291,7 +291,8 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/mllmConfig.cmake
 
 # Pymllm install
 if(MLLM_ENABLE_PY_MLLM)
-  target_compile_options(MllmRT PRIVATE -fPIC)
+  add_compile_definitions(MLLM_ENABLE_PY_MLLM=1)
+  target_compile_options(MllmRT PRIVATE -fPIC -fvisibility=default)
 
   find_package(Python3 COMPONENTS Interpreter Development)
   include_directories(${Python3_INCLUDE_DIRS})

--- a/docker/Dockerfile.cu124
+++ b/docker/Dockerfile.cu124
@@ -2,9 +2,9 @@ FROM nvcr.io/nvidia/pytorch:24.05-py3
 
 WORKDIR /root
 
-RUN echo "LC_ALL=en_US.UTF-8" >> /etc/environment
-
-ENV DEBIAN_FRONTEND=noninteractive
+ENV DEBIAN_FRONTEND=noninteractive \
+    LC_ALL=en_US.UTF-8 \
+    PATH="/opt/conda/bin:$PATH"
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \

--- a/docker/README.md
+++ b/docker/README.md
@@ -7,8 +7,14 @@ To simplify developers' experience with MLLM, we provide ready-to-use Dockerfile
 ```bash
 git clone https://github.com/UbiquitousLearning/mllm.git
 cd mllm/docker
+
+# CPU
 docker build -t mllm_arm -f Dockerfile.arm .
 docker run -it --cap-add=SYS_ADMIN --network=host --cap-add=SYS_PTRACE --shm-size=4G --security-opt seccomp=unconfined --security-opt apparmor=unconfined --name mllm_arm_dev mllm_arm bash
+
+# NVIDIA GPU. Chose your CUDA version: Dockerfile.cuxxx
+docker build -t mllm_cu124 -f Dockerfile.cu124 .
+docker run -it --gpus all --cap-add=SYS_ADMIN --network=host --cap-add=SYS_PTRACE --shm-size=4G --security-opt seccomp=unconfined --security-opt apparmor=unconfined --name mllm_cu124_dev mllm_cu124 bash
 ```
 
 Important Notes:

--- a/mllm/core/ParameterFile.cpp
+++ b/mllm/core/ParameterFile.cpp
@@ -33,6 +33,18 @@ void ParameterFile::push(const std::string& name, const Tensor& tensor) {
   }
 }
 
+#ifdef MLLM_ENABLE_PY_MLLM
+void ParameterFile::__py_push(const std::string& name, const Tensor& tensor) {
+  if (data_.has(name)) {
+    MLLM_ERROR_EXIT(ExitCode::kIOError, "Parameter already exists: {}", name);
+  } else {
+    // The tensor is a py object. And may released in the feature.
+    // We need to recreate a Tensor descriptor in c++ side.
+    data_.reg(name, Tensor(tensor.impl()));
+  }
+}
+#endif
+
 Tensor ParameterFile::pull(const std::string& name) {
   if (!data_.has(name)) { MLLM_ERROR_EXIT(ExitCode::kIOError, "Parameter does not exist: {}", name); }
   return data_[name];

--- a/mllm/core/ParameterFile.hpp
+++ b/mllm/core/ParameterFile.hpp
@@ -41,6 +41,10 @@ class ParameterFile {
 
   void push(const std::string& name, const Tensor& tensor);
 
+#ifdef MLLM_ENABLE_PY_MLLM
+  void __py_push(const std::string& name, const Tensor& tensor);
+#endif
+
   Tensor pull(const std::string& name);
 
   [[nodiscard]] bool has(const std::string& name) const;

--- a/pymllm/_C.pyi
+++ b/pymllm/_C.pyi
@@ -2,7 +2,10 @@ from __future__ import annotations
 import collections.abc
 import typing
 import typing_extensions
-__all__: list[str] = ['AbstractNnNode', 'Backend', 'BaseOp', 'BaseOpOptionsBase', 'CXXLayer', 'CXXModule', 'CausalMaskOpOptions', 'ConfigFile', 'Context', 'DataTypes', 'DeviceTypes', 'Dispatcher', 'DispatcherManager', 'DispatcherManagerOptions', 'EmbeddingOpOptions', 'GELUOpOptions', 'KVCacheOpOptions', 'LayerImpl', 'LayerNormOpOptions', 'LinearImplTypes', 'LinearOp', 'LinearOpOptions', 'MemoryManager', 'MemoryManagerOptions', 'ModelFileVersion', 'ModuleImpl', 'OpTypes', 'ParameterFile', 'RMSNormOpOptions', 'SessionTCB', 'SiLUOpOptions', 'SoftmaxOpOptions', 'Task', 'TaskTypes', 'Tensor', 'TensorMemTypes', 'clean_this_thread', 'initialize_context', 'is_opencl_available', 'is_qnn_available', 'load', 'memory_report', 'save', 'set_maximum_num_threads', 'set_random_seed', 'shutdown_context', 'this_thread']
+__all__ = ['AbsOpOptions', 'AbstractNnNode', 'AddOpOptions', 'Backend', 'BaseOp', 'BaseOpOptionsBase', 'CXXLayer', 'CXXModule', 'CastTypeOpOptions', 'CausalMaskOpOptions', 'ClipOpOptions', 'CloneOpOptions', 'ConcatOpOptions', 'ConfigFile', 'Context', 'ContiguousOpOptions', 'Conv1DOpOptions', 'Conv3DOpOptions', 'CopyOpOptions', 'CosOpOptions', 'DataTypes', 'DeviceTypes', 'Dispatcher', 'DispatcherManager', 'DispatcherManagerOptions', 'DivOpOptions', 'EmbeddingOpOptions', 'ExpOpOptions', 'FillOpOptions', 'FlashAttention2OpOptions', 'GELUOpOptions', 'GraphBeginOpOptions', 'GraphEndOpOptions', 'ISTFTOpOptions', 'IndexOpOptions', 'KVCacheOpOptions', 'LayerImpl', 'LayerNormOpOptions', 'LinearImplTypes', 'LinearOp', 'LinearOpOptions', 'LogOpOptions', 'MatMulOpOptions', 'MeanOpOptions', 'MemoryManager', 'MemoryManagerOptions', 'ModelFileVersion', 'ModuleImpl', 'MulOpOptions', 'MultimodalRoPEOpOptions', 'NegOpOptions', 'OpTypes', 'ParamOpOptions', 'ParameterFile', 'PermuteOpOptions', 'QuickGELUOpOptions', 'Qwen2VLRoPEOpOptions', 'RMSNormOpOptions', 'ReLUOpOptions', 'ReduceMaxOpOptions', 'ReduceMinOpOptions', 'ReduceSumOpOptions', 'RepeatOpOptions', 'ReshapeOpOptions', 'STFTOpOptions', 'SessionTCB', 'SiLUOpOptions', 'SinOpOptions', 'SliceOpOptions', 'SoftmaxOpOptions', 'SplitOpOptions', 'SubOpOptions', 'Task', 'TaskTypes', 'Tensor', 'TensorMemTypes', 'TopKOpOptions', 'TransposeOpOptions', 'ViewOpOptions', 'VisionRoPEOpOptions', 'X2XOpOptions', 'clean_this_thread', 'initialize_context', 'is_opencl_available', 'is_qnn_available', 'load', 'memory_report', 'save', 'set_maximum_num_threads', 'set_random_seed', 'shutdown_context', 'this_thread']
+class AbsOpOptions:
+    def __init__(self) -> None:
+        ...
 class AbstractNnNode:
     def depth_decrease(self) -> None:
         ...
@@ -34,6 +37,9 @@ class AbstractNnNode:
         ...
     def set_name(self, arg0: str) -> None:
         ...
+class AddOpOptions:
+    def __init__(self) -> None:
+        ...
 class Backend:
     def create_op(self, arg0: OpTypes, arg1: BaseOpOptionsBase) -> BaseOp:
         ...
@@ -61,7 +67,12 @@ class BaseOp:
     def trace(self, arg0: typing_extensions.CapsuleType, arg1: collections.abc.Sequence[Tensor], arg2: collections.abc.Sequence[Tensor]) -> None:
         ...
 class BaseOpOptionsBase:
-    pass
+    @typing.overload
+    def __init__(self, arg0: LinearOpOptions) -> None:
+        ...
+    @typing.overload
+    def __init__(self, arg0: ClipOpOptions) -> None:
+        ...
 class CXXLayer:
     def __init__(self, impl: LayerImpl) -> None:
         ...
@@ -76,15 +87,53 @@ class CXXModule:
         ...
     def __trace(self, arg0: collections.abc.Sequence[Tensor], arg1: collections.abc.Sequence[...]) -> list[Tensor]:
         ...
+class CastTypeOpOptions:
+    def __init__(self) -> None:
+        ...
 class CausalMaskOpOptions:
     sliding_window: bool
+    @typing.overload
     def __init__(self) -> None:
+        ...
+    @typing.overload
+    def __init__(self, sliding_window: bool = False, window_size: typing.SupportsInt = 0) -> None:
         ...
     @property
     def window_size(self) -> int:
         ...
     @window_size.setter
     def window_size(self, arg0: typing.SupportsInt) -> None:
+        ...
+class ClipOpOptions:
+    def __init__(self) -> None:
+        ...
+    @property
+    def max_val(self) -> float:
+        ...
+    @max_val.setter
+    def max_val(self, arg0: typing.SupportsFloat) -> None:
+        ...
+    @property
+    def min_val(self) -> float:
+        ...
+    @min_val.setter
+    def min_val(self, arg0: typing.SupportsFloat) -> None:
+        ...
+class CloneOpOptions:
+    def __init__(self) -> None:
+        ...
+class ConcatOpOptions:
+    @typing.overload
+    def __init__(self) -> None:
+        ...
+    @typing.overload
+    def __init__(self, dim: typing.SupportsInt = 0) -> None:
+        ...
+    @property
+    def dim(self) -> int:
+        ...
+    @dim.setter
+    def dim(self, arg0: typing.SupportsInt) -> None:
         ...
 class ConfigFile:
     @typing.overload
@@ -107,6 +156,8 @@ class Context:
     @staticmethod
     def instance() -> Context:
         ...
+    def build_op_and_submit_task(self, arg0: OpTypes, arg1: BaseOpOptionsBase, arg2: collections.abc.Sequence[Tensor], arg3: DeviceTypes) -> list[Tensor]:
+        ...
     def dispatcher_manager(self) -> DispatcherManager:
         ...
     def get_backend(self, arg0: DeviceTypes) -> Backend:
@@ -124,6 +175,84 @@ class Context:
     def set_random_seed(self, arg0: typing.SupportsInt) -> None:
         ...
     def this_thread(self) -> SessionTCB:
+        ...
+class ContiguousOpOptions:
+    def __init__(self) -> None:
+        ...
+class Conv1DOpOptions:
+    bias: bool
+    def __init__(self) -> None:
+        ...
+    @property
+    def groups(self) -> int:
+        ...
+    @groups.setter
+    def groups(self, arg0: typing.SupportsInt) -> None:
+        ...
+    @property
+    def in_channels(self) -> int:
+        ...
+    @in_channels.setter
+    def in_channels(self, arg0: typing.SupportsInt) -> None:
+        ...
+    @property
+    def kernel_size(self) -> int:
+        ...
+    @kernel_size.setter
+    def kernel_size(self, arg0: typing.SupportsInt) -> None:
+        ...
+    @property
+    def out_channels(self) -> int:
+        ...
+    @out_channels.setter
+    def out_channels(self, arg0: typing.SupportsInt) -> None:
+        ...
+    @property
+    def padding(self) -> int:
+        ...
+    @padding.setter
+    def padding(self, arg0: typing.SupportsInt) -> None:
+        ...
+    @property
+    def stride(self) -> int:
+        ...
+    @stride.setter
+    def stride(self, arg0: typing.SupportsInt) -> None:
+        ...
+class Conv3DOpOptions:
+    bias: bool
+    impl_type: ...
+    def __init__(self) -> None:
+        ...
+    @property
+    def in_channels(self) -> int:
+        ...
+    @in_channels.setter
+    def in_channels(self, arg0: typing.SupportsInt) -> None:
+        ...
+    @property
+    def kernel_size(self) -> list[int]:
+        ...
+    @kernel_size.setter
+    def kernel_size(self, arg0: collections.abc.Sequence[typing.SupportsInt]) -> None:
+        ...
+    @property
+    def out_channels(self) -> int:
+        ...
+    @out_channels.setter
+    def out_channels(self, arg0: typing.SupportsInt) -> None:
+        ...
+    @property
+    def stride(self) -> list[int]:
+        ...
+    @stride.setter
+    def stride(self, arg0: collections.abc.Sequence[typing.SupportsInt]) -> None:
+        ...
+class CopyOpOptions:
+    def __init__(self) -> None:
+        ...
+class CosOpOptions:
+    def __init__(self) -> None:
         ...
 class DataTypes:
     """
@@ -314,8 +443,15 @@ class DispatcherManagerOptions:
     @num_threads.setter
     def num_threads(self, arg0: typing.SupportsInt) -> None:
         ...
-class EmbeddingOpOptions:
+class DivOpOptions:
     def __init__(self) -> None:
+        ...
+class EmbeddingOpOptions:
+    @typing.overload
+    def __init__(self) -> None:
+        ...
+    @typing.overload
+    def __init__(self, vocab_size: typing.SupportsInt = 0, hidden_size: typing.SupportsInt = 0) -> None:
         ...
     @property
     def hidden_size(self) -> int:
@@ -329,12 +465,132 @@ class EmbeddingOpOptions:
     @vocab_size.setter
     def vocab_size(self, arg0: typing.SupportsInt) -> None:
         ...
+class ExpOpOptions:
+    def __init__(self) -> None:
+        ...
+class FillOpOptions:
+    type: ...
+    def __init__(self) -> None:
+        ...
+    @property
+    def end(self) -> float:
+        ...
+    @end.setter
+    def end(self, arg0: typing.SupportsFloat) -> None:
+        ...
+    @property
+    def seed(self) -> int:
+        ...
+    @seed.setter
+    def seed(self, arg0: typing.SupportsInt) -> None:
+        ...
+    @property
+    def start(self) -> float:
+        ...
+    @start.setter
+    def start(self, arg0: typing.SupportsFloat) -> None:
+        ...
+    @property
+    def step(self) -> float:
+        ...
+    @step.setter
+    def step(self, arg0: typing.SupportsFloat) -> None:
+        ...
+    @property
+    def value(self) -> float:
+        ...
+    @value.setter
+    def value(self, arg0: typing.SupportsFloat) -> None:
+        ...
+class FlashAttention2OpOptions:
+    causal_mask: bool
+    hp_exp: bool
+    @typing.overload
+    def __init__(self) -> None:
+        ...
+    @typing.overload
+    def __init__(self, B: typing.SupportsInt = 0, q_head: typing.SupportsInt = 0, kv_head: typing.SupportsInt = 0, D: typing.SupportsInt = 0, hp_exp: typing.SupportsInt = 0, causal_mask: bool = False) -> None:
+        ...
+    @property
+    def B(self) -> int:
+        ...
+    @B.setter
+    def B(self, arg0: typing.SupportsInt) -> None:
+        ...
+    @property
+    def D(self) -> int:
+        ...
+    @D.setter
+    def D(self, arg0: typing.SupportsInt) -> None:
+        ...
+    @property
+    def kv_head(self) -> int:
+        ...
+    @kv_head.setter
+    def kv_head(self, arg0: typing.SupportsInt) -> None:
+        ...
+    @property
+    def q_head(self) -> int:
+        ...
+    @q_head.setter
+    def q_head(self, arg0: typing.SupportsInt) -> None:
+        ...
 class GELUOpOptions:
     def __init__(self) -> None:
         ...
+class GraphBeginOpOptions:
+    def __init__(self) -> None:
+        ...
+class GraphEndOpOptions:
+    def __init__(self) -> None:
+        ...
+class ISTFTOpOptions:
+    center: bool
+    normalized: bool
+    onesided: bool
+    pad_mode: str
+    def __init__(self) -> None:
+        ...
+    @property
+    def hop_length(self) -> int:
+        ...
+    @hop_length.setter
+    def hop_length(self, arg0: typing.SupportsInt) -> None:
+        ...
+    @property
+    def length(self) -> int:
+        ...
+    @length.setter
+    def length(self, arg0: typing.SupportsInt) -> None:
+        ...
+    @property
+    def n_fft(self) -> int:
+        ...
+    @n_fft.setter
+    def n_fft(self, arg0: typing.SupportsInt) -> None:
+        ...
+    @property
+    def win_length(self) -> int:
+        ...
+    @win_length.setter
+    def win_length(self, arg0: typing.SupportsInt) -> None:
+        ...
+class IndexOpOptions:
+    def __init__(self) -> None:
+        ...
+    @property
+    def indices_(self) -> list[...]:
+        ...
+    @indices_.setter
+    def indices_(self, arg0: collections.abc.Sequence[...]) -> None:
+        ...
 class KVCacheOpOptions:
     use_fa2: bool
+    @typing.overload
     def __init__(self) -> None:
+        ...
+    @typing.overload
+    def __init__(self, layer_idx: typing.SupportsInt = 0, q_head: typing.SupportsInt = 0, kv_head: typing.SupportsInt = 0, head_dim: typing.SupportsInt = 0, use_fa2: bool = False) -> None:
         ...
     @property
     def head_dim(self) -> int:
@@ -378,7 +634,11 @@ class LayerImpl(AbstractNnNode):
 class LayerNormOpOptions:
     bias: bool
     elementwise_affine: bool
+    @typing.overload
     def __init__(self) -> None:
+        ...
+    @typing.overload
+    def __init__(self, normalized_shape: collections.abc.Sequence[typing.SupportsInt] = [], elementwise_affine: bool = True, bias: bool = True, eps: typing.SupportsFloat = 9.999999747378752e-06) -> None:
         ...
     @property
     def eps(self) -> float:
@@ -486,6 +746,29 @@ class LinearOpOptions:
     @out_channels.setter
     def out_channels(self, arg0: typing.SupportsInt) -> None:
         ...
+class LogOpOptions:
+    def __init__(self) -> None:
+        ...
+class MatMulOpOptions:
+    matmul_type: ...
+    transpose_a: bool
+    transpose_b: bool
+    @typing.overload
+    def __init__(self) -> None:
+        ...
+    @typing.overload
+    def __init__(self, transpose_a: bool = False, transpose_b: bool = False, matmul_type: str = 'Default') -> None:
+        ...
+class MeanOpOptions:
+    keep_dim: bool
+    def __init__(self) -> None:
+        ...
+    @property
+    def dim(self) -> int:
+        ...
+    @dim.setter
+    def dim(self, arg0: typing.SupportsInt) -> None:
+        ...
 class MemoryManager:
     def clear_all(self) -> None:
         ...
@@ -550,6 +833,15 @@ class ModuleImpl(AbstractNnNode):
         ...
     def to(self, arg0: DeviceTypes) -> None:
         ...
+class MulOpOptions:
+    def __init__(self) -> None:
+        ...
+class MultimodalRoPEOpOptions:
+    def __init__(self) -> None:
+        ...
+class NegOpOptions:
+    def __init__(self) -> None:
+        ...
 class OpTypes:
     """
     Members:
@@ -575,6 +867,10 @@ class OpTypes:
       RoPE
     
       Softmax
+    
+      STFT
+    
+      ISTFT
     
       Transpose
     
@@ -638,15 +934,39 @@ class OpTypes:
     
       Reshape
     
+      Slice
+    
+      Param
+    
+      Index
+    
+      Abs
+    
+      Log
+    
+      TopK
+    
+      Mean
+    
+      Clip
+    
+      Exp
+    
+      Sin
+    
+      Cos
+    
       GraphBegin
     
       GraphEnd
     
       OpType_End
     """
+    Abs: typing.ClassVar[OpTypes]  # value = <OpTypes.Abs: 47>
     Add: typing.ClassVar[OpTypes]  # value = <OpTypes.Add: 2>
     CastType: typing.ClassVar[OpTypes]  # value = <OpTypes.CastType: 18>
     CausalMask: typing.ClassVar[OpTypes]  # value = <OpTypes.CausalMask: 17>
+    Clip: typing.ClassVar[OpTypes]  # value = <OpTypes.Clip: 51>
     Clone: typing.ClassVar[OpTypes]  # value = <OpTypes.Clone: 34>
     Concat: typing.ClassVar[OpTypes]  # value = <OpTypes.Concat: 36>
     Contiguous: typing.ClassVar[OpTypes]  # value = <OpTypes.Contiguous: 42>
@@ -654,22 +974,29 @@ class OpTypes:
     Conv2D: typing.ClassVar[OpTypes]  # value = <OpTypes.Conv2D: 26>
     Conv3D: typing.ClassVar[OpTypes]  # value = <OpTypes.Conv3D: 25>
     Copy: typing.ClassVar[OpTypes]  # value = <OpTypes.Copy: 33>
+    Cos: typing.ClassVar[OpTypes]  # value = <OpTypes.Cos: 54>
     Div: typing.ClassVar[OpTypes]  # value = <OpTypes.Div: 5>
     Embedding: typing.ClassVar[OpTypes]  # value = <OpTypes.Embedding: 7>
+    Exp: typing.ClassVar[OpTypes]  # value = <OpTypes.Exp: 52>
     Fill: typing.ClassVar[OpTypes]  # value = <OpTypes.Fill: 1>
     FlashAttention2: typing.ClassVar[OpTypes]  # value = <OpTypes.FlashAttention2: 22>
     GELU: typing.ClassVar[OpTypes]  # value = <OpTypes.GELU: 28>
     GraphBegin: typing.ClassVar[OpTypes]  # value = <OpTypes.GraphBegin: 55>
     GraphEnd: typing.ClassVar[OpTypes]  # value = <OpTypes.GraphEnd: 56>
+    ISTFT: typing.ClassVar[OpTypes]  # value = <OpTypes.ISTFT: 12>
+    Index: typing.ClassVar[OpTypes]  # value = <OpTypes.Index: 46>
     KVCache: typing.ClassVar[OpTypes]  # value = <OpTypes.KVCache: 16>
     LayerNorm: typing.ClassVar[OpTypes]  # value = <OpTypes.LayerNorm: 29>
     Linear: typing.ClassVar[OpTypes]  # value = <OpTypes.Linear: 8>
+    Log: typing.ClassVar[OpTypes]  # value = <OpTypes.Log: 48>
     MatMul: typing.ClassVar[OpTypes]  # value = <OpTypes.MatMul: 6>
+    Mean: typing.ClassVar[OpTypes]  # value = <OpTypes.Mean: 50>
     Mul: typing.ClassVar[OpTypes]  # value = <OpTypes.Mul: 4>
     MultimodalRoPE: typing.ClassVar[OpTypes]  # value = <OpTypes.MultimodalRoPE: 30>
     Neg: typing.ClassVar[OpTypes]  # value = <OpTypes.Neg: 35>
     OpType_End: typing.ClassVar[OpTypes]  # value = <OpTypes.OpType_End: 57>
     OpType_Start: typing.ClassVar[OpTypes]  # value = <OpTypes.OpType_Start: 0>
+    Param: typing.ClassVar[OpTypes]  # value = <OpTypes.Param: 45>
     Permute: typing.ClassVar[OpTypes]  # value = <OpTypes.Permute: 24>
     QuickGELU: typing.ClassVar[OpTypes]  # value = <OpTypes.QuickGELU: 32>
     RMSNorm: typing.ClassVar[OpTypes]  # value = <OpTypes.RMSNorm: 14>
@@ -681,15 +1008,19 @@ class OpTypes:
     Repeat: typing.ClassVar[OpTypes]  # value = <OpTypes.Repeat: 23>
     Reshape: typing.ClassVar[OpTypes]  # value = <OpTypes.Reshape: 43>
     RoPE: typing.ClassVar[OpTypes]  # value = <OpTypes.RoPE: 9>
+    STFT: typing.ClassVar[OpTypes]  # value = <OpTypes.STFT: 11>
     SiLU: typing.ClassVar[OpTypes]  # value = <OpTypes.SiLU: 15>
+    Sin: typing.ClassVar[OpTypes]  # value = <OpTypes.Sin: 53>
+    Slice: typing.ClassVar[OpTypes]  # value = <OpTypes.Slice: 44>
     Softmax: typing.ClassVar[OpTypes]  # value = <OpTypes.Softmax: 10>
     Split: typing.ClassVar[OpTypes]  # value = <OpTypes.Split: 20>
     Sub: typing.ClassVar[OpTypes]  # value = <OpTypes.Sub: 3>
+    TopK: typing.ClassVar[OpTypes]  # value = <OpTypes.TopK: 49>
     Transpose: typing.ClassVar[OpTypes]  # value = <OpTypes.Transpose: 13>
     View: typing.ClassVar[OpTypes]  # value = <OpTypes.View: 21>
     VisionRoPE: typing.ClassVar[OpTypes]  # value = <OpTypes.VisionRoPE: 31>
     X2X: typing.ClassVar[OpTypes]  # value = <OpTypes.X2X: 19>
-    __members__: typing.ClassVar[dict[str, OpTypes]]  # value = {'OpType_Start': <OpTypes.OpType_Start: 0>, 'Fill': <OpTypes.Fill: 1>, 'Add': <OpTypes.Add: 2>, 'Sub': <OpTypes.Sub: 3>, 'Mul': <OpTypes.Mul: 4>, 'Div': <OpTypes.Div: 5>, 'MatMul': <OpTypes.MatMul: 6>, 'Embedding': <OpTypes.Embedding: 7>, 'Linear': <OpTypes.Linear: 8>, 'RoPE': <OpTypes.RoPE: 9>, 'Softmax': <OpTypes.Softmax: 10>, 'Transpose': <OpTypes.Transpose: 13>, 'RMSNorm': <OpTypes.RMSNorm: 14>, 'SiLU': <OpTypes.SiLU: 15>, 'KVCache': <OpTypes.KVCache: 16>, 'CausalMask': <OpTypes.CausalMask: 17>, 'CastType': <OpTypes.CastType: 18>, 'X2X': <OpTypes.X2X: 19>, 'Split': <OpTypes.Split: 20>, 'View': <OpTypes.View: 21>, 'FlashAttention2': <OpTypes.FlashAttention2: 22>, 'Repeat': <OpTypes.Repeat: 23>, 'Permute': <OpTypes.Permute: 24>, 'Conv3D': <OpTypes.Conv3D: 25>, 'Conv2D': <OpTypes.Conv2D: 26>, 'Conv1D': <OpTypes.Conv1D: 27>, 'GELU': <OpTypes.GELU: 28>, 'LayerNorm': <OpTypes.LayerNorm: 29>, 'MultimodalRoPE': <OpTypes.MultimodalRoPE: 30>, 'VisionRoPE': <OpTypes.VisionRoPE: 31>, 'QuickGELU': <OpTypes.QuickGELU: 32>, 'Copy': <OpTypes.Copy: 33>, 'Clone': <OpTypes.Clone: 34>, 'Neg': <OpTypes.Neg: 35>, 'Concat': <OpTypes.Concat: 36>, 'ReLU': <OpTypes.ReLU: 37>, 'ReLU2': <OpTypes.ReLU2: 38>, 'ReduceMax': <OpTypes.ReduceMax: 39>, 'ReduceMin': <OpTypes.ReduceMin: 40>, 'ReduceSum': <OpTypes.ReduceSum: 41>, 'Contiguous': <OpTypes.Contiguous: 42>, 'Reshape': <OpTypes.Reshape: 43>, 'GraphBegin': <OpTypes.GraphBegin: 55>, 'GraphEnd': <OpTypes.GraphEnd: 56>, 'OpType_End': <OpTypes.OpType_End: 57>}
+    __members__: typing.ClassVar[dict[str, OpTypes]]  # value = {'OpType_Start': <OpTypes.OpType_Start: 0>, 'Fill': <OpTypes.Fill: 1>, 'Add': <OpTypes.Add: 2>, 'Sub': <OpTypes.Sub: 3>, 'Mul': <OpTypes.Mul: 4>, 'Div': <OpTypes.Div: 5>, 'MatMul': <OpTypes.MatMul: 6>, 'Embedding': <OpTypes.Embedding: 7>, 'Linear': <OpTypes.Linear: 8>, 'RoPE': <OpTypes.RoPE: 9>, 'Softmax': <OpTypes.Softmax: 10>, 'STFT': <OpTypes.STFT: 11>, 'ISTFT': <OpTypes.ISTFT: 12>, 'Transpose': <OpTypes.Transpose: 13>, 'RMSNorm': <OpTypes.RMSNorm: 14>, 'SiLU': <OpTypes.SiLU: 15>, 'KVCache': <OpTypes.KVCache: 16>, 'CausalMask': <OpTypes.CausalMask: 17>, 'CastType': <OpTypes.CastType: 18>, 'X2X': <OpTypes.X2X: 19>, 'Split': <OpTypes.Split: 20>, 'View': <OpTypes.View: 21>, 'FlashAttention2': <OpTypes.FlashAttention2: 22>, 'Repeat': <OpTypes.Repeat: 23>, 'Permute': <OpTypes.Permute: 24>, 'Conv3D': <OpTypes.Conv3D: 25>, 'Conv2D': <OpTypes.Conv2D: 26>, 'Conv1D': <OpTypes.Conv1D: 27>, 'GELU': <OpTypes.GELU: 28>, 'LayerNorm': <OpTypes.LayerNorm: 29>, 'MultimodalRoPE': <OpTypes.MultimodalRoPE: 30>, 'VisionRoPE': <OpTypes.VisionRoPE: 31>, 'QuickGELU': <OpTypes.QuickGELU: 32>, 'Copy': <OpTypes.Copy: 33>, 'Clone': <OpTypes.Clone: 34>, 'Neg': <OpTypes.Neg: 35>, 'Concat': <OpTypes.Concat: 36>, 'ReLU': <OpTypes.ReLU: 37>, 'ReLU2': <OpTypes.ReLU2: 38>, 'ReduceMax': <OpTypes.ReduceMax: 39>, 'ReduceMin': <OpTypes.ReduceMin: 40>, 'ReduceSum': <OpTypes.ReduceSum: 41>, 'Contiguous': <OpTypes.Contiguous: 42>, 'Reshape': <OpTypes.Reshape: 43>, 'Slice': <OpTypes.Slice: 44>, 'Param': <OpTypes.Param: 45>, 'Index': <OpTypes.Index: 46>, 'Abs': <OpTypes.Abs: 47>, 'Log': <OpTypes.Log: 48>, 'TopK': <OpTypes.TopK: 49>, 'Mean': <OpTypes.Mean: 50>, 'Clip': <OpTypes.Clip: 51>, 'Exp': <OpTypes.Exp: 52>, 'Sin': <OpTypes.Sin: 53>, 'Cos': <OpTypes.Cos: 54>, 'GraphBegin': <OpTypes.GraphBegin: 55>, 'GraphEnd': <OpTypes.GraphEnd: 56>, 'OpType_End': <OpTypes.OpType_End: 57>}
     def __eq__(self, other: typing.Any) -> bool:
         ...
     def __getstate__(self) -> int:
@@ -716,6 +1047,9 @@ class OpTypes:
     @property
     def value(self) -> int:
         ...
+class ParamOpOptions:
+    def __init__(self) -> None:
+        ...
 class ParameterFile:
     def __init__(self, v: ModelFileVersion = ...) -> None:
         ...
@@ -727,6 +1061,43 @@ class ParameterFile:
         ...
     def remove(self, arg0: str) -> None:
         ...
+class PermuteOpOptions:
+    @typing.overload
+    def __init__(self) -> None:
+        ...
+    @typing.overload
+    def __init__(self, axis: collections.abc.Sequence[typing.SupportsInt] = []) -> None:
+        ...
+    @property
+    def axis(self) -> list[int]:
+        ...
+    @axis.setter
+    def axis(self, arg0: collections.abc.Sequence[typing.SupportsInt]) -> None:
+        ...
+class QuickGELUOpOptions:
+    def __init__(self) -> None:
+        ...
+class Qwen2VLRoPEOpOptions:
+    def __init__(self) -> None:
+        ...
+    @property
+    def dims(self) -> int:
+        ...
+    @dims.setter
+    def dims(self, arg0: typing.SupportsInt) -> None:
+        ...
+    @property
+    def spatial_merge_size(self) -> int:
+        ...
+    @spatial_merge_size.setter
+    def spatial_merge_size(self, arg0: typing.SupportsInt) -> None:
+        ...
+    @property
+    def theta(self) -> float:
+        ...
+    @theta.setter
+    def theta(self, arg0: typing.SupportsFloat) -> None:
+        ...
 class RMSNormOpOptions:
     add_unit_offset: bool
     def __init__(self) -> None:
@@ -737,19 +1108,129 @@ class RMSNormOpOptions:
     @epsilon.setter
     def epsilon(self, arg0: typing.SupportsFloat) -> None:
         ...
+class ReLUOpOptions:
+    def __init__(self) -> None:
+        ...
+class ReduceMaxOpOptions:
+    keep_dim: bool
+    def __init__(self) -> None:
+        ...
+    @property
+    def dim(self) -> int:
+        ...
+    @dim.setter
+    def dim(self, arg0: typing.SupportsInt) -> None:
+        ...
+class ReduceMinOpOptions:
+    keep_dim: bool
+    def __init__(self) -> None:
+        ...
+    @property
+    def dim(self) -> int:
+        ...
+    @dim.setter
+    def dim(self, arg0: typing.SupportsInt) -> None:
+        ...
+class ReduceSumOpOptions:
+    keep_dim: bool
+    def __init__(self) -> None:
+        ...
+    @property
+    def dim(self) -> int:
+        ...
+    @dim.setter
+    def dim(self, arg0: typing.SupportsInt) -> None:
+        ...
+class RepeatOpOptions:
+    def __init__(self) -> None:
+        ...
+class ReshapeOpOptions:
+    @typing.overload
+    def __init__(self) -> None:
+        ...
+    @typing.overload
+    def __init__(self, shape: collections.abc.Sequence[typing.SupportsInt] = []) -> None:
+        ...
+    @property
+    def shape(self) -> list[int]:
+        ...
+    @shape.setter
+    def shape(self, arg0: collections.abc.Sequence[typing.SupportsInt]) -> None:
+        ...
+class STFTOpOptions:
+    center: bool
+    onesided: bool
+    pad_mode: str
+    return_complex: bool
+    @typing.overload
+    def __init__(self) -> None:
+        ...
+    @typing.overload
+    def __init__(self, n_fft: typing.SupportsInt, hop_length: typing.SupportsInt, win_length: typing.SupportsInt, onesided: bool, center: bool, pad_mode: str = 'constant', return_complex: bool = False) -> None:
+        ...
+    @property
+    def hop_length(self) -> int:
+        ...
+    @hop_length.setter
+    def hop_length(self, arg0: typing.SupportsInt) -> None:
+        ...
+    @property
+    def n_fft(self) -> int:
+        ...
+    @n_fft.setter
+    def n_fft(self, arg0: typing.SupportsInt) -> None:
+        ...
+    @property
+    def win_length(self) -> int:
+        ...
+    @win_length.setter
+    def win_length(self, arg0: typing.SupportsInt) -> None:
+        ...
 class SessionTCB:
     trace_mode: bool
 class SiLUOpOptions:
     def __init__(self) -> None:
         ...
-class SoftmaxOpOptions:
+class SinOpOptions:
     def __init__(self) -> None:
+        ...
+class SliceOpOptions:
+    def __init__(self) -> None:
+        ...
+class SoftmaxOpOptions:
+    @typing.overload
+    def __init__(self) -> None:
+        ...
+    @typing.overload
+    def __init__(self, axis: typing.SupportsInt = 0) -> None:
         ...
     @property
     def axis(self) -> int:
         ...
     @axis.setter
     def axis(self, arg0: typing.SupportsInt) -> None:
+        ...
+class SplitOpOptions:
+    @typing.overload
+    def __init__(self) -> None:
+        ...
+    @typing.overload
+    def __init__(self, dim: typing.SupportsInt, split_size_or_sections: collections.abc.Sequence[typing.SupportsInt]) -> None:
+        ...
+    @property
+    def dim(self) -> int:
+        ...
+    @dim.setter
+    def dim(self, arg0: typing.SupportsInt) -> None:
+        ...
+    @property
+    def split_size_or_sections(self) -> list[int]:
+        ...
+    @split_size_or_sections.setter
+    def split_size_or_sections(self, arg0: collections.abc.Sequence[typing.SupportsInt]) -> None:
+        ...
+class SubOpOptions:
+    def __init__(self) -> None:
         ...
 class Task:
     custom_context_ptr: typing_extensions.CapsuleType
@@ -992,6 +1473,41 @@ class TensorMemTypes:
         ...
     @property
     def value(self) -> int:
+        ...
+class TopKOpOptions:
+    largest: bool
+    sorted: bool
+    def __init__(self) -> None:
+        ...
+    @property
+    def dim(self) -> int:
+        ...
+    @dim.setter
+    def dim(self, arg0: typing.SupportsInt) -> None:
+        ...
+    @property
+    def k(self) -> int:
+        ...
+    @k.setter
+    def k(self, arg0: typing.SupportsInt) -> None:
+        ...
+class TransposeOpOptions:
+    def __init__(self) -> None:
+        ...
+class ViewOpOptions:
+    def __init__(self) -> None:
+        ...
+    @property
+    def to_shape(self) -> list[int]:
+        ...
+    @to_shape.setter
+    def to_shape(self, arg0: collections.abc.Sequence[typing.SupportsInt]) -> None:
+        ...
+class VisionRoPEOpOptions:
+    def __init__(self) -> None:
+        ...
+class X2XOpOptions:
+    def __init__(self) -> None:
         ...
 def clean_this_thread() -> None:
     """

--- a/pymllm/_C.pyi
+++ b/pymllm/_C.pyi
@@ -2,7 +2,7 @@ from __future__ import annotations
 import collections.abc
 import typing
 import typing_extensions
-__all__ = ['AbstractNnNode', 'Backend', 'BaseOp', 'BaseOpOptionsBase', 'CXXLayer', 'CXXModule', 'ConfigFile', 'Context', 'DataTypes', 'DeviceTypes', 'Dispatcher', 'DispatcherManager', 'DispatcherManagerOptions', 'LayerImpl', 'LinearImplTypes', 'LinearOp', 'LinearOpOptions', 'MemoryManager', 'MemoryManagerOptions', 'ModelFileVersion', 'ModuleImpl', 'OpTypes', 'ParameterFile', 'SessionTCB', 'Task', 'TaskTypes', 'Tensor', 'TensorMemTypes', 'clean_this_thread', 'initialize_context', 'is_opencl_available', 'is_qnn_available', 'load', 'memory_report', 'save', 'set_maximum_num_threads', 'set_random_seed', 'shutdown_context', 'this_thread']
+__all__: list[str] = ['AbstractNnNode', 'Backend', 'BaseOp', 'BaseOpOptionsBase', 'CXXLayer', 'CXXModule', 'CausalMaskOpOptions', 'ConfigFile', 'Context', 'DataTypes', 'DeviceTypes', 'Dispatcher', 'DispatcherManager', 'DispatcherManagerOptions', 'EmbeddingOpOptions', 'GELUOpOptions', 'KVCacheOpOptions', 'LayerImpl', 'LayerNormOpOptions', 'LinearImplTypes', 'LinearOp', 'LinearOpOptions', 'MemoryManager', 'MemoryManagerOptions', 'ModelFileVersion', 'ModuleImpl', 'OpTypes', 'ParameterFile', 'RMSNormOpOptions', 'SessionTCB', 'SiLUOpOptions', 'SoftmaxOpOptions', 'Task', 'TaskTypes', 'Tensor', 'TensorMemTypes', 'clean_this_thread', 'initialize_context', 'is_opencl_available', 'is_qnn_available', 'load', 'memory_report', 'save', 'set_maximum_num_threads', 'set_random_seed', 'shutdown_context', 'this_thread']
 class AbstractNnNode:
     def depth_decrease(self) -> None:
         ...
@@ -75,6 +75,16 @@ class CXXModule:
     def __send_graph_end(self, arg0: collections.abc.Sequence[Tensor]) -> None:
         ...
     def __trace(self, arg0: collections.abc.Sequence[Tensor], arg1: collections.abc.Sequence[...]) -> list[Tensor]:
+        ...
+class CausalMaskOpOptions:
+    sliding_window: bool
+    def __init__(self) -> None:
+        ...
+    @property
+    def window_size(self) -> int:
+        ...
+    @window_size.setter
+    def window_size(self, arg0: typing.SupportsInt) -> None:
         ...
 class ConfigFile:
     @typing.overload
@@ -304,6 +314,52 @@ class DispatcherManagerOptions:
     @num_threads.setter
     def num_threads(self, arg0: typing.SupportsInt) -> None:
         ...
+class EmbeddingOpOptions:
+    def __init__(self) -> None:
+        ...
+    @property
+    def hidden_size(self) -> int:
+        ...
+    @hidden_size.setter
+    def hidden_size(self, arg0: typing.SupportsInt) -> None:
+        ...
+    @property
+    def vocab_size(self) -> int:
+        ...
+    @vocab_size.setter
+    def vocab_size(self, arg0: typing.SupportsInt) -> None:
+        ...
+class GELUOpOptions:
+    def __init__(self) -> None:
+        ...
+class KVCacheOpOptions:
+    use_fa2: bool
+    def __init__(self) -> None:
+        ...
+    @property
+    def head_dim(self) -> int:
+        ...
+    @head_dim.setter
+    def head_dim(self, arg0: typing.SupportsInt) -> None:
+        ...
+    @property
+    def kv_head(self) -> int:
+        ...
+    @kv_head.setter
+    def kv_head(self, arg0: typing.SupportsInt) -> None:
+        ...
+    @property
+    def layer_idx(self) -> int:
+        ...
+    @layer_idx.setter
+    def layer_idx(self, arg0: typing.SupportsInt) -> None:
+        ...
+    @property
+    def q_head(self) -> int:
+        ...
+    @q_head.setter
+    def q_head(self, arg0: typing.SupportsInt) -> None:
+        ...
 class LayerImpl(AbstractNnNode):
     def __init__(self, op_type: OpTypes, options: LinearOpOptions) -> None:
         ...
@@ -318,6 +374,23 @@ class LayerImpl(AbstractNnNode):
     def set_instanced_op(self, arg0: BaseOp) -> None:
         ...
     def to(self, arg0: DeviceTypes) -> None:
+        ...
+class LayerNormOpOptions:
+    bias: bool
+    elementwise_affine: bool
+    def __init__(self) -> None:
+        ...
+    @property
+    def eps(self) -> float:
+        ...
+    @eps.setter
+    def eps(self, arg0: typing.SupportsFloat) -> None:
+        ...
+    @property
+    def normalized_shape(self) -> list[int]:
+        ...
+    @normalized_shape.setter
+    def normalized_shape(self, arg0: collections.abc.Sequence[typing.SupportsInt]) -> None:
         ...
 class LinearImplTypes:
     """
@@ -654,8 +727,30 @@ class ParameterFile:
         ...
     def remove(self, arg0: str) -> None:
         ...
+class RMSNormOpOptions:
+    add_unit_offset: bool
+    def __init__(self) -> None:
+        ...
+    @property
+    def epsilon(self) -> float:
+        ...
+    @epsilon.setter
+    def epsilon(self, arg0: typing.SupportsFloat) -> None:
+        ...
 class SessionTCB:
     trace_mode: bool
+class SiLUOpOptions:
+    def __init__(self) -> None:
+        ...
+class SoftmaxOpOptions:
+    def __init__(self) -> None:
+        ...
+    @property
+    def axis(self) -> int:
+        ...
+    @axis.setter
+    def axis(self, arg0: typing.SupportsInt) -> None:
+        ...
 class Task:
     custom_context_ptr: typing_extensions.CapsuleType
     type: TaskTypes

--- a/pymllm/_C/Core.cpp
+++ b/pymllm/_C/Core.cpp
@@ -6,7 +6,28 @@
 #include "pymllm/_C/Core.hpp"
 
 #include "mllm/mllm.hpp"
+#include "mllm/core/BaseOp.hpp"
+#include "mllm/core/aops/LinearOp.hpp"
 #include "mllm/core/aops/GraphOps.hpp"
+#include "mllm/core/aops/ElewiseOps.hpp"
+#include "mllm/core/aops/ConcatOp.hpp"
+#include "mllm/core/aops/FillOp.hpp"
+#include "mllm/core/aops/FlashAttention2Op.hpp"
+#include "mllm/core/aops/IndexOp.hpp"
+#include "mllm/core/aops/ReduceOps.hpp"
+#include "mllm/core/aops/PermuteOp.hpp"
+#include "mllm/core/aops/SliceOp.hpp"
+#include "mllm/core/aops/ReshapeOp.hpp"
+#include "mllm/core/aops/RepeatOp.hpp"
+#include "mllm/core/aops/TopKOp.hpp"
+#include "mllm/core/aops/CloneOp.hpp"
+#include "mllm/core/aops/ContiguousOp.hpp"
+#include "mllm/core/aops/GraphOps.hpp"
+#include "mllm/core/aops/CastTypeOp.hpp"
+#include "mllm/core/aops/TransposeOp.hpp"
+#include "mllm/core/aops/X2XOp.hpp"
+#include "mllm/core/aops/ViewOp.hpp"
+#include "mllm/core/aops/CopyOp.hpp"
 
 void registerCoreBinding(py::module_& m) {
   pybind11::enum_<mllm::ModelFileVersion>(m, "ModelFileVersion")
@@ -26,6 +47,8 @@ void registerCoreBinding(py::module_& m) {
       .value("Linear", mllm::OpTypes::kLinear)
       .value("RoPE", mllm::OpTypes::kRoPE)
       .value("Softmax", mllm::OpTypes::kSoftmax)
+      .value("STFT", mllm::OpTypes::kSTFT)
+      .value("ISTFT", mllm::OpTypes::kISTFT)
       .value("Transpose", mllm::OpTypes::kTranspose)
       .value("RMSNorm", mllm::OpTypes::kRMSNorm)
       .value("SiLU", mllm::OpTypes::kSiLU)
@@ -57,6 +80,17 @@ void registerCoreBinding(py::module_& m) {
       .value("ReduceSum", mllm::OpTypes::kReduceSum)
       .value("Contiguous", mllm::OpTypes::kContiguous)
       .value("Reshape", mllm::OpTypes::kReshape)
+      .value("Slice", mllm::OpTypes::kSlice)
+      .value("Param", mllm::OpTypes::kParam)
+      .value("Index", mllm::OpTypes::kIndex)
+      .value("Abs", mllm::OpTypes::kAbs)
+      .value("Log", mllm::OpTypes::kLog)
+      .value("TopK", mllm::OpTypes::kTopK)
+      .value("Mean", mllm::OpTypes::kMean)
+      .value("Clip", mllm::OpTypes::kClip)
+      .value("Exp", mllm::OpTypes::kExp)
+      .value("Sin", mllm::OpTypes::kSin)
+      .value("Cos", mllm::OpTypes::kCos)
       .value("GraphBegin", mllm::OpTypes::kGraphBegin)
       .value("GraphEnd", mllm::OpTypes::kGraphEnd)
       .value("OpType_End", mllm::OpTypes::kOpType_End);
@@ -204,8 +238,6 @@ void registerCoreBinding(py::module_& m) {
       .def("set_device_type", &mllm::BaseOp::setDeviceType)
       .def("get_op_type", &mllm::BaseOp::getOpType);
 
-  py::class_<mllm::BaseOpOptionsBase>(m, "BaseOpOptionsBase");
-
   //===----------------------------------------------------------------------===//
   // Linear Options And LinearOp
   //===----------------------------------------------------------------------===//
@@ -246,4 +278,275 @@ void registerCoreBinding(py::module_& m) {
       .def("forward", &mllm::aops::LinearOp::forward)
       .def("setup", &mllm::aops::LinearOp::setup)
       .def("reshape", &mllm::aops::LinearOp::reshape);
+
+  // Bind Options classes
+  py::class_<mllm::aops::RMSNormOpOptions>(m, "RMSNormOpOptions")
+      .def(py::init<>())
+      .def_readwrite("epsilon", &mllm::aops::RMSNormOpOptions::epsilon)
+      .def_readwrite("add_unit_offset", &mllm::aops::RMSNormOpOptions::add_unit_offset);
+  py::class_<mllm::aops::SiLUOpOptions>(m, "SiLUOpOptions").def(py::init<>());
+  py::class_<mllm::aops::EmbeddingOpOptions>(m, "EmbeddingOpOptions")
+      .def(py::init<>())
+      .def(py::init([](int32_t vocab_size, int32_t hidden_size) {
+             auto options = mllm::aops::EmbeddingOpOptions{};
+             options.vocab_size = vocab_size;
+             options.hidden_size = hidden_size;
+             return options;
+           }),
+           py::arg("vocab_size") = 0, py::arg("hidden_size") = 0)
+      .def_readwrite("vocab_size", &mllm::aops::EmbeddingOpOptions::vocab_size)
+      .def_readwrite("hidden_size", &mllm::aops::EmbeddingOpOptions::hidden_size);
+
+  py::class_<mllm::aops::GELUOpOptions>(m, "GELUOpOptions").def(py::init<>());
+  py::class_<mllm::aops::LayerNormOpOptions>(m, "LayerNormOpOptions")
+      .def(py::init<>())
+      .def(py::init([](const std::vector<int>& normalized_shape, bool elementwise_affine, bool bias, float eps) {
+             auto options = mllm::aops::LayerNormOpOptions{};
+             options.normalized_shape = normalized_shape;
+             options.elementwise_affine = elementwise_affine;
+             options.bias = bias;
+             options.eps = eps;
+             return options;
+           }),
+           py::arg("normalized_shape") = std::vector<int>{}, py::arg("elementwise_affine") = true, py::arg("bias") = true,
+           py::arg("eps") = 1e-5f)
+      .def_readwrite("normalized_shape", &mllm::aops::LayerNormOpOptions::normalized_shape)
+      .def_readwrite("elementwise_affine", &mllm::aops::LayerNormOpOptions::elementwise_affine)
+      .def_readwrite("bias", &mllm::aops::LayerNormOpOptions::bias)
+      .def_readwrite("eps", &mllm::aops::LayerNormOpOptions::eps);
+  py::class_<mllm::aops::SoftmaxOpOptions>(m, "SoftmaxOpOptions")
+      .def(py::init<>())
+      .def(py::init([](int axis) {
+             auto options = mllm::aops::SoftmaxOpOptions{};
+             options.axis = axis;
+             return options;
+           }),
+           py::arg("axis") = 0)
+      .def_readwrite("axis", &mllm::aops::SoftmaxOpOptions::axis);
+  py::class_<mllm::aops::CausalMaskOpOptions>(m, "CausalMaskOpOptions")
+      .def(py::init<>())
+      .def(py::init([](bool sliding_window, int window_size) {
+             auto options = mllm::aops::CausalMaskOpOptions{};
+             options.sliding_window = sliding_window;
+             options.window_size = window_size;
+             return options;
+           }),
+           py::arg("sliding_window") = false, py::arg("window_size") = 0)
+      .def_readwrite("sliding_window", &mllm::aops::CausalMaskOpOptions::sliding_window)
+      .def_readwrite("window_size", &mllm::aops::CausalMaskOpOptions::window_size);
+  py::class_<mllm::aops::KVCacheOpOptions>(m, "KVCacheOpOptions")
+      .def(py::init<>())
+      .def(py::init([](int layer_idx, int q_head, int kv_head, int head_dim, bool use_fa2) {
+             auto options = mllm::aops::KVCacheOpOptions{};
+             options.layer_idx = layer_idx;
+             options.q_head = q_head;
+             options.kv_head = kv_head;
+             options.head_dim = head_dim;
+             options.use_fa2 = use_fa2;
+             return options;
+           }),
+           py::arg("layer_idx") = 0, py::arg("q_head") = 0, py::arg("kv_head") = 0, py::arg("head_dim") = 0,
+           py::arg("use_fa2") = false)
+      .def_readwrite("layer_idx", &mllm::aops::KVCacheOpOptions::layer_idx)
+      .def_readwrite("q_head", &mllm::aops::KVCacheOpOptions::q_head)
+      .def_readwrite("kv_head", &mllm::aops::KVCacheOpOptions::kv_head)
+      .def_readwrite("head_dim", &mllm::aops::KVCacheOpOptions::head_dim)
+      .def_readwrite("use_fa2", &mllm::aops::KVCacheOpOptions::use_fa2);
+  py::class_<mllm::aops::AddOpOptions>(m, "AddOpOptions").def(py::init<>());
+  py::class_<mllm::aops::SubOpOptions>(m, "SubOpOptions").def(py::init<>());
+  py::class_<mllm::aops::MulOpOptions>(m, "MulOpOptions").def(py::init<>());
+  py::class_<mllm::aops::DivOpOptions>(m, "DivOpOptions").def(py::init<>());
+  py::class_<mllm::aops::NegOpOptions>(m, "NegOpOptions").def(py::init<>());
+  py::class_<mllm::aops::AbsOpOptions>(m, "AbsOpOptions").def(py::init<>());
+  py::class_<mllm::aops::LogOpOptions>(m, "LogOpOptions").def(py::init<>());
+  py::class_<mllm::aops::ExpOpOptions>(m, "ExpOpOptions").def(py::init<>());
+  py::class_<mllm::aops::SinOpOptions>(m, "SinOpOptions").def(py::init<>());
+  py::class_<mllm::aops::CosOpOptions>(m, "CosOpOptions").def(py::init<>());
+  py::class_<mllm::aops::ConcatOpOptions>(m, "ConcatOpOptions")
+      .def(py::init<>())
+      .def(py::init([](int dim) {
+             auto options = mllm::aops::ConcatOpOptions{};
+             options.dim = dim;
+             return options;
+           }),
+           py::arg("dim") = 0)
+      .def_readwrite("dim", &mllm::aops::ConcatOpOptions::dim);
+  py::class_<mllm::aops::Conv1DOpOptions>(m, "Conv1DOpOptions")
+      .def(py::init<>())
+      .def_readwrite("in_channels", &mllm::aops::Conv1DOpOptions::in_channels)
+      .def_readwrite("out_channels", &mllm::aops::Conv1DOpOptions::out_channels)
+      .def_readwrite("kernel_size", &mllm::aops::Conv1DOpOptions::kernel_size)
+      .def_readwrite("stride", &mllm::aops::Conv1DOpOptions::stride)
+      .def_readwrite("bias", &mllm::aops::Conv1DOpOptions::bias)
+      .def_readwrite("padding", &mllm::aops::Conv1DOpOptions::padding)
+      .def_readwrite("groups", &mllm::aops::Conv1DOpOptions::groups);
+  py::class_<mllm::aops::Conv3DOpOptions>(m, "Conv3DOpOptions")
+      .def(py::init<>())
+      .def_readwrite("in_channels", &mllm::aops::Conv3DOpOptions::in_channels)
+      .def_readwrite("out_channels", &mllm::aops::Conv3DOpOptions::out_channels)
+      .def_readwrite("kernel_size", &mllm::aops::Conv3DOpOptions::kernel_size)
+      .def_readwrite("stride", &mllm::aops::Conv3DOpOptions::stride)
+      .def_readwrite("bias", &mllm::aops::Conv3DOpOptions::bias)
+      .def_readwrite("impl_type", &mllm::aops::Conv3DOpOptions::impl_type);
+  py::class_<mllm::aops::FillOpOptions>(m, "FillOpOptions")
+      .def(py::init<>())
+      .def_readwrite("type", &mllm::aops::FillOpOptions::type)
+      .def_readwrite("value", &mllm::aops::FillOpOptions::value)
+      .def_readwrite("start", &mllm::aops::FillOpOptions::start)
+      .def_readwrite("end", &mllm::aops::FillOpOptions::end)
+      .def_readwrite("step", &mllm::aops::FillOpOptions::step)
+      .def_readwrite("seed", &mllm::aops::FillOpOptions::seed);
+  py::class_<mllm::aops::FlashAttention2OpOptions>(m, "FlashAttention2OpOptions")
+      .def(py::init<>())
+      .def(py::init([](int B, int q_head, int kv_head, int D, int hp_exp, bool causal_mask) {
+             auto options = mllm::aops::FlashAttention2OpOptions{};
+             options.B = B;
+             options.q_head = q_head;
+             options.kv_head = kv_head;
+             options.D = D;
+             options.hp_exp = hp_exp;
+             options.causal_mask = causal_mask;
+             return options;
+           }),
+           py::arg("B") = 0, py::arg("q_head") = 0, py::arg("kv_head") = 0, py::arg("D") = 0, py::arg("hp_exp") = 0,
+           py::arg("causal_mask") = false)
+      .def_readwrite("B", &mllm::aops::FlashAttention2OpOptions::B)
+      .def_readwrite("q_head", &mllm::aops::FlashAttention2OpOptions::q_head)
+      .def_readwrite("kv_head", &mllm::aops::FlashAttention2OpOptions::kv_head)
+      .def_readwrite("D", &mllm::aops::FlashAttention2OpOptions::D)
+      .def_readwrite("hp_exp", &mllm::aops::FlashAttention2OpOptions::hp_exp)
+      .def_readwrite("causal_mask", &mllm::aops::FlashAttention2OpOptions::causal_mask);
+  py::class_<mllm::aops::IndexOpOptions>(m, "IndexOpOptions")
+      .def(py::init<>())
+      .def_readwrite("indices_", &mllm::aops::IndexOpOptions::indices_);
+  py::class_<mllm::aops::MatMulOpOptions>(m, "MatMulOpOptions")
+      .def(py::init<>())
+      .def(py::init([](bool transpose_a, bool transpose_b, const std::string& matmul_type) {
+             auto options = mllm::aops::MatMulOpOptions{};
+             options.transpose_a = transpose_a;
+             options.transpose_b = transpose_b;
+             options.matmul_type = mllm::aops::str2MatMulOpType(matmul_type);
+             return options;
+           }),
+           py::arg("transpose_a") = false, py::arg("transpose_b") = false, py::arg("matmul_type") = "Default")
+      .def_readwrite("transpose_a", &mllm::aops::MatMulOpOptions::transpose_a)
+      .def_readwrite("transpose_b", &mllm::aops::MatMulOpOptions::transpose_b)
+      .def_readwrite("matmul_type", &mllm::aops::MatMulOpOptions::matmul_type);
+  py::class_<mllm::aops::PermuteOpOptions>(m, "PermuteOpOptions")
+      .def(py::init<>())
+      .def(py::init([](const std::vector<int>& axis) {
+             auto options = mllm::aops::PermuteOpOptions{};
+             options.axis = axis;
+             return options;
+           }),
+           py::arg("axis") = std::vector<int>{})
+      .def_readwrite("axis", &mllm::aops::PermuteOpOptions::axis);
+  py::class_<mllm::aops::ReduceMaxOpOptions>(m, "ReduceMaxOpOptions")
+      .def(py::init<>())
+      .def_readwrite("dim", &mllm::aops::ReduceMaxOpOptions::dim)
+      .def_readwrite("keep_dim", &mllm::aops::ReduceMaxOpOptions::keep_dim);
+  py::class_<mllm::aops::ReduceMinOpOptions>(m, "ReduceMinOpOptions")
+      .def(py::init<>())
+      .def_readwrite("dim", &mllm::aops::ReduceMinOpOptions::dim)
+      .def_readwrite("keep_dim", &mllm::aops::ReduceMinOpOptions::keep_dim);
+  py::class_<mllm::aops::ReduceSumOpOptions>(m, "ReduceSumOpOptions")
+      .def(py::init<>())
+      .def_readwrite("dim", &mllm::aops::ReduceSumOpOptions::dim)
+      .def_readwrite("keep_dim", &mllm::aops::ReduceSumOpOptions::keep_dim);
+  py::class_<mllm::aops::MeanOpOptions>(m, "MeanOpOptions")
+      .def(py::init<>())
+      .def_readwrite("dim", &mllm::aops::MeanOpOptions::dim)
+      .def_readwrite("keep_dim", &mllm::aops::MeanOpOptions::keep_dim);
+  py::class_<mllm::aops::ReshapeOpOptions>(m, "ReshapeOpOptions")
+      .def(py::init<>())
+      .def(py::init([](const std::vector<int>& shape) {
+             auto options = mllm::aops::ReshapeOpOptions{};
+             options.shape = shape;
+             return options;
+           }),
+           py::arg("shape") = std::vector<int>{})
+      .def_readwrite("shape", &mllm::aops::ReshapeOpOptions::shape);
+  py::class_<mllm::aops::SliceOpOptions>(m, "SliceOpOptions").def(py::init<>());
+  py::class_<mllm::aops::SplitOpOptions>(m, "SplitOpOptions")
+      .def(py::init<>())
+      .def(py::init([](int32_t dim, const std::vector<int32_t>& split_size_or_sections) {
+             auto options = mllm::aops::SplitOpOptions{};
+             options.dim = dim;
+             options.split_size_or_sections = split_size_or_sections;
+             return options;
+           }),
+           py::arg("dim"), py::arg("split_size_or_sections"))
+      .def_readwrite("dim", &mllm::aops::SplitOpOptions::dim)
+      .def_readwrite("split_size_or_sections", &mllm::aops::SplitOpOptions::split_size_or_sections);
+  py::class_<mllm::aops::STFTOpOptions>(m, "STFTOpOptions")
+      .def(py::init<>())
+      .def(py::init([](int n_fft, int hop_length, int win_length, bool onesided, bool center, const std::string& pad_mode,
+                       bool return_complex) {
+             auto options = mllm::aops::STFTOpOptions{};
+             options.n_fft = n_fft;
+             options.hop_length = hop_length;
+             options.win_length = win_length;
+             options.onesided = onesided;
+             options.center = center;
+             options.pad_mode = pad_mode;
+             options.return_complex = return_complex;
+             return options;
+           }),
+           py::arg("n_fft"), py::arg("hop_length"), py::arg("win_length"), py::arg("onesided"), py::arg("center"),
+           py::arg("pad_mode") = "constant", py::arg("return_complex") = false)
+      .def_readwrite("n_fft", &mllm::aops::STFTOpOptions::n_fft)
+      .def_readwrite("hop_length", &mllm::aops::STFTOpOptions::hop_length)
+      .def_readwrite("win_length", &mllm::aops::STFTOpOptions::win_length)
+      .def_readwrite("onesided", &mllm::aops::STFTOpOptions::onesided)
+      .def_readwrite("center", &mllm::aops::STFTOpOptions::center)
+      .def_readwrite("pad_mode", &mllm::aops::STFTOpOptions::pad_mode)
+      .def_readwrite("return_complex", &mllm::aops::STFTOpOptions::return_complex);
+  py::class_<mllm::aops::ISTFTOpOptions>(m, "ISTFTOpOptions")
+      .def(py::init<>())
+      .def_readwrite("n_fft", &mllm::aops::ISTFTOpOptions::n_fft)
+      .def_readwrite("hop_length", &mllm::aops::ISTFTOpOptions::hop_length)
+      .def_readwrite("win_length", &mllm::aops::ISTFTOpOptions::win_length)
+      .def_readwrite("onesided", &mllm::aops::ISTFTOpOptions::onesided)
+      .def_readwrite("center", &mllm::aops::ISTFTOpOptions::center)
+      .def_readwrite("pad_mode", &mllm::aops::ISTFTOpOptions::pad_mode)
+      .def_readwrite("normalized", &mllm::aops::ISTFTOpOptions::normalized)
+      .def_readwrite("length", &mllm::aops::ISTFTOpOptions::length);
+  py::class_<mllm::aops::TopKOpOptions>(m, "TopKOpOptions")
+      .def(py::init<>())
+      .def_readwrite("k", &mllm::aops::TopKOpOptions::k)
+      .def_readwrite("dim", &mllm::aops::TopKOpOptions::dim)
+      .def_readwrite("largest", &mllm::aops::TopKOpOptions::largest)
+      .def_readwrite("sorted", &mllm::aops::TopKOpOptions::sorted);
+  py::class_<mllm::aops::CloneOpOptions>(m, "CloneOpOptions").def(py::init<>());
+  py::class_<mllm::aops::ContiguousOpOptions>(m, "ContiguousOpOptions").def(py::init<>());
+  py::class_<mllm::aops::CopyOpOptions>(m, "CopyOpOptions").def(py::init<>());
+  py::class_<mllm::aops::QuickGELUOpOptions>(m, "QuickGELUOpOptions").def(py::init<>());
+  py::class_<mllm::aops::ReLUOpOptions>(m, "ReLUOpOptions").def(py::init<>());
+  py::class_<mllm::aops::RepeatOpOptions>(m, "RepeatOpOptions").def(py::init<>());
+  py::class_<mllm::aops::TransposeOpOptions>(m, "TransposeOpOptions").def(py::init<>());
+  py::class_<mllm::aops::ViewOpOptions>(m, "ViewOpOptions")
+      .def(py::init<>())
+      .def_readwrite("to_shape", &mllm::aops::ViewOpOptions::to_shape);
+  py::class_<mllm::aops::X2XOpOptions>(m, "X2XOpOptions").def(py::init<>());
+  py::class_<mllm::aops::CastTypeOpOptions>(m, "CastTypeOpOptions").def(py::init<>());
+  py::class_<mllm::aops::ParamOpOptions>(m, "ParamOpOptions").def(py::init<>());
+  py::class_<mllm::aops::GraphBeginOpOptions>(m, "GraphBeginOpOptions").def(py::init<>());
+  py::class_<mllm::aops::GraphEndOpOptions>(m, "GraphEndOpOptions").def(py::init<>());
+  py::class_<mllm::aops::Qwen2VLRoPEOpOptions>(m, "Qwen2VLRoPEOpOptions")
+      .def(py::init<>())
+      .def_readwrite("dims", &mllm::aops::Qwen2VLRoPEOpOptions::dims)
+      .def_readwrite("spatial_merge_size", &mllm::aops::Qwen2VLRoPEOpOptions::spatial_merge_size)
+      .def_readwrite("theta", &mllm::aops::Qwen2VLRoPEOpOptions::theta);
+  py::class_<mllm::aops::VisionRoPEOpOptions>(m, "VisionRoPEOpOptions").def(py::init<>());
+  py::class_<mllm::aops::MultimodalRoPEOpOptions>(m, "MultimodalRoPEOpOptions").def(py::init<>());
+  py::class_<mllm::aops::ClipOpOptions>(m, "ClipOpOptions")
+      .def(py::init<>())
+      .def_readwrite("min_val", &mllm::aops::ClipOpOptions::min_val)
+      .def_readwrite("max_val", &mllm::aops::ClipOpOptions::max_val);
+
+  auto base_opt_base = py::class_<mllm::BaseOpOptionsBase>(m, "BaseOpOptionsBase");
+  // FIXME others.
+
+  implicit_convertible_with_concept<mllm::aops::LinearOpOptions>(base_opt_base);
+  implicit_convertible_with_concept<mllm::aops::ClipOpOptions>(base_opt_base);
 }

--- a/pymllm/_C/Core.cpp
+++ b/pymllm/_C/Core.cpp
@@ -217,7 +217,7 @@ void registerCoreBinding(py::module_& m) {
   //===----------------------------------------------------------------------===//
   py::class_<mllm::ParameterFile, std::shared_ptr<mllm::ParameterFile>>(m, "ParameterFile")
       .def(py::init<mllm::ModelFileVersion>(), py::arg("v") = mllm::ModelFileVersion::kUserTemporary)
-      .def("push", &mllm::ParameterFile::push)
+      .def("push", &mllm::ParameterFile::push, py::keep_alive<1, 3>())
       .def("pull", &mllm::ParameterFile::pull)
       .def("has", &mllm::ParameterFile::has)
       .def("remove", &mllm::ParameterFile::remove);

--- a/pymllm/_C/Core.hpp
+++ b/pymllm/_C/Core.hpp
@@ -8,3 +8,9 @@
 namespace py = pybind11;
 
 void registerCoreBinding(py::module_& m);
+
+template<typename Derived, typename Base>
+void implicit_convertible_with_concept(py::class_<Base>& cl) {
+  cl.def(py::init<Derived const&>());
+  py::implicitly_convertible<Derived, Base>();
+}

--- a/pymllm/_C/Engine.cpp
+++ b/pymllm/_C/Engine.cpp
@@ -56,7 +56,8 @@ void registerEngineBinding(py::module_& m) {
       .def("set_random_seed", &mllm::Context::setRandomSeed)
       .def("get_random_seed", &mllm::Context::getRandomSeed)
       .def("ref_session_threads", &mllm::Context::refSessionThreads)
-      .def("get_backend", &mllm::Context::getBackend, py::return_value_policy::reference);
+      .def("get_backend", &mllm::Context::getBackend, py::return_value_policy::reference)
+      .def("build_op_and_submit_task", &mllm::Context::buildOpAndSubmitTask);
 
   pybind11::class_<mllm::ConfigFile>(m, "ConfigFile")
       .def(py::init<>())

--- a/pymllm/_C/Nn.cpp
+++ b/pymllm/_C/Nn.cpp
@@ -64,4 +64,43 @@ void registerNnBinding(pybind11::module_& m) {
       .def("__send_graph_begin", &Module::__send_graph_begin)
       .def("__send_graph_end", &Module::__send_graph_end)
       .def("__trace", &Module::__trace);
+
+  // Bind Options classes
+  py::class_<mllm::aops::RMSNormOpOptions>(m, "RMSNormOpOptions")
+      .def(py::init<>())
+      .def_readwrite("epsilon", &mllm::aops::RMSNormOpOptions::epsilon)
+      .def_readwrite("add_unit_offset", &mllm::aops::RMSNormOpOptions::add_unit_offset);
+
+  py::class_<mllm::aops::SiLUOpOptions>(m, "SiLUOpOptions").def(py::init<>());
+
+  py::class_<mllm::aops::EmbeddingOpOptions>(m, "EmbeddingOpOptions")
+      .def(py::init<>())
+      .def_readwrite("vocab_size", &mllm::aops::EmbeddingOpOptions::vocab_size)
+      .def_readwrite("hidden_size", &mllm::aops::EmbeddingOpOptions::hidden_size);
+
+  py::class_<mllm::aops::GELUOpOptions>(m, "GELUOpOptions").def(py::init<>());
+
+  py::class_<mllm::aops::LayerNormOpOptions>(m, "LayerNormOpOptions")
+      .def(py::init<>())
+      .def_readwrite("normalized_shape", &mllm::aops::LayerNormOpOptions::normalized_shape)
+      .def_readwrite("elementwise_affine", &mllm::aops::LayerNormOpOptions::elementwise_affine)
+      .def_readwrite("bias", &mllm::aops::LayerNormOpOptions::bias)
+      .def_readwrite("eps", &mllm::aops::LayerNormOpOptions::eps);
+
+  py::class_<mllm::aops::SoftmaxOpOptions>(m, "SoftmaxOpOptions")
+      .def(py::init<>())
+      .def_readwrite("axis", &mllm::aops::SoftmaxOpOptions::axis);
+
+  py::class_<mllm::aops::CausalMaskOpOptions>(m, "CausalMaskOpOptions")
+      .def(py::init<>())
+      .def_readwrite("sliding_window", &mllm::aops::CausalMaskOpOptions::sliding_window)
+      .def_readwrite("window_size", &mllm::aops::CausalMaskOpOptions::window_size);
+
+  py::class_<mllm::aops::KVCacheOpOptions>(m, "KVCacheOpOptions")
+      .def(py::init<>())
+      .def_readwrite("layer_idx", &mllm::aops::KVCacheOpOptions::layer_idx)
+      .def_readwrite("q_head", &mllm::aops::KVCacheOpOptions::q_head)
+      .def_readwrite("kv_head", &mllm::aops::KVCacheOpOptions::kv_head)
+      .def_readwrite("head_dim", &mllm::aops::KVCacheOpOptions::head_dim)
+      .def_readwrite("use_fa2", &mllm::aops::KVCacheOpOptions::use_fa2);
 }

--- a/pymllm/_C/Nn.cpp
+++ b/pymllm/_C/Nn.cpp
@@ -64,43 +64,4 @@ void registerNnBinding(pybind11::module_& m) {
       .def("__send_graph_begin", &Module::__send_graph_begin)
       .def("__send_graph_end", &Module::__send_graph_end)
       .def("__trace", &Module::__trace);
-
-  // Bind Options classes
-  py::class_<mllm::aops::RMSNormOpOptions>(m, "RMSNormOpOptions")
-      .def(py::init<>())
-      .def_readwrite("epsilon", &mllm::aops::RMSNormOpOptions::epsilon)
-      .def_readwrite("add_unit_offset", &mllm::aops::RMSNormOpOptions::add_unit_offset);
-
-  py::class_<mllm::aops::SiLUOpOptions>(m, "SiLUOpOptions").def(py::init<>());
-
-  py::class_<mllm::aops::EmbeddingOpOptions>(m, "EmbeddingOpOptions")
-      .def(py::init<>())
-      .def_readwrite("vocab_size", &mllm::aops::EmbeddingOpOptions::vocab_size)
-      .def_readwrite("hidden_size", &mllm::aops::EmbeddingOpOptions::hidden_size);
-
-  py::class_<mllm::aops::GELUOpOptions>(m, "GELUOpOptions").def(py::init<>());
-
-  py::class_<mllm::aops::LayerNormOpOptions>(m, "LayerNormOpOptions")
-      .def(py::init<>())
-      .def_readwrite("normalized_shape", &mllm::aops::LayerNormOpOptions::normalized_shape)
-      .def_readwrite("elementwise_affine", &mllm::aops::LayerNormOpOptions::elementwise_affine)
-      .def_readwrite("bias", &mllm::aops::LayerNormOpOptions::bias)
-      .def_readwrite("eps", &mllm::aops::LayerNormOpOptions::eps);
-
-  py::class_<mllm::aops::SoftmaxOpOptions>(m, "SoftmaxOpOptions")
-      .def(py::init<>())
-      .def_readwrite("axis", &mllm::aops::SoftmaxOpOptions::axis);
-
-  py::class_<mllm::aops::CausalMaskOpOptions>(m, "CausalMaskOpOptions")
-      .def(py::init<>())
-      .def_readwrite("sliding_window", &mllm::aops::CausalMaskOpOptions::sliding_window)
-      .def_readwrite("window_size", &mllm::aops::CausalMaskOpOptions::window_size);
-
-  py::class_<mllm::aops::KVCacheOpOptions>(m, "KVCacheOpOptions")
-      .def(py::init<>())
-      .def_readwrite("layer_idx", &mllm::aops::KVCacheOpOptions::layer_idx)
-      .def_readwrite("q_head", &mllm::aops::KVCacheOpOptions::q_head)
-      .def_readwrite("kv_head", &mllm::aops::KVCacheOpOptions::kv_head)
-      .def_readwrite("head_dim", &mllm::aops::KVCacheOpOptions::head_dim)
-      .def_readwrite("use_fa2", &mllm::aops::KVCacheOpOptions::use_fa2);
 }

--- a/pymllm/__init__.py
+++ b/pymllm/__init__.py
@@ -21,13 +21,13 @@ opencl = DeviceTypes.OpenCL
 initialize_context()
 
 
-def ones(shape, dtype=float32, device_type=cpu):
-    return Tensor.ones(shape, dtype, device_type)
+def ones(shape, dtype=float32, device=cpu):
+    return Tensor.ones(shape, dtype, device)
 
 
-def zeros(shape, dtype=float32, device_type=cpu):
-    return Tensor.zeros(shape, dtype, device_type)
+def zeros(shape, dtype=float32, device=cpu):
+    return Tensor.zeros(shape, dtype, device)
 
 
-def random(shape, start=-1.0, end=1.0, dtype=float32, device_type=cpu):
-    return Tensor.random(shape, start, end, dtype, device_type)
+def random(shape, start=-1.0, end=1.0, dtype=float32, device=cpu):
+    return Tensor.random(shape, start, end, dtype, device)

--- a/pymllm/nn/__init__.py
+++ b/pymllm/nn/__init__.py
@@ -1,4 +1,5 @@
 from .module import Module
 from .layer import Layer, Linear
+from . import functional
 
-__all__ = ["Module", "Layer", "Linear"]
+__all__ = ["Module", "Layer", "Linear", "functional"]

--- a/pymllm/nn/functional.py
+++ b/pymllm/nn/functional.py
@@ -1,0 +1,345 @@
+"""
+Functional interface for MLLM operations.
+"""
+
+from typing import List, Union, Tuple
+from .._C import Context, OpTypes
+from .._C import Tensor
+from .._C import BaseOpOptionsBase
+from .._C import (
+    MatMulOpOptions,
+    ViewOpOptions,
+    SplitOpOptions,
+    ConcatOpOptions,
+    SoftmaxOpOptions,
+    LogOpOptions,
+    ExpOpOptions,
+    SinOpOptions,
+    CosOpOptions,
+    TopKOpOptions,
+    ClipOpOptions,
+    ReduceMinOpOptions,
+    ReduceMaxOpOptions,
+    ReduceSumOpOptions,
+    MeanOpOptions,
+)
+
+
+def matmul(
+    A: Tensor, B: Tensor, transpose_A: bool = False, transpose_B: bool = False
+) -> Tensor:
+    """
+    Matrix multiplication of two tensors.
+
+    Args:
+        A: First tensor
+        B: Second tensor
+        transpose_A: Whether to transpose A before multiplication
+        transpose_B: Whether to transpose B before multiplication
+
+    Returns:
+        Result tensor of matrix multiplication
+    """
+    options = MatMulOpOptions()
+    options.transpose_a = transpose_A
+    options.transpose_b = transpose_B
+    options.matmul_type = 0  # kDefault
+
+    outputs = Context.instance().build_op_and_submit_task(
+        OpTypes.MatMul, options, [A, B]
+    )
+    return outputs[0]
+
+
+def view(x: Tensor, shape: List[int]) -> Tensor:
+    """
+    Reshape tensor to specified shape.
+
+    Args:
+        x: Input tensor
+        shape: Target shape
+
+    Returns:
+        Reshaped tensor
+    """
+    options = ViewOpOptions()
+    options.to_shape = shape
+
+    outputs = Context.instance().build_op_and_submit_task(OpTypes.View, options, [x])
+    return outputs[0]
+
+
+def split(
+    x: Tensor, split_size_or_sections: Union[int, List[int]], dim: int = 0
+) -> List[Tensor]:
+    """
+    Split tensor into chunks.
+
+    Args:
+        x: Input tensor
+        split_size_or_sections: Size of each chunk or list of sizes
+        dim: Dimension along which to split
+
+    Returns:
+        List of split tensors
+    """
+    options = SplitOpOptions()
+    options.dim = dim
+    if isinstance(split_size_or_sections, int):
+        options.split_size_or_sections = [split_size_or_sections]
+    else:
+        options.split_size_or_sections = split_size_or_sections
+
+    outputs = Context.instance().build_op_and_submit_task(OpTypes.Split, options, [x])
+    return outputs
+
+
+def concat(tensors: List[Tensor], dim: int) -> Tensor:
+    """
+    Concatenate tensors along specified dimension.
+
+    Args:
+        tensors: List of tensors to concatenate
+        dim: Dimension along which to concatenate
+
+    Returns:
+        Concatenated tensor
+    """
+    options = ConcatOpOptions()
+    options.dim = dim
+
+    outputs = Context.instance().build_op_and_submit_task(
+        OpTypes.Concat, options, tensors
+    )
+    return outputs[0]
+
+
+def softmax(x: Tensor, dim: int) -> Tensor:
+    """
+    Apply softmax along specified dimension.
+
+    Args:
+        x: Input tensor
+        dim: Dimension along which to apply softmax
+
+    Returns:
+        Tensor with softmax applied
+    """
+    options = SoftmaxOpOptions()
+    options.axis = dim
+
+    outputs = Context.instance().build_op_and_submit_task(OpTypes.Softmax, options, [x])
+    return outputs[0]
+
+
+def log(x: Tensor) -> Tensor:
+    """
+    Element-wise natural logarithm.
+
+    Args:
+        x: Input tensor
+
+    Returns:
+        Tensor with natural logarithm applied
+    """
+    options = LogOpOptions()
+
+    outputs = Context.instance().build_op_and_submit_task(OpTypes.Log, options, [x])
+    return outputs[0]
+
+
+def exp(x: Tensor) -> Tensor:
+    """
+    Element-wise exponential.
+
+    Args:
+        x: Input tensor
+
+    Returns:
+        Tensor with exponential applied
+    """
+    options = ExpOpOptions()
+
+    outputs = Context.instance().build_op_and_submit_task(OpTypes.Exp, options, [x])
+    return outputs[0]
+
+
+def sin(x: Tensor) -> Tensor:
+    """
+    Element-wise sine.
+
+    Args:
+        x: Input tensor
+
+    Returns:
+        Tensor with sine applied
+    """
+    options = SinOpOptions()
+
+    outputs = Context.instance().build_op_and_submit_task(OpTypes.Sin, options, [x])
+    return outputs[0]
+
+
+def cos(x: Tensor) -> Tensor:
+    """
+    Element-wise cosine.
+
+    Args:
+        x: Input tensor
+
+    Returns:
+        Tensor with cosine applied
+    """
+    options = CosOpOptions()
+
+    outputs = Context.instance().build_op_and_submit_task(OpTypes.Cos, options, [x])
+    return outputs[0]
+
+
+def topk(
+    x: Tensor, k: int, dim: int = -1, largest: bool = True, sorted: bool = True
+) -> Tuple[Tensor, Tensor]:
+    """
+    Returns the k largest elements of the given input tensor along a given dimension.
+
+    Args:
+        x: Input tensor
+        k: The k in "top-k"
+        dim: The dimension to sort along
+        largest: Controls whether to return largest or smallest elements
+        sorted: Controls whether to return the elements in sorted order
+
+    Returns:
+        Tuple of (values, indices)
+    """
+    options = TopKOpOptions()
+    options.k = k
+    options.dim = dim
+    options.largest = largest
+    options.sorted = sorted
+
+    outputs = Context.instance().build_op_and_submit_task(OpTypes.TopK, options, [x])
+    return (outputs[0], outputs[1])
+
+
+def clip(x: Tensor, min_val: float, max_val: float) -> Tensor:
+    """
+    Clip tensor values to be within [min_val, max_val].
+
+    Args:
+        x: Input tensor
+        min_val: Minimum value
+        max_val: Maximum value
+
+    Returns:
+        Clipped tensor
+    """
+    options = ClipOpOptions()
+    options.min_val = min_val
+    options.max_val = max_val
+
+    outputs = Context.instance().build_op_and_submit_task(
+        OpTypes.Clip,
+        BaseOpOptionsBase(options),
+        [x],
+        x.device(),
+    )
+    return outputs[0]
+
+
+def min(x: Tensor, dim: int = None, keep_dim: bool = False) -> Tensor:
+    """
+    Returns the minimum value of all elements in the input tensor.
+
+    Args:
+        x: Input tensor
+        dim: The dimension to reduce. If None, reduce all dimensions
+        keep_dim: Whether the output tensor has dim retained or not
+
+    Returns:
+        Minimum values tensor
+    """
+    options = ReduceMinOpOptions()
+    if dim is None:
+        options.dim = 2147483647  # std::numeric_limits<int32_t>::max()
+    else:
+        options.dim = dim
+    options.keep_dim = keep_dim
+
+    outputs = Context.instance().build_op_and_submit_task(
+        OpTypes.ReduceMin, options, [x]
+    )
+    return outputs[0]
+
+
+def max(x: Tensor, dim: int = None, keep_dim: bool = False) -> Tensor:
+    """
+    Returns the maximum value of all elements in the input tensor.
+
+    Args:
+        x: Input tensor
+        dim: The dimension to reduce. If None, reduce all dimensions
+        keep_dim: Whether the output tensor has dim retained or not
+
+    Returns:
+        Maximum values tensor
+    """
+    options = ReduceMaxOpOptions()
+    if dim is None:
+        options.dim = 2147483647  # std::numeric_limits<int32_t>::max()
+    else:
+        options.dim = dim
+    options.keep_dim = keep_dim
+
+    outputs = Context.instance().build_op_and_submit_task(
+        OpTypes.ReduceMax, options, [x]
+    )
+    return outputs[0]
+
+
+def sum(x: Tensor, dim: int = None, keep_dim: bool = False) -> Tensor:
+    """
+    Returns the sum of all elements in the input tensor.
+
+    Args:
+        x: Input tensor
+        dim: The dimension to reduce. If None, reduce all dimensions
+        keep_dim: Whether the output tensor has dim retained or not
+
+    Returns:
+        Sum tensor
+    """
+    options = ReduceSumOpOptions()
+    if dim is None:
+        options.dim = 2147483647  # std::numeric_limits<int32_t>::max()
+    else:
+        options.dim = dim
+    options.keep_dim = keep_dim
+
+    outputs = Context.instance().build_op_and_submit_task(
+        OpTypes.ReduceSum, options, [x]
+    )
+    return outputs[0]
+
+
+def mean(x: Tensor, dim: int = None, keep_dim: bool = False) -> Tensor:
+    """
+    Returns the mean value of all elements in the input tensor.
+
+    Args:
+        x: Input tensor
+        dim: The dimension to reduce. If None, reduce all dimensions
+        keep_dim: Whether the output tensor has dim retained or not
+
+    Returns:
+        Mean tensor
+    """
+    options = MeanOpOptions()
+    if dim is None:
+        options.dim = 2147483647  # std::numeric_limits<int32_t>::max()
+    else:
+        options.dim = dim
+    options.keep_dim = keep_dim
+
+    outputs = Context.instance().build_op_and_submit_task(OpTypes.Mean, options, [x])
+    return outputs[0]

--- a/pymllm/nn/layer.py
+++ b/pymllm/nn/layer.py
@@ -2,6 +2,17 @@
 # Licensed under the MIT License.
 
 from .._C import Tensor, CXXLayer, LayerImpl, OpTypes, LinearImplTypes, LinearOpOptions
+# 导入其他Options类
+from .._C import (
+    RMSNormOpOptions,
+    SiLUOpOptions,
+    EmbeddingOpOptions,
+    GELUOpOptions,
+    LayerNormOpOptions,
+    SoftmaxOpOptions,
+    CausalMaskOpOptions,
+    KVCacheOpOptions,
+)
 
 
 class Layer:
@@ -70,3 +81,129 @@ class Linear(Layer):
         Return a string representation of the Layer.
         """
         return f"{self.__class__.__name__}(in_channels={self.in_channels}, out_channels={self.out_channels}, bias={self.bias}, impl_type={self.impl_type})"
+
+
+class RMSNorm(Layer):
+    def __init__(self, epsilon=1e-5, add_unit_offset=False):
+        options = RMSNormOpOptions()
+        options.epsilon = epsilon
+        options.add_unit_offset = add_unit_offset
+        super().__init__(OpTypes.RMSNorm, options)
+        self.epsilon = epsilon
+        self.add_unit_offset = add_unit_offset
+
+    def forward(self, *args):
+        return super().forward(*args)[0]
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}(epsilon={self.epsilon}, add_unit_offset={self.add_unit_offset})"
+
+
+class SiLU(Layer):
+    def __init__(self):
+        super().__init__(OpTypes.SiLU, SiLUOpOptions())
+
+    def forward(self, *args):
+        return super().forward(*args)[0]
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}()"
+
+
+class Embedding(Layer):
+    def __init__(self, vocab_size, hidden_size):
+        options = EmbeddingOpOptions()
+        options.vocab_size = vocab_size
+        options.hidden_size = hidden_size
+        super().__init__(OpTypes.Embedding, options)
+        self.vocab_size = vocab_size
+        self.hidden_size = hidden_size
+
+    def forward(self, *args):
+        return super().forward(*args)[0]
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}(vocab_size={self.vocab_size}, hidden_size={self.hidden_size})"
+
+
+class GELU(Layer):
+    def __init__(self):
+        super().__init__(OpTypes.GELU, GELUOpOptions())
+
+    def forward(self, *args):
+        return super().forward(*args)[0]
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}()"
+
+
+class LayerNorm(Layer):
+    def __init__(self, normalized_shape, elementwise_affine=True, bias=True, eps=1e-6):
+        options = LayerNormOpOptions()
+        options.normalized_shape = normalized_shape
+        options.elementwise_affine = elementwise_affine
+        options.bias = bias
+        options.eps = eps
+        super().__init__(OpTypes.LayerNorm, options)
+        self.normalized_shape = normalized_shape
+        self.elementwise_affine = elementwise_affine
+        self.bias = bias
+        self.eps = eps
+
+    def forward(self, *args):
+        return super().forward(*args)[0]
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}(normalized_shape={self.normalized_shape}, elementwise_affine={self.elementwise_affine}, bias={self.bias}, eps={self.eps})"
+
+
+class Softmax(Layer):
+    def __init__(self, dim):
+        options = SoftmaxOpOptions()
+        options.axis = dim
+        super().__init__(OpTypes.Softmax, options)
+        self.dim = dim
+
+    def forward(self, *args):
+        return super().forward(*args)[0]
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}(dim={self.dim})"
+
+
+class CausalMask(Layer):
+    def __init__(self, sliding_window=False, window_size=0):
+        options = CausalMaskOpOptions()
+        options.sliding_window = sliding_window
+        options.window_size = window_size
+        super().__init__(OpTypes.CausalMask, options)
+        self.sliding_window = sliding_window
+        self.window_size = window_size
+
+    def forward(self, *args):
+        return super().forward(*args)[0]
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}(sliding_window={self.sliding_window}, window_size={self.window_size})"
+
+
+class KVCache(Layer):
+    def __init__(self, layer_idx, q_head, kv_head, head_dim, use_fa2=True):
+        options = KVCacheOpOptions()
+        options.layer_idx = layer_idx
+        options.q_head = q_head
+        options.kv_head = kv_head
+        options.head_dim = head_dim
+        options.use_fa2 = use_fa2
+        super().__init__(OpTypes.KVCache, options)
+        self.layer_idx = layer_idx
+        self.q_head = q_head
+        self.kv_head = kv_head
+        self.head_dim = head_dim
+        self.use_fa2 = use_fa2
+
+    def forward(self, *args):
+        return super().forward(*args)
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}(layer_idx={self.layer_idx}, q_head={self.q_head}, kv_head={self.kv_head}, head_dim={self.head_dim}, use_fa2={self.use_fa2})"

--- a/pymllm/nn/layer.py
+++ b/pymllm/nn/layer.py
@@ -75,6 +75,22 @@ class Linear(Layer):
     def forward(self, *args):
         return super().forward(*args)[0]
 
+    def bias(self):
+        return (
+            self.cxx_impl()
+            .get_instanced_op()
+            .get_params()
+            .pull(self.cxx_impl().get_name() + ".bias")
+        )
+
+    def weight(self):
+        return (
+            self.cxx_impl()
+            .get_instanced_op()
+            .get_params()
+            .pull(self.cxx_impl().get_name() + ".weight")
+        )
+
     def __repr__(self):
         """
         Return a string representation of the Layer.

--- a/pymllm/nn/layer.py
+++ b/pymllm/nn/layer.py
@@ -2,7 +2,6 @@
 # Licensed under the MIT License.
 
 from .._C import Tensor, CXXLayer, LayerImpl, OpTypes, LinearImplTypes, LinearOpOptions
-# 导入其他Options类
 from .._C import (
     RMSNormOpOptions,
     SiLUOpOptions,

--- a/pymllm/tests/test_nn.py
+++ b/pymllm/tests/test_nn.py
@@ -1,5 +1,6 @@
 import pymllm as torch
 import pymllm.nn as nn
+import pymllm.nn.functional as F
 from pymllm import ParameterFile
 
 
@@ -14,28 +15,47 @@ class FooNet(nn.Module):
         return self.linear_0(self.linear_1(self.linear_2(x)))
 
 
-def test_foo_net():
-    net = FooNet()
-    print(net)
-
+def feed_fake_params(net: nn.Module) -> None:
     # Insert some random params
     param = ParameterFile()
-    linear_0 = torch.random((1024, 1024), torch.float32, torch.cpu).set_name(
-        "linear_0.weight"
-    )
-    linear_1 = torch.random((1024, 1024), torch.float32, torch.cpu).set_name(
-        "linear_1.weight"
-    )
-    linear_2 = torch.random((1024, 1024), torch.float32, torch.cpu).set_name(
-        "linear_2.weight"
-    )
+    linear_0 = torch.random(
+        (1024, 1024), dtype=torch.float32, device=torch.cpu
+    ).set_name("linear_0.weight")
+    linear_1 = torch.random(
+        (1024, 1024), dtype=torch.float32, device=torch.cpu
+    ).set_name("linear_1.weight")
+    linear_2 = torch.random(
+        (1024, 1024), dtype=torch.float32, device=torch.cpu
+    ).set_name("linear_2.weight")
     param.push("linear_0.weight", linear_0)
     param.push("linear_1.weight", linear_1)
     param.push("linear_2.weight", linear_2)
     net.load(param)
-    t = torch.ones((1, 1024), torch.float32, torch.cpu)
+
+
+def test_foo_net():
+    net = FooNet()
+    print(net)
+    # Insert some random params
+    param = ParameterFile()
+    linear_0 = torch.random(
+        (1024, 1024), dtype=torch.float32, device=torch.cpu
+    ).set_name("linear_0.weight")
+    linear_1 = torch.random(
+        (1024, 1024), dtype=torch.float32, device=torch.cpu
+    ).set_name("linear_1.weight")
+    linear_2 = torch.random(
+        (1024, 1024), dtype=torch.float32, device=torch.cpu
+    ).set_name("linear_2.weight")
+    param.push("linear_0.weight", linear_0)
+    param.push("linear_1.weight", linear_1)
+    param.push("linear_2.weight", linear_2)
+    net.load(param)
+    t = torch.random((1, 1024), dtype=torch.float32, device=torch.cpu)
     print(t)
     o = net(t)
+    print(o)
+    o = F.clip(o, min_val=-1.0, max_val=1.0)
     print(o)
 
 

--- a/pymllm/tests/test_nn.py
+++ b/pymllm/tests/test_nn.py
@@ -2,6 +2,9 @@ import pymllm as torch
 import pymllm.nn as nn
 import pymllm.nn.functional as F
 from pymllm import ParameterFile
+from pymllm.utils.error_handler import enable_faulthandler
+
+enable_faulthandler()
 
 
 class FooNet(nn.Module):
@@ -15,7 +18,7 @@ class FooNet(nn.Module):
         return self.linear_0(self.linear_1(self.linear_2(x)))
 
 
-def feed_fake_params(net: nn.Module) -> None:
+def feed_fake_params(net: nn.Module):
     # Insert some random params
     param = ParameterFile()
     linear_0 = torch.random(
@@ -31,32 +34,28 @@ def feed_fake_params(net: nn.Module) -> None:
     param.push("linear_1.weight", linear_1)
     param.push("linear_2.weight", linear_2)
     net.load(param)
+    print(net.linear_0.weight())
+    print(net.linear_1.weight())
+    print(net.linear_2.weight())
+    return param
 
 
 def test_foo_net():
     net = FooNet()
     print(net)
     # Insert some random params
-    param = ParameterFile()
-    linear_0 = torch.random(
-        (1024, 1024), dtype=torch.float32, device=torch.cpu
-    ).set_name("linear_0.weight")
-    linear_1 = torch.random(
-        (1024, 1024), dtype=torch.float32, device=torch.cpu
-    ).set_name("linear_1.weight")
-    linear_2 = torch.random(
-        (1024, 1024), dtype=torch.float32, device=torch.cpu
-    ).set_name("linear_2.weight")
-    param.push("linear_0.weight", linear_0)
-    param.push("linear_1.weight", linear_1)
-    param.push("linear_2.weight", linear_2)
-    net.load(param)
+    p = feed_fake_params(net)
+    print("yes")
     t = torch.random((1, 1024), dtype=torch.float32, device=torch.cpu)
     print(t)
+    print(net.linear_0.weight())
+    print(net.linear_1.weight())
+    print(net.linear_2.weight())
     o = net(t)
     print(o)
     o = F.clip(o, min_val=-1.0, max_val=1.0)
     print(o)
+    print(p)
 
 
 if __name__ == "__main__":

--- a/pymllm/utils/error_handler.py
+++ b/pymllm/utils/error_handler.py
@@ -1,0 +1,4 @@
+def enable_faulthandler():
+    import faulthandler
+
+    faulthandler.enable()


### PR DESCRIPTION
feat(pymllm): add support for accessing Linear layer weights and biases
- Add `weight()` and `bias()` methods to Linear layer class
- Implement `__py_push` method in ParameterFile for Python integration
- Update CMakeLists.txt to enable MLLM_ENABLE_PY_MLLM option
- Modify Core.cpp to use keep_alive for ParameterFile push method
- Update test_nn.py to demonstrate new weight and bias access functionality
- Add error_handler.py for improved error handling