### PR TITLE
feat(cpu): u1-u7 bitspack packing

### DIFF
--- a/docs/contribute/roadmap.rst
+++ b/docs/contribute/roadmap.rst
@@ -25,6 +25,7 @@ Transform models supported by v1 to v2.
 - Qwen3 Series
 - Qwen2 Series
 - Llama3 Series
+- TinyLlama
 
 Performance Optimization
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -70,7 +71,7 @@ Arm Kernel support
 
 - ✅ MLLM-BLAS fp32 GEMM Kernels (transpose_a=False, transpose_b=True) [@chenghua]
 - Element-wise Kernels has slightly performance issues
-- Arm I8-Gemm and I8-Gemv Kernels. (Co-works with bitspack)
+- Arm I8-Gemm and I8-Gemv Kernels. (Co-works with bitspack) [@chenghua]
 - Arm U1-7 Group Quantized Embedding Kernels. (Co-works with bitspack)
 - More KleidiAI Kernels (SME Supports)
 - Optimizing MLLM-BLAS-SGEMV and MLLM-BLAS-SGEMM Kernels, for Shapes in LLM Scenarios.

--- a/mllm/backends/cpu/kernels/arm/mllm_blas/mllm_blas_i8gemm.hpp
+++ b/mllm/backends/cpu/kernels/arm/mllm_blas/mllm_blas_i8gemm.hpp
@@ -17,7 +17,7 @@
 #include "mllm/backends/cpu/kernels/arm/quantize/bitspack/ux.hpp"
 
 namespace mllm::cpu::arm {
-namespace i8gemm_details {
+namespace bitspack_i8gemm_details {
 
 inline float32x4_t vec_clamp(float32x4_t x, float32x4_t vec_min, float32x4_t vec_max) {
   float32x4_t tmp = vmaxq_f32(x, vec_min);
@@ -241,8 +241,8 @@ void kernel_impl(
       if constexpr (has_clamp) {
         float32x4_t vec_min = vdupq_n_f32(clamp_min);
         float32x4_t vec_max = vdupq_n_f32(clamp_max);
-        res_0123 = i8gemm_details::vec_clamp(res_0123, vec_min, vec_max);
-        res_4567 = i8gemm_details::vec_clamp(res_4567, vec_min, vec_max);
+        res_0123 = bitspack_i8gemm_details::vec_clamp(res_0123, vec_min, vec_max);
+        res_4567 = bitspack_i8gemm_details::vec_clamp(res_4567, vec_min, vec_max);
       }
 
       // Store result
@@ -277,5 +277,5 @@ void kernel_impl(
   }  // m_idx
 }
 
-}  // namespace i8gemm_details
+}  // namespace bitspack_i8gemm_details
 }  // namespace mllm::cpu::arm

--- a/mllm/backends/cpu/kernels/arm/quantize/bitspack/bitspack.cpp
+++ b/mllm/backends/cpu/kernels/arm/quantize/bitspack/bitspack.cpp
@@ -1,0 +1,181 @@
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
+
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <arm_neon.h>
+
+#include <algorithm>
+#include <cassert>
+#include <cfenv>
+#include <cmath>
+#include "mllm/utils/Common.hpp"
+
+#include "mllm/backends/cpu/kernels/arm/quantize/bitspack/bitspack.hpp"
+
+#if defined(MLLM_HOST_ARCH_ARM64) || defined(MLLM_HOST_ARCH_ARM)
+
+namespace mllm::cpu::arm::bitspack {
+
+namespace quant_internal {
+
+void get_qvals_range(int& qmin, int& qmax, int nbit, bool is_symmetric) {
+  if (is_symmetric) {
+    qmin = -(1 << (nbit - 1)) + 1;
+    qmax = -qmin;
+  } else {
+    qmin = -(1 << (nbit - 1));
+    qmax = (1 << (nbit - 1)) - 1;
+  }
+}
+
+float get_scale(float vmin, float vmax, int qmin, int qmax) {
+  assert(qmin < qmax);
+  assert(vmin < vmax);
+  return (vmax - vmin) / (qmax - qmin);
+}
+
+void get_scale_and_zero(float& scale, int& zero, float vmin, float vmax, int qmin, int qmax) {
+  scale = get_scale(vmin, vmax, qmin, qmax);
+  zero = qmin - std::round(vmin / scale);
+}
+
+void find_min_and_max(float& min, float& max, const float* vals, int size) {
+  assert(size > 0);
+
+  // Needed in case size < 4 so we don't compare to
+  // uninitialized min/max values
+  min = vals[0];
+  max = min;
+
+  int i = 0;
+  if (i + 3 < size) {
+    float32x4_t mins = vld1q_f32(vals + i);
+    float32x4_t maxes = mins;
+    i += 4;
+    for (; i + 3 < size; i += 4) {
+      float32x4_t v = vld1q_f32(vals + i);
+      mins = vminq_f32(mins, v);
+      maxes = vmaxq_f32(maxes, v);
+    }
+    min = vminvq_f32(mins);
+    max = vmaxvq_f32(maxes);
+  }
+
+  // Remainder
+  while (i < size) {
+    if (vals[i] < min) { min = vals[i]; }
+    if (vals[i] > max) { max = vals[i]; }
+    i += 1;
+  }
+}
+
+int32_t compute_sum(const int8_t* vals, int size) {
+  assert(size >= 1);
+
+  int32_t res = 0;
+  int i = 0;
+
+#pragma unroll(4)
+  for (; i + 15 < size; i += 16) {
+    int8x16_t vec_vals = vld1q_s8(vals + i);
+    res += (int)(vaddlvq_s8(vec_vals));
+  }
+  for (; i < size; i += 1) { res += vals[i]; }
+  return res;
+}
+
+namespace {
+inline void _vec_clip_inplace(int32x4_t& vec, int32x4_t vec_min, int32x4_t vec_max) {
+  vec = vmaxq_s32(vec, vec_min);
+  vec = vminq_s32(vec, vec_max);
+}
+
+}  // namespace
+
+void quantize(
+    // Output
+    int8_t* qvals,
+    // Inputs
+    const float32_t* vals, int size, float32_t scale, int8_t zero, int8_t qmin, int8_t qmax) {
+  float32_t invScale = 1.0 / (scale + 1e-16);
+  float32x4_t vec_zero = vdupq_n_f32(zero);
+  float32x4_t vec_invScale = vdupq_n_f32(invScale);
+  int32x4_t vec_qmin = vdupq_n_s32(qmin);
+  int32x4_t vec_qmax = vdupq_n_s32(qmax);
+
+  float32x4_t vec_val;
+  float32x4_t vec_qval_f32;
+  int32x4_t vec_qval_s32;
+  int16x4_t vec_qval_s16_0;
+  int16x4_t vec_qval_s16_1;
+
+  int i = 0;
+  for (; (i + 8) < size; i += 8) {
+    //////////////////////////////////////
+    // Quantize first 4 element chunk to int16
+    //////////////////////////////////////
+    vec_val = vld1q_f32(vals + i);
+
+    // Quantize and round
+    vec_qval_f32 = vfmaq_f32(vec_zero, vec_val, vec_invScale);
+    vec_qval_s32 = vcvtnq_s32_f32(vec_qval_f32);
+
+    _vec_clip_inplace(vec_qval_s32, vec_qmin, vec_qmax);
+
+    vec_qval_s16_0 = vqmovn_s32(vec_qval_s32);
+
+    //////////////////////////////////////
+    // Quantize second 4 element chunk to int16
+    //////////////////////////////////////
+    vec_val = vld1q_f32(vals + i + 4);
+
+    // Quantize and round
+    vec_qval_f32 = vfmaq_f32(vec_zero, vec_val, vec_invScale);
+    vec_qval_s32 = vcvtnq_s32_f32(vec_qval_f32);
+
+    _vec_clip_inplace(vec_qval_s32, vec_qmin, vec_qmax);
+
+    vec_qval_s16_1 = vqmovn_s32(vec_qval_s32);
+
+    //////////////////////////////////////
+    // Store 8 quantized elements
+    //////////////////////////////////////
+    int16x8_t vec_qval_s16_01 = vcombine_s16(vec_qval_s16_0, vec_qval_s16_1);
+    int8x8_t vec_qval_s8_01 = vqmovn_s16(vec_qval_s16_01);
+    vst1_s8(qvals + i, vec_qval_s8_01);
+  }
+  auto curr_rounding_mode = fegetround();
+  fesetround(FE_TONEAREST);
+  for (; i < size; ++i) {
+    // Quantize remaining elements using scalar code
+    float32_t val = vals[i];
+    float32_t qval_f32 = zero + val * invScale;
+    int32_t qval_s32 = static_cast<int32_t>(std::nearbyint(qval_f32));
+
+    // Clip to qmin and qmax
+    qval_s32 = std::max(static_cast<int32_t>(qmin), std::min(qval_s32, static_cast<int32_t>(qmax)));
+
+    // Store the quantized value
+    qvals[i] = static_cast<int8_t>(qval_s32);
+  }
+  fesetround(int(curr_rounding_mode));
+}
+
+}  // namespace quant_internal
+
+namespace activation_packing {
+MLLM_EMPTY_SCOPE;
+}
+
+namespace weight_packing {
+MLLM_EMPTY_SCOPE;
+}
+
+}  // namespace mllm::cpu::arm::bitspack
+
+#endif

--- a/mllm/backends/cpu/kernels/arm/quantize/bitspack/bitspack.hpp
+++ b/mllm/backends/cpu/kernels/arm/quantize/bitspack/bitspack.hpp
@@ -1,0 +1,592 @@
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
+
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the license found in the
+// LICENSE file in the root directory of this source tree.
+
+// NOTE from mllm team.
+// Bitspack implement wxa32 quantization algorithms. It receive per-channel int8 activations and x bits per group quantized
+// weight as inputs, output fp32 activations.
+
+#pragma once
+
+#include <cstddef>
+#include <cassert>
+#include <array>
+
+#include "mllm/utils/CPUArchHelper.hpp"
+#include "mllm/backends/cpu/kernels/arm/macro.hpp"
+#include "mllm/backends/cpu/kernels/arm/quantize/bitspack/ux.hpp"
+#include "mllm/backends/cpu/kernels/arm/quantize/bitspack/ux_packing.hpp"
+
+#if defined(MLLM_HOST_ARCH_ARM64) || defined(MLLM_HOST_ARCH_ARM)
+
+#include <arm_neon.h>
+
+namespace mllm::cpu::arm::bitspack {
+
+// For quantize activations(per channel int8)
+namespace quant_internal {
+
+void get_qvals_range(int& qmin, int& qmax, int nbit, bool is_symmetric);
+
+// val = scale * qval
+float get_scale(float vmin, float vmax, int qmin, int qmax);
+
+// val = scale * (qval - zero)
+void get_scale_and_zero(float& scale, int& zero, float vmin, float vmax, int qmin, int qmax);
+
+void find_min_and_max(float& min, float& max, const float* vals, int size);
+
+int32_t compute_sum(const int8_t* vals, int size);
+
+void quantize(
+    // Output
+    int8_t* qvals,
+    // Inputs
+    const float32_t* vals, int size, float32_t scale, int8_t zero, int8_t qmin, int8_t qmax);
+
+}  // namespace quant_internal
+
+namespace activation_packing {
+
+// Prepares activation data for kernel_impl.
+//   Per m_idx (row), activations are stored as follows:
+//     scale (float), zero (int8_t),
+//     group0_qvals (int8_t[group_size]), [group0_qvals_sum (int32_t)]?
+//     group1_qvals (int8_t[group_size]), [group1_qvals_sum (int32_t)]?
+//     ...
+//   The groupi_qvals_sum is only present if has_weight_zeros = true.
+
+// Returns number of bytes required for activation_data
+size_t inline packed_activations_size(int m, int k,
+                                      // Ignored if has_weight_zeros = false
+                                      int group_size, bool has_weight_zeros) {
+  int row_size = 0;
+
+  // scale
+  row_size += sizeof(float);
+
+  // zero
+  row_size += sizeof(int8_t);
+
+  // qvals
+  row_size += sizeof(int8_t) * k;
+
+  // qvals_sum
+  if (has_weight_zeros) {
+    assert(k % group_size == 0);
+    int groups_per_row = k / group_size;
+    row_size += sizeof(int32_t) * groups_per_row;
+  }
+
+  return row_size * m;
+}
+
+template<int mr, int kr, int sr>
+void inline pack_activations(
+    // Output
+    void* activation_data,
+    // Inputs
+    int m, int k,
+    // Ignored if has_weight_zeros = false
+    int group_size, const float* activations, bool has_weight_zeros) {
+  // when mr == 1, kr/sr do not matter
+  static_assert(mr == 1);
+
+  auto activation_data_byte_ptr = (char*)activation_data;
+
+  float vmin, vmax, scale;
+  int qmin, qmax, zero, qvals_sum;
+  quant_internal::get_qvals_range(qmin, qmax, /*nbit=*/8, /*is_symmetric=*/false);
+
+  for (int m_idx = 0; m_idx < m; m_idx++) {
+    quant_internal::find_min_and_max(vmin, vmax, activations, k);
+    quant_internal::get_scale_and_zero(scale, zero, vmin, vmax, qmin, qmax);
+
+    // Save scale and zero
+    *(float32_t*)activation_data_byte_ptr = scale;
+    activation_data_byte_ptr += sizeof(float32_t);
+
+    *(int8_t*)activation_data_byte_ptr = (int8_t)zero;
+    activation_data_byte_ptr += sizeof(int8_t);
+
+    if (has_weight_zeros) {
+      for (int k_idx = 0; k_idx < k; k_idx += group_size) {
+        quant_internal::quantize(
+            /*qvals=*/(int8_t*)activation_data_byte_ptr,
+            /*vals=*/activations,
+            /*size=*/group_size,
+            /*scale=*/scale,
+            /*zero=*/zero,
+            /*qmin=*/qmin,
+            /*qmax=*/qmax);
+
+        qvals_sum = quant_internal::compute_sum(
+            /*vals=*/(int8_t*)activation_data_byte_ptr,
+            /*size=*/group_size);
+
+        activation_data_byte_ptr += group_size;
+
+        *(int32_t*)activation_data_byte_ptr = qvals_sum;
+        activation_data_byte_ptr += sizeof(int32_t);
+
+        activations += group_size;
+      }
+    } else {
+      quant_internal::quantize(
+          /*qvals=*/(int8_t*)activation_data_byte_ptr,
+          /*vals=*/activations,
+          /*size=*/k,
+          /*scale=*/scale,
+          /*zero=*/zero,
+          /*qmin=*/qmin,
+          /*qmax=*/qmax);
+      activation_data_byte_ptr += k;
+      activations += k;
+    }
+  }
+}
+
+}  // namespace activation_packing
+
+namespace weight_packing {
+namespace internal {
+
+// Packs a buffer of (kr * nr) lowbit values (stored as int8_t) down to bits
+template<int weight_nbit, int kr, int nr>
+MLLM_CPU_ARM_FORCE_INLINE void pack_buffer(void* packed_weights, const int8_t* buffer) {
+  if constexpr (kr * nr == 128) {
+    bitspack::vec_pack_128_lowbit_values<weight_nbit>((uint8_t*)packed_weights, vld1q_s8(buffer), vld1q_s8(buffer + 16),
+                                                      vld1q_s8(buffer + 32), vld1q_s8(buffer + 48), vld1q_s8(buffer + 64),
+                                                      vld1q_s8(buffer + 80), vld1q_s8(buffer + 96), vld1q_s8(buffer + 112));
+    return;
+  }
+  if constexpr (kr * nr == 64) {
+    bitspack::vec_pack_64_lowbit_values<weight_nbit>((uint8_t*)packed_weights, vld1q_s8(buffer), vld1q_s8(buffer + 16),
+                                                     vld1q_s8(buffer + 32), vld1q_s8(buffer + 48));
+    return;
+  }
+  if constexpr (kr * nr == 32) {
+    bitspack::vec_pack_32_lowbit_values<weight_nbit>((uint8_t*)packed_weights, vld1q_s8(buffer), vld1q_s8(buffer + 16));
+    return;
+  }
+  assert(false);
+}
+
+template<int weight_nbit, int kr, int nr>
+MLLM_CPU_ARM_FORCE_INLINE void pack_buffer_for_lut(void* packed_weights, const int8_t* buffer) {
+  static_assert(weight_nbit >= 1);
+  static_assert(weight_nbit <= 4);
+  const uint8_t* buffer_u8 = reinterpret_cast<const uint8_t*>(buffer);
+  if constexpr (kr * nr == 128) {
+    bitspack::vec_pack_128_uintx_values<weight_nbit>((uint8_t*)packed_weights, vld1q_u8(buffer_u8), vld1q_u8(buffer_u8 + 16),
+                                                     vld1q_u8(buffer_u8 + 32), vld1q_u8(buffer_u8 + 48),
+                                                     vld1q_u8(buffer_u8 + 64), vld1q_u8(buffer_u8 + 80),
+                                                     vld1q_u8(buffer_u8 + 96), vld1q_u8(buffer_u8 + 112));
+    return;
+  }
+  assert(false);
+}
+
+// Unpacks bits to a buffer of (kr * nr) lowbit values (stored as int8_t)
+template<int weight_nbit, int kr, int nr>
+MLLM_CPU_ARM_FORCE_INLINE void unpack_buffer(int8_t* buffer, const void* packed_weights) {
+  int8x16_t vals0;
+  int8x16_t vals1;
+  int8x16_t vals2;
+  int8x16_t vals3;
+  int8x16_t vals4;
+  int8x16_t vals5;
+  int8x16_t vals6;
+  int8x16_t vals7;
+
+  if constexpr (kr * nr == 128) {
+    bitspack::vec_unpack_128_lowbit_values<weight_nbit>(vals0, vals1, vals2, vals3, vals4, vals5, vals6, vals7,
+                                                        (const uint8_t*)packed_weights);
+    vst1q_s8(buffer, vals0);
+    vst1q_s8(buffer + 16, vals1);
+    vst1q_s8(buffer + 32, vals2);
+    vst1q_s8(buffer + 48, vals3);
+    vst1q_s8(buffer + 64, vals4);
+    vst1q_s8(buffer + 80, vals5);
+    vst1q_s8(buffer + 96, vals6);
+    vst1q_s8(buffer + 112, vals7);
+    return;
+  }
+  if constexpr (kr * nr == 64) {
+    bitspack::vec_unpack_64_lowbit_values<weight_nbit>(vals0, vals1, vals2, vals3, (const uint8_t*)packed_weights);
+    vst1q_s8(buffer, vals0);
+    vst1q_s8(buffer + 16, vals1);
+    vst1q_s8(buffer + 32, vals2);
+    vst1q_s8(buffer + 48, vals3);
+    return;
+  }
+  if constexpr (kr * nr == 32) {
+    bitspack::vec_unpack_32_lowbit_values<weight_nbit>(vals0, vals1, (const uint8_t*)packed_weights);
+    vst1q_s8(buffer, vals0);
+    vst1q_s8(buffer + 16, vals1);
+    return;
+  }
+  assert(false);
+}
+
+// Size in bytes of 1 packed weights column
+size_t inline packed_weights_size_per_n(int k, int group_size, int weight_nbit, bool has_weight_zeros, bool has_bias) {
+  assert(k % group_size == 0);
+  int groups_per_col = k / group_size;
+  int col_size = 0;
+
+  // qvals
+  col_size += (k / 8) * weight_nbit;
+
+  // scales
+  col_size += sizeof(float) * groups_per_col;
+
+  // qvals_sum
+  col_size += sizeof(int32_t) * groups_per_col;
+
+  // zeros
+  if (has_weight_zeros) { col_size += sizeof(int32_t) * groups_per_col; }
+
+  // bias
+  if (has_bias) { col_size += sizeof(float); }
+
+  return col_size;
+}
+
+MLLM_CPU_ARM_FORCE_INLINE void map_values(int8_t* dst, int8_t* src, int8x16_t lut, int size) {
+  // src will be in range 0 to 16, which fits in int8_t
+  assert(size % 16 == 0);
+  for (int i = 0; i < size; i += 16) {
+    uint8x16_t idx = vreinterpretq_u8_s8(vld1q_s8(src + i));
+    vst1q_s8(dst + i, vqtbl1q_s8(lut, idx));
+  }
+}
+
+// Call pack_weights every n_step columns
+
+template<int weight_nbit, int nr, int kr, int sr, bool has_lut>
+MLLM_CPU_ARM_FORCE_INLINE void pack_weights_impl(
+    // Output
+    void* packed_weights,
+    // Inputs
+    int n, int k, int group_size,
+    // weight_ints holds weight_qvals if has_lut is false
+    // Otherwise it holds weight_qval_idxs
+    const int8_t* weight_ints,
+    // number of luts, not used if has_lut is false
+    // must be nr group or coarser (per tensor)
+    int n_luts,
+    const int8_t* luts,  // luts (each 2**weight_nbit values), not used if has_lut is false
+    const float* weight_scales,
+    // weight_zeros not packed if nullptr
+    const int8_t* weight_zeros,
+    // bias not packed if nullptr
+    const float* bias) {
+  if constexpr (!has_lut) {
+    (void)n_luts;  // unused
+    (void)luts;    // unused
+  }
+
+  assert(k % group_size == 0);
+  assert(group_size % kr == 0);
+  bool has_weight_zeros = (weight_zeros != nullptr);
+  bool has_bias = (bias != nullptr);
+  int groups_per_k = k / group_size;
+
+  // LUT has size lut_size, which is <= 16
+  // If lut_size < 16, we extend it with 0s in lut_buffer
+  int8x16_t lut;
+  constexpr int lut_size = (1 << weight_nbit);
+  std::array<int8_t, 16> lut_buffer;
+  int cols_per_lut;
+
+  // Buffer to hold kr qvals, mapped with LUT from qval_idxs
+  std::array<int8_t, kr> mapped_val_buffer;
+  if constexpr (has_lut) {
+    static_assert(weight_nbit <= 4);
+    static_assert(lut_size <= 16);
+    lut_buffer.fill(0);
+
+    assert(n % n_luts == 0);
+    cols_per_lut = n / n_luts;
+    assert((cols_per_lut == n) || (cols_per_lut % nr == 0));
+  } else {
+    (void)lut;                // unused
+    (void)lut_size;           // unused
+    (void)lut_buffer;         // unused
+    (void)cols_per_lut;       // unused
+    (void)mapped_val_buffer;  // unused
+  }
+
+  // Buffer to hold (kr * nr) values
+  std::array<int8_t, nr * kr> buffer;
+
+  // Buffer to hold (kr * nr) values after theose values
+  // are packed by params (nr, kr, sr)
+  int8_t packed_values[buffer.size()];
+
+  // Bytes of packed buffer of (nr * kr) values
+  assert(nr * kr % 8 == 0);
+  constexpr int packed_buffer_bytes = weight_nbit * nr * kr / 8;
+
+  // Buffer to hold sum of weight_qvals in each column group
+  std::array<int, nr> qvals_sum;
+
+  // Data pointer for packed weights
+  auto packed_weights_byte_ptr = (char*)packed_weights;
+
+  // Loop over n by nr
+  for (int n_idx = 0; n_idx < n; n_idx += nr) {
+    // Look over groups along k
+    for (int group_idx = 0; group_idx < groups_per_k; group_idx++) {
+      // Populate lut and write it out to packed_weights
+      if constexpr (has_lut) {
+        // Set lut variable and write lut for nr group
+        if (group_idx == 0) {
+          int lut_idx = n_idx / cols_per_lut;
+          std::memcpy(lut_buffer.data(), luts + lut_idx * lut_size, lut_size);
+          lut = vld1q_s8(lut_buffer.data());
+          vst1q_s8((int8_t*)packed_weights_byte_ptr, lut);
+          packed_weights_byte_ptr += 16;
+        }
+      }
+
+      // Initialize qvals_sum for each group to 0
+      qvals_sum.fill(0);
+
+      // Loop over group by kr and pack the weights for the next nr columns
+      int k_idx = group_idx * group_size;
+      for (int idx_in_group = 0; idx_in_group < group_size; idx_in_group += kr) {
+        // Fill buffer with next kr values from the next nr columns
+        // If there are fewer than nr columns, 0s are stored
+        buffer.fill(0);
+        for (int j = 0; j < nr; j++) {
+          if (n_idx + j < n) {
+            std::memcpy(buffer.data() + kr * j, weight_ints + (n_idx + j) * k + (k_idx + idx_in_group), kr);
+            if constexpr (has_lut) {
+              internal::map_values(mapped_val_buffer.data(), buffer.data() + kr * j, lut, kr);
+              qvals_sum[j] += quant_internal::compute_sum(mapped_val_buffer.data(), kr);
+            } else {
+              qvals_sum[j] += quant_internal::compute_sum(buffer.data() + kr * j, kr);
+            }
+          }
+        }
+
+        // Pack buffer
+        bitspack::pack_values(packed_values, buffer.data(), nr, kr, sr);
+        if constexpr (has_lut) {
+          internal::pack_buffer_for_lut<weight_nbit, kr, nr>(packed_weights_byte_ptr, packed_values);
+        } else {
+          internal::pack_buffer<weight_nbit, kr, nr>(packed_weights_byte_ptr, packed_values);
+        }
+        packed_weights_byte_ptr += packed_buffer_bytes;
+      }  // loop over group (idx_in_group)
+
+      // Store group attributes scale, qval_sums, and zeros for next nr columns
+      // If there are fewer than nr columns, 0s are stored
+
+      // Store weight scales
+      for (int j = 0; j < nr; j++) {
+        float32_t scale = 0.0;
+        if (n_idx + j < n) { scale = weight_scales[(n_idx + j) * groups_per_k + group_idx]; }
+        *((float*)packed_weights_byte_ptr) = scale;
+        packed_weights_byte_ptr += sizeof(float);
+      }
+
+      // Store weight qval sums
+      for (int j = 0; j < nr; j++) {
+        *((int*)packed_weights_byte_ptr) = qvals_sum[j];
+        packed_weights_byte_ptr += sizeof(int);
+      }
+
+      // Store weight zeros
+      if (has_weight_zeros) {
+        for (int j = 0; j < nr; j++) {
+          int32_t zero = 0;
+          if (n_idx + j < n) { zero = weight_zeros[(n_idx + j) * groups_per_k + group_idx]; }
+          *((int32_t*)packed_weights_byte_ptr) = zero;
+          packed_weights_byte_ptr += sizeof(int32_t);
+        }
+      }
+    }  // loop over k (group_idx)
+
+    // Store bias for next nr columns
+    if (has_bias) {
+      for (int j = 0; j < nr; j++) {
+        float bias_ = 0.0;
+        if (n_idx + j < n) { bias_ = bias[n_idx + j]; }
+        *((float*)packed_weights_byte_ptr) = bias_;
+        packed_weights_byte_ptr += sizeof(float);
+      }
+    }
+  }  // n_idx
+}
+
+}  // namespace internal
+
+template<int weight_nbit, int nr, int kr, int sr>
+void pack_weights(
+    // Output
+    void* packed_weights,
+    // Inputs
+    int n, int k, int group_size, const int8_t* weight_qvals, const float* weight_scales,
+    // weight_zeros not packed if nullptr
+    const int8_t* weight_zeros,
+    // bias not packed if nullptr
+    const float* bias) {
+  internal::pack_weights_impl<weight_nbit, nr, kr, sr, /*has_lut*/ false>(packed_weights, n, k, group_size,
+                                                                          /*weight_ints*/ weight_qvals,
+                                                                          /*n_luts*/ 0,
+                                                                          /*luts*/ nullptr, weight_scales, weight_zeros, bias);
+}
+
+// Returns number of bytes required for weight_data
+size_t inline packed_weights_size(int n, int k, int group_size, int weight_nbit, bool has_weight_zeros, bool has_bias, int nr) {
+  auto packed_weights_size_per_n = internal::packed_weights_size_per_n(k, group_size, weight_nbit, has_weight_zeros, has_bias);
+
+  // Replace n with next multiple of nr >= n
+  n = ((n + nr - 1) / nr) * nr;
+  return packed_weights_size_per_n * n;
+}
+
+// Unpack weights at n_idx to support shared embedding/unembedding
+template<int weight_nbit, int nr, int kr, int sr>
+void unpack_weights_at_n_idx(
+    // Output
+    int8_t* weight_qvals,  // k * nr values at n_idx
+    float* weight_scales,  // groups_per_k * nr values at n_idx
+    // weight_zeros is not extracted if has_weight_zeros is false
+    int8_t* weight_zeros,  // groups_per_k * nr values at n_idx
+    // bias is not extracted if has_bias is false
+    float* bias,  // nr values at n_idx
+    // Inputs
+    int n_idx, int n, int k, int group_size, bool has_weight_zeros, bool has_bias, const void* packed_weights) {
+  assert(k % group_size == 0);
+  assert(group_size % kr == 0);
+  assert(n_idx % nr == 0);
+
+  int groups_per_k = k / group_size;
+
+  // Buffer to hold (kr * nr) values
+  std::array<int8_t, nr * kr> buffer;
+
+  // Buffer to hold (kr * nr) values after theose values
+  // are packed by params (nr, kr, sr)
+  int8_t packed_values[buffer.size()];
+
+  // Bytes of packed buffer of (nr * kr) values
+  assert(nr * kr % 8 == 0);
+  constexpr int packed_buffer_bytes = weight_nbit * nr * kr / 8;
+
+  // Data pointer for packed weights
+  auto packed_weights_byte_ptr =
+      ((char*)packed_weights
+       + n_idx * internal::packed_weights_size_per_n(k, group_size, weight_nbit, has_weight_zeros, has_bias));
+
+  // Look over groups along k
+  for (int group_idx = 0; group_idx < groups_per_k; group_idx++) {
+    // Loop over group by kr and pack the weights for the next nr columns
+    int k_idx = group_idx * group_size;
+    for (int idx_in_group = 0; idx_in_group < group_size; idx_in_group += kr) {
+      // Unpack qvals
+      internal::unpack_buffer<weight_nbit, kr, nr>(packed_values, packed_weights_byte_ptr);
+      packed_weights_byte_ptr += packed_buffer_bytes;
+      bitspack::unpack_values(buffer.data(), packed_values, nr, kr, sr);
+
+      // Write weight_qvals
+      for (int j = 0; j < nr; j++) {
+        if (n_idx + j < n) { std::memcpy(weight_qvals + j * k + (k_idx + idx_in_group), buffer.data() + kr * j, kr); }
+      }
+
+    }  // loop over group (idx_in_group)
+
+    // Write group scales and zeros for next nr columns
+
+    // Write weight scales
+    for (int j = 0; j < nr; j++) {
+      float scale = *((float*)packed_weights_byte_ptr);
+      packed_weights_byte_ptr += sizeof(float);
+      if (n_idx + j < n) { weight_scales[j * groups_per_k + group_idx] = scale; }
+    }
+
+    // Skip over weight qval sums
+    packed_weights_byte_ptr += nr * sizeof(int);
+
+    // Write weight zeros
+    if (has_weight_zeros) {
+      for (int j = 0; j < nr; j++) {
+        int32_t zero = *((int32_t*)packed_weights_byte_ptr);
+        packed_weights_byte_ptr += sizeof(int32_t);
+        if (n_idx + j < n) { weight_zeros[j * groups_per_k + group_idx] = (int8_t)zero; }
+      }
+    }
+
+  }  // loop over k (group_idx)
+
+  // Write bias
+  if (has_bias) {
+    for (int j = 0; j < nr; j++) {
+      float bias_ = *((float*)packed_weights_byte_ptr);
+      packed_weights_byte_ptr += sizeof(float);
+      if (n_idx + j < n) { bias[j] = bias_; }
+    }
+  }
+}
+
+template<int weight_nbit, int nr, int kr, int sr>
+void unpack_weights(
+    // Output
+    int8_t* weight_qvals, float* weight_scales,
+    // weight_zeros is not extracted if has_weight_zeros is false
+    int8_t* weight_zeros,
+    // bias is not extracted if has_bias is false
+    float* bias,
+    // Inputs
+    int n, int k, int group_size, bool has_weight_zeros, bool has_bias, const void* packed_weights) {
+  assert(k % group_size == 0);
+  assert(group_size % kr == 0);
+  int groups_per_k = k / group_size;
+
+  for (int n_idx = 0; n_idx < n; n_idx += nr) {
+    unpack_weights_at_n_idx<weight_nbit, nr, kr, sr>(weight_qvals + n_idx * k, weight_scales + n_idx * groups_per_k,
+                                                     weight_zeros + n_idx * groups_per_k, bias + n_idx, n_idx, n, k, group_size,
+                                                     has_weight_zeros, has_bias, packed_weights);
+  }
+}
+
+template<int weight_nbit, int nr, int kr, int sr>
+void pack_weights_with_lut(
+    // Output
+    void* packed_weights,
+    // Inputs
+    int n, int k, int group_size, const int8_t* weight_qval_idxs, int n_luts, const int8_t* luts, const float* weight_scales,
+    // weight_zeros not packed if nullptr
+    const int8_t* weight_zeros,
+    // bias not packed if nullptr
+    const float* bias) {
+  internal::pack_weights_impl<weight_nbit, nr, kr, sr, /*has_lut*/ true>(packed_weights, n, k, group_size, weight_qval_idxs,
+                                                                         n_luts, luts, weight_scales, weight_zeros, bias);
+}
+
+size_t inline packed_weights_with_lut_size(int n, int k, int group_size, int weight_nbit, bool has_weight_zeros, bool has_bias,
+                                           int nr) {
+  auto packed_weights_col_size = internal::packed_weights_size_per_n(k, group_size, weight_nbit, has_weight_zeros, has_bias);
+
+  // Replace n with next multiple of nr >= n
+  n = ((n + nr - 1) / nr) * nr;
+
+  // Per nr columns, we have one 16 byte lut
+  auto lut_size = (n / nr) * 16;
+
+  return packed_weights_col_size * n + lut_size;
+}
+}  // namespace weight_packing
+
+}  // namespace mllm::cpu::arm::bitspack
+
+#endif

--- a/mllm/backends/cpu/kernels/arm/quantize/bitspack/u1.hpp
+++ b/mllm/backends/cpu/kernels/arm/quantize/bitspack/u1.hpp
@@ -11,7 +11,7 @@
 
 #if defined(MLLM_HOST_ARCH_ARM64) || defined(MLLM_HOST_ARCH_ARM)
 
-namespace mllm::cpu::arm {
+namespace mllm::cpu::arm::bitspack {
 
 // We use the code from torch for u1-u7 bits packing/unpacking.
 
@@ -115,5 +115,5 @@ MLLM_CPU_ARM_FORCE_INLINE void vec_unpack_128_uint1_values(uint8x16_t& unpacked0
   unpacked7 = vandq_u8(vec_packed, vdupq_n_u8(1));
 }
 
-}  // namespace mllm::cpu::arm
+}  // namespace mllm::cpu::arm::bitspack
 #endif

--- a/mllm/backends/cpu/kernels/arm/quantize/bitspack/u2.hpp
+++ b/mllm/backends/cpu/kernels/arm/quantize/bitspack/u2.hpp
@@ -11,7 +11,7 @@
 
 #if defined(MLLM_HOST_ARCH_ARM64) || defined(MLLM_HOST_ARCH_ARM)
 
-namespace mllm::cpu::arm {
+namespace mllm::cpu::arm::bitspack {
 
 // We use the code from torch for u1-u7 bits packing/unpacking.
 
@@ -110,6 +110,6 @@ MLLM_CPU_ARM_FORCE_INLINE void vec_unpack_64_uint2_values(uint8x16_t& unpacked0,
   unpacked2 = vshrq_n_u8(vandq_u8(vec_packed, vdupq_n_u8(12)), 2);
   unpacked3 = vandq_u8(vec_packed, vdupq_n_u8(3));
 }
-}  // namespace mllm::cpu::arm
+}  // namespace mllm::cpu::arm::bitspack
 
 #endif

--- a/mllm/backends/cpu/kernels/arm/quantize/bitspack/u3.hpp
+++ b/mllm/backends/cpu/kernels/arm/quantize/bitspack/u3.hpp
@@ -11,7 +11,7 @@
 
 #if defined(MLLM_HOST_ARCH_ARM64) || defined(MLLM_HOST_ARCH_ARM)
 
-namespace mllm::cpu::arm {
+namespace mllm::cpu::arm::bitspack {
 
 // We use the code from torch for u1-u7 bits packing/unpacking.
 
@@ -249,6 +249,6 @@ MLLM_CPU_ARM_FORCE_INLINE void vec_unpack_128_uint3_values(uint8x16_t& unpacked0
   unpacked7 = vorrq_u8(unpacked7, vandq_u8(vshrq_n_u8(b2, 4), mask));
 }
 
-}  // namespace mllm::cpu::arm
+}  // namespace mllm::cpu::arm::bitspack
 
 #endif

--- a/mllm/backends/cpu/kernels/arm/quantize/bitspack/u4.hpp
+++ b/mllm/backends/cpu/kernels/arm/quantize/bitspack/u4.hpp
@@ -11,7 +11,7 @@
 
 #if defined(MLLM_HOST_ARCH_ARM64) || defined(MLLM_HOST_ARCH_ARM)
 
-namespace mllm::cpu::arm {
+namespace mllm::cpu::arm::bitspack {
 
 // We use the code from torch for u1-u7 bits packing/unpacking.
 
@@ -56,6 +56,6 @@ MLLM_CPU_ARM_FORCE_INLINE void vec_unpack_32_uint4_values(uint8x16_t& unpacked0,
   unpacked0 = vandq_u8(packed_ld, vdupq_n_u8(0xF));
 }
 
-}  // namespace mllm::cpu::arm
+}  // namespace mllm::cpu::arm::bitspack
 
 #endif

--- a/mllm/backends/cpu/kernels/arm/quantize/bitspack/u5.hpp
+++ b/mllm/backends/cpu/kernels/arm/quantize/bitspack/u5.hpp
@@ -11,7 +11,7 @@
 
 #if defined(MLLM_HOST_ARCH_ARM64) || defined(MLLM_HOST_ARCH_ARM)
 
-namespace mllm::cpu::arm {
+namespace mllm::cpu::arm::bitspack {
 
 // We use the code from torch for u1-u7 bits packing/unpacking.
 
@@ -174,5 +174,5 @@ MLLM_CPU_ARM_FORCE_INLINE void vec_unpack_128_uint5_values(uint8x16_t& unpacked0
   unpacked6 = vandq_u8(p3, vdupq_n_u8(0b11111));
   unpacked7 = vorrq_u8(vshrq_n_u8(p3, 5), vshrq_n_u8(vandq_u8(p4, vdupq_n_u8(0b11000000)), 3));
 }
-}  // namespace mllm::cpu::arm
+}  // namespace mllm::cpu::arm::bitspack
 #endif

--- a/mllm/backends/cpu/kernels/arm/quantize/bitspack/u6.hpp
+++ b/mllm/backends/cpu/kernels/arm/quantize/bitspack/u6.hpp
@@ -11,7 +11,7 @@
 
 #if defined(MLLM_HOST_ARCH_ARM64) || defined(MLLM_HOST_ARCH_ARM)
 
-namespace mllm::cpu::arm {
+namespace mllm::cpu::arm::bitspack {
 
 // We use the code from torch for u1-u7 bits packing/unpacking.
 
@@ -189,5 +189,5 @@ MLLM_CPU_ARM_FORCE_INLINE void vec_unpack_64_uint6_values(uint8x16_t& unpacked0,
   unpacked1 = vandq_u8(unpacked1, mask);
   unpacked2 = vandq_u8(unpacked2, mask);
 }
-}  // namespace mllm::cpu::arm
+}  // namespace mllm::cpu::arm::bitspack
 #endif

--- a/mllm/backends/cpu/kernels/arm/quantize/bitspack/u7.hpp
+++ b/mllm/backends/cpu/kernels/arm/quantize/bitspack/u7.hpp
@@ -11,7 +11,7 @@
 
 #if defined(MLLM_HOST_ARCH_ARM64) || defined(MLLM_HOST_ARCH_ARM)
 
-namespace mllm::cpu::arm {
+namespace mllm::cpu::arm::bitspack {
 
 // We use the code from torch for u1-u7 bits packing/unpacking.
 
@@ -234,5 +234,5 @@ MLLM_CPU_ARM_FORCE_INLINE void vec_unpack_128_uint7_values(uint8x16_t& unpacked0
   unpacked7 = vsriq_n_u8(unpacked7, unpacked0, 7);
   unpacked0 = vandq_u8(unpacked0, mask);
 }
-}  // namespace mllm::cpu::arm
+}  // namespace mllm::cpu::arm::bitspack
 #endif

--- a/mllm/backends/cpu/kernels/arm/quantize/bitspack/ux.hpp
+++ b/mllm/backends/cpu/kernels/arm/quantize/bitspack/ux.hpp
@@ -136,6 +136,87 @@ MLLM_CPU_ARM_FORCE_INLINE void vec_pack_32_lowbit_values(uint8_t* packed, const 
 }
 
 template<int nbit>
+MLLM_CPU_ARM_FORCE_INLINE void vec_pack_32_uintx_values(uint8_t* packed, const uint8x16_t& unpacked0,
+                                                        const uint8x16_t& unpacked1) {
+  // Ensure nbit is within the valid range [1, 8]
+  static_assert(nbit < 9);
+  static_assert(nbit >= 1);
+
+  switch (nbit) {
+    case 1: {
+      // For 1-bit, we store the 32 values into a temporary buffer
+      // and then pack them in 8-value chunks.
+      uint8_t buffer[32];
+      vst1q_u8(buffer, unpacked0);
+      vst1q_u8(buffer + 16, unpacked1);
+
+      pack_8_uint1_values(packed, buffer);
+      pack_8_uint1_values(packed + 1, buffer + 8);
+      pack_8_uint1_values(packed + 2, buffer + 16);
+      pack_8_uint1_values(packed + 3, buffer + 24);
+      break;
+    }
+    case 2:
+      // Use the existing vectorized implementation for 2-bit packing.
+      vec_pack_32_uint2_values(packed, vget_low_u8(unpacked0), vget_high_u8(unpacked0), vget_low_u8(unpacked1),
+                               vget_high_u8(unpacked1));
+      break;
+    case 3: {
+      // For 3-bit, we store to a buffer and pack in 8-value chunks.
+      uint8_t buffer[32];
+      vst1q_u8(buffer, unpacked0);
+      vst1q_u8(buffer + 16, unpacked1);
+
+      pack_8_uint3_values(packed, buffer);
+      pack_8_uint3_values(packed + 3, buffer + 8);
+      pack_8_uint3_values(packed + 6, buffer + 16);
+      pack_8_uint3_values(packed + 9, buffer + 24);
+      break;
+    }
+    case 4:
+      // Use the existing vectorized implementation for 4-bit packing.
+      vec_pack_32_uint4_values(packed, unpacked0, unpacked1);
+      break;
+    case 5: {
+      // For 5-bit, we store to a buffer and pack in 8-value chunks.
+      uint8_t buffer[32];
+      vst1q_u8(buffer, unpacked0);
+      vst1q_u8(buffer + 16, unpacked1);
+
+      pack_8_uint5_values(packed, buffer);
+      pack_8_uint5_values(packed + 5, buffer + 8);
+      pack_8_uint5_values(packed + 10, buffer + 16);
+      pack_8_uint5_values(packed + 15, buffer + 24);
+      break;
+    }
+    case 6:
+      // Use the existing vectorized implementation for 6-bit packing.
+      vec_pack_32_uint6_values(packed, unpacked0, unpacked1);
+      break;
+    case 7: {
+      // For 7-bit, we store to a buffer and pack in 8-value chunks.
+      uint8_t buffer[32];
+      vst1q_u8(buffer, unpacked0);
+      vst1q_u8(buffer + 16, unpacked1);
+
+      pack_8_uint7_values(packed, buffer);
+      pack_8_uint7_values(packed + 7, buffer + 8);
+      pack_8_uint7_values(packed + 14, buffer + 16);
+      pack_8_uint7_values(packed + 21, buffer + 24);
+      break;
+    }
+    case 8:
+      // For 8-bit, it's a direct memory store of the two vectors.
+      vst1q_u8(packed, unpacked0);
+      vst1q_u8(packed + 16, unpacked1);
+      break;
+    default:
+      // This should be unreachable due to the static_asserts
+      assert(false);
+  }
+}
+
+template<int nbit>
 MLLM_CPU_ARM_FORCE_INLINE void vec_unpack_32_lowbit_values(int8x16_t& unpacked0, int8x16_t& unpacked1, const uint8_t* packed) {
   static_assert(nbit < 9);
   static_assert(nbit >= 1);
@@ -250,6 +331,39 @@ MLLM_CPU_ARM_FORCE_INLINE void vec_pack_64_lowbit_values(uint8_t* packed, const 
 }
 
 template<int nbit>
+MLLM_CPU_ARM_FORCE_INLINE void vec_pack_64_uintx_values(uint8_t* packed, const uint8x16_t& unpacked0,
+                                                        const uint8x16_t& unpacked1, const uint8x16_t& unpacked2,
+                                                        const uint8x16_t& unpacked3) {
+  static_assert(nbit < 9);
+  static_assert(nbit >= 1);
+
+  // No shifting is needed because the data is already unsigned.
+
+  switch (nbit) {
+    case 1:
+      // The internal functions are already designed to take uint8x16_t
+      vec_pack_64_uint1_values(packed, unpacked0, unpacked1, unpacked2, unpacked3);
+      break;
+    case 2: vec_pack_64_uint2_values(packed, unpacked0, unpacked1, unpacked2, unpacked3); break;
+    case 3: vec_pack_64_uint3_values(packed, unpacked0, unpacked1, unpacked2, unpacked3); break;
+    case 4:
+      vec_pack_32_uint4_values(packed, unpacked0, unpacked1);
+      vec_pack_32_uint4_values(packed + 16, unpacked2, unpacked3);
+      break;
+    case 5: vec_pack_64_uint5_values(packed, unpacked0, unpacked1, unpacked2, unpacked3); break;
+    case 6: vec_pack_64_uint6_values(packed, unpacked0, unpacked1, unpacked2, unpacked3); break;
+    case 7: vec_pack_64_uint7_values(packed, unpacked0, unpacked1, unpacked2, unpacked3); break;
+    case 8:
+      vst1q_u8(packed, unpacked0);
+      vst1q_u8(packed + 16, unpacked1);
+      vst1q_u8(packed + 32, unpacked2);
+      vst1q_u8(packed + 48, unpacked3);
+      break;
+    default: assert(false);
+  }
+}
+
+template<int nbit>
 MLLM_CPU_ARM_FORCE_INLINE void vec_unpack_64_lowbit_values(int8x16_t& unpacked0, int8x16_t& unpacked1, int8x16_t& unpacked2,
                                                            int8x16_t& unpacked3, const uint8_t* packed) {
   static_assert(nbit < 9);
@@ -288,6 +402,107 @@ MLLM_CPU_ARM_FORCE_INLINE void vec_unpack_64_lowbit_values(int8x16_t& unpacked0,
     unpacked1 = vaddq_s8(vreinterpretq_s8_u8(shifted1), unshift);
     unpacked2 = vaddq_s8(vreinterpretq_s8_u8(shifted2), unshift);
     unpacked3 = vaddq_s8(vreinterpretq_s8_u8(shifted3), unshift);
+  }
+}
+
+template<int nbit>
+MLLM_CPU_ARM_FORCE_INLINE void vec_pack_128_uintx_values(uint8_t* packed, const uint8x16_t& unpacked0,
+                                                         const uint8x16_t& unpacked1, const uint8x16_t& unpacked2,
+                                                         const uint8x16_t& unpacked3, const uint8x16_t& unpacked4,
+                                                         const uint8x16_t& unpacked5, const uint8x16_t& unpacked6,
+                                                         const uint8x16_t& unpacked7) {
+  static_assert(nbit < 9);
+  static_assert(nbit >= 1);
+  switch (nbit) {
+    case 1:
+      vec_pack_128_uint1_values(packed, unpacked0, unpacked1, unpacked2, unpacked3, unpacked4, unpacked5, unpacked6, unpacked7);
+      break;
+    case 2:
+      vec_pack_64_uint2_values(packed, unpacked0, unpacked1, unpacked2, unpacked3);
+      vec_pack_64_uint2_values(packed + 16, unpacked4, unpacked5, unpacked6, unpacked7);
+      break;
+    case 3:
+      vec_pack_128_uint3_values(packed, unpacked0, unpacked1, unpacked2, unpacked3, unpacked4, unpacked5, unpacked6, unpacked7);
+      break;
+    case 4:
+      vec_pack_32_uint4_values(packed, unpacked0, unpacked1);
+      vec_pack_32_uint4_values(packed + 16, unpacked2, unpacked3);
+      vec_pack_32_uint4_values(packed + 32, unpacked4, unpacked5);
+      vec_pack_32_uint4_values(packed + 48, unpacked6, unpacked7);
+      break;
+    case 5:
+      vec_pack_128_uint5_values(packed, unpacked0, unpacked1, unpacked2, unpacked3, unpacked4, unpacked5, unpacked6, unpacked7);
+      break;
+    case 6:
+      vec_pack_64_uint6_values(packed, unpacked0, unpacked1, unpacked2, unpacked3);
+      vec_pack_64_uint6_values(packed + 48, unpacked4, unpacked5, unpacked6, unpacked7);
+      break;
+    case 7:
+      vec_pack_128_uint7_values(packed, unpacked0, unpacked1, unpacked2, unpacked3, unpacked4, unpacked5, unpacked6, unpacked7);
+      break;
+    case 8:
+      vst1q_u8(packed, unpacked0);
+      vst1q_u8(packed + 16, unpacked1);
+      vst1q_u8(packed + 32, unpacked2);
+      vst1q_u8(packed + 48, unpacked3);
+      vst1q_u8(packed + 64, unpacked4);
+      vst1q_u8(packed + 80, unpacked5);
+      vst1q_u8(packed + 96, unpacked6);
+      vst1q_u8(packed + 112, unpacked7);
+      break;
+    default: assert(false);
+  }
+}
+
+template<int nbit>
+MLLM_CPU_ARM_FORCE_INLINE void vec_unpack_128_uintx_values(uint8x16_t& unpacked0, uint8x16_t& unpacked1, uint8x16_t& unpacked2,
+                                                           uint8x16_t& unpacked3, uint8x16_t& unpacked4, uint8x16_t& unpacked5,
+                                                           uint8x16_t& unpacked6, uint8x16_t& unpacked7,
+                                                           const uint8_t* packed) {
+  static_assert(nbit < 9);
+  static_assert(nbit >= 1);
+  switch (nbit) {
+    case 1:
+      vec_unpack_128_uint1_values(unpacked0, unpacked1, unpacked2, unpacked3, unpacked4, unpacked5, unpacked6, unpacked7,
+                                  packed);
+      break;
+    case 2:
+      vec_unpack_64_uint2_values(unpacked0, unpacked1, unpacked2, unpacked3, packed);
+      vec_unpack_64_uint2_values(unpacked4, unpacked5, unpacked6, unpacked7, packed + 16);
+      break;
+    case 3:
+      vec_unpack_128_uint3_values(unpacked0, unpacked1, unpacked2, unpacked3, unpacked4, unpacked5, unpacked6, unpacked7,
+                                  packed);
+      break;
+    case 4:
+      vec_unpack_32_uint4_values(unpacked0, unpacked1, packed);
+      vec_unpack_32_uint4_values(unpacked2, unpacked3, packed + 16);
+      vec_unpack_32_uint4_values(unpacked4, unpacked5, packed + 32);
+      vec_unpack_32_uint4_values(unpacked6, unpacked7, packed + 48);
+      break;
+    case 5:
+      vec_unpack_128_uint5_values(unpacked0, unpacked1, unpacked2, unpacked3, unpacked4, unpacked5, unpacked6, unpacked7,
+                                  packed);
+      break;
+    case 6:
+      vec_unpack_64_uint6_values(unpacked0, unpacked1, unpacked2, unpacked3, packed);
+      vec_unpack_64_uint6_values(unpacked4, unpacked5, unpacked6, unpacked7, packed + 48);
+      break;
+    case 7:
+      vec_unpack_128_uint7_values(unpacked0, unpacked1, unpacked2, unpacked3, unpacked4, unpacked5, unpacked6, unpacked7,
+                                  packed);
+      break;
+    case 8:
+      unpacked0 = vld1q_u8(packed);
+      unpacked1 = vld1q_u8(packed + 16);
+      unpacked2 = vld1q_u8(packed + 32);
+      unpacked3 = vld1q_u8(packed + 48);
+      unpacked4 = vld1q_u8(packed + 64);
+      unpacked5 = vld1q_u8(packed + 80);
+      unpacked6 = vld1q_u8(packed + 96);
+      unpacked7 = vld1q_u8(packed + 112);
+      break;
+    default: assert(false);
   }
 }
 
@@ -433,5 +648,215 @@ MLLM_CPU_ARM_FORCE_INLINE void vec_unpack_128_lowbit_values(int8x16_t& unpacked0
     unpacked7 = vaddq_s8(vreinterpretq_s8_u8(shifted7), unshift);
   }
 }
+
+template<int nbit>
+MLLM_CPU_ARM_FORCE_INLINE void vec_unpack_128_lowbit_values_with_lut(int8x16_t& unpacked0, int8x16_t& unpacked1,
+                                                                     int8x16_t& unpacked2, int8x16_t& unpacked3,
+                                                                     int8x16_t& unpacked4, int8x16_t& unpacked5,
+                                                                     int8x16_t& unpacked6, int8x16_t& unpacked7,
+                                                                     const uint8_t* packed, const int8x16_t& lut) {
+  static_assert(nbit <= 4);
+  static_assert(nbit >= 1);
+  uint8x16_t idx0;
+  uint8x16_t idx1;
+  uint8x16_t idx2;
+  uint8x16_t idx3;
+  uint8x16_t idx4;
+  uint8x16_t idx5;
+  uint8x16_t idx6;
+  uint8x16_t idx7;
+  vec_unpack_128_uintx_values<nbit>(idx0, idx1, idx2, idx3, idx4, idx5, idx6, idx7, packed);
+  unpacked0 = vqtbl1q_s8(lut, idx0);
+  unpacked1 = vqtbl1q_s8(lut, idx1);
+  unpacked2 = vqtbl1q_s8(lut, idx2);
+  unpacked3 = vqtbl1q_s8(lut, idx3);
+  unpacked4 = vqtbl1q_s8(lut, idx4);
+  unpacked5 = vqtbl1q_s8(lut, idx5);
+  unpacked6 = vqtbl1q_s8(lut, idx6);
+  unpacked7 = vqtbl1q_s8(lut, idx7);
+}
+
+template<int nbit>
+MLLM_CPU_ARM_FORCE_INLINE void vec_unpack_64_uintx_values(uint8x16_t& unpacked0, uint8x16_t& unpacked1, uint8x16_t& unpacked2,
+                                                          uint8x16_t& unpacked3, const uint8_t* packed) {
+  static_assert(nbit < 9);
+  static_assert(nbit >= 1);
+
+  switch (nbit) {
+    case 1: vec_unpack_64_uint1_values(unpacked0, unpacked1, unpacked2, unpacked3, packed); break;
+    case 2: vec_unpack_64_uint2_values(unpacked0, unpacked1, unpacked2, unpacked3, packed); break;
+    case 3: vec_unpack_64_uint3_values(unpacked0, unpacked1, unpacked2, unpacked3, packed); break;
+    case 4:
+      vec_unpack_32_uint4_values(unpacked0, unpacked1, packed);
+      vec_unpack_32_uint4_values(unpacked2, unpacked3, packed + 16);
+      break;
+    case 5: vec_unpack_64_uint5_values(unpacked0, unpacked1, unpacked2, unpacked3, packed); break;
+    case 6: vec_unpack_64_uint6_values(unpacked0, unpacked1, unpacked2, unpacked3, packed); break;
+    case 7: vec_unpack_64_uint7_values(unpacked0, unpacked1, unpacked2, unpacked3, packed); break;
+    case 8:
+      unpacked0 = vld1q_u8(packed);
+      unpacked1 = vld1q_u8(packed + 16);
+      unpacked2 = vld1q_u8(packed + 32);
+      unpacked3 = vld1q_u8(packed + 48);
+      break;
+    default: assert(false);
+  }
+}
+
+template<int nbit>
+MLLM_CPU_ARM_FORCE_INLINE void vec_unpack_64_lut_indices(uint8x16_t& unpacked0, uint8x16_t& unpacked1, uint8x16_t& unpacked2,
+                                                         uint8x16_t& unpacked3, const uint8_t* packed) {
+  static_assert(nbit <= 8);
+  static_assert(nbit >= 1);
+
+  if constexpr (nbit == 8) {
+    unpacked0 = vld1q_u8(packed + 0);
+    unpacked1 = vld1q_u8(packed + 16);
+    unpacked2 = vld1q_u8(packed + 32);
+    unpacked3 = vld1q_u8(packed + 48);
+    return;
+  }
+
+  vec_unpack_64_uintx_values<nbit>(unpacked0, unpacked1, unpacked2, unpacked3, packed);
+
+  const uint8_t mask = (1 << nbit) - 1;
+  uint8x16_t mask_vec = vdupq_n_u8(mask);
+
+  unpacked0 = vandq_u8(unpacked0, mask_vec);
+  unpacked1 = vandq_u8(unpacked1, mask_vec);
+  unpacked2 = vandq_u8(unpacked2, mask_vec);
+  unpacked3 = vandq_u8(unpacked3, mask_vec);
+}
+
+template<int nbit>
+MLLM_CPU_ARM_FORCE_INLINE void vec_unpack_32_uintx_values(uint8x16_t& unpacked0, uint8x16_t& unpacked1, const uint8_t* packed) {
+  static_assert(nbit < 9);
+  static_assert(nbit >= 1);
+
+  uint8x16_t shifted0 = vdupq_n_u8(0);
+  uint8x16_t shifted1 = vdupq_n_u8(0);
+
+  switch (nbit) {
+    case 1:
+      uint8_t buffer1[32];
+      unpack_8_uint1_values(buffer1, packed);
+      unpack_8_uint1_values(buffer1 + 8, packed + 1);
+      unpack_8_uint1_values(buffer1 + 16, packed + 2);
+      unpack_8_uint1_values(buffer1 + 24, packed + 3);
+      shifted0 = vld1q_u8(buffer1);
+      shifted1 = vld1q_u8(buffer1 + 16);
+      break;
+    case 2:
+      uint8x8_t shifted0_low;
+      uint8x8_t shifted0_high;
+      uint8x8_t shifted1_low;
+      uint8x8_t shifted1_high;
+      vec_unpack_32_uint2_values(shifted0_low, shifted0_high, shifted1_low, shifted1_high, packed);
+      shifted0 = vcombine_u8(shifted0_low, shifted0_high);
+      shifted1 = vcombine_u8(shifted1_low, shifted1_high);
+      break;
+    case 3:
+      uint8_t buffer3[32];
+      unpack_8_uint3_values(buffer3, packed);
+      unpack_8_uint3_values(buffer3 + 8, packed + 3);
+      unpack_8_uint3_values(buffer3 + 16, packed + 6);
+      unpack_8_uint3_values(buffer3 + 24, packed + 9);
+      shifted0 = vld1q_u8(buffer3);
+      shifted1 = vld1q_u8(buffer3 + 16);
+      break;
+    case 4: vec_unpack_32_uint4_values(shifted0, shifted1, packed); break;
+    case 5:
+      uint8_t buffer5[32];
+      unpack_8_uint5_values(buffer5, packed);
+      unpack_8_uint5_values(buffer5 + 8, packed + 5);
+      unpack_8_uint5_values(buffer5 + 16, packed + 10);
+      unpack_8_uint5_values(buffer5 + 24, packed + 15);
+      shifted0 = vld1q_u8(buffer5);
+      shifted1 = vld1q_u8(buffer5 + 16);
+      break;
+    case 6: vec_unpack_32_uint6_values(shifted0, shifted1, packed); break;
+    case 7:
+      uint8_t buffer7[32];
+      unpack_8_uint7_values(buffer7, packed);
+      unpack_8_uint7_values(buffer7 + 8, packed + 7);
+      unpack_8_uint7_values(buffer7 + 16, packed + 14);
+      unpack_8_uint7_values(buffer7 + 24, packed + 21);
+      shifted0 = vld1q_u8(buffer7);
+      shifted1 = vld1q_u8(buffer7 + 16);
+      break;
+    case 8:
+      shifted0 = vld1q_u8(packed);
+      shifted1 = vld1q_u8(packed + 16);
+      break;
+    default: assert(false);
+  }
+  unpacked0 = shifted0;
+  unpacked1 = shifted1;
+}
+
+template<int nbit>
+MLLM_CPU_ARM_FORCE_INLINE void vec_unpack_32_lut_indices(uint8x16_t& unpacked0, uint8x16_t& unpacked1, const uint8_t* packed) {
+  static_assert(nbit <= 8);
+  static_assert(nbit >= 1);
+
+  // For 8-bit, the data is already unpacked. Just load directly.
+  if constexpr (nbit == 8) {
+    unpacked0 = vld1q_u8(packed + 0);
+    unpacked1 = vld1q_u8(packed + 16);
+    return;
+  }
+
+  // 1. Call the internal helper to get the raw unpacked values.
+  vec_unpack_32_uintx_values<nbit>(unpacked0, unpacked1, packed);
+
+  // 2. Apply the bitmask to get the final, correct indices for a LUT.
+  const uint8_t mask = (1 << nbit) - 1;
+  uint8x16_t mask_vec = vdupq_n_u8(mask);
+
+  unpacked0 = vandq_u8(unpacked0, mask_vec);
+  unpacked1 = vandq_u8(unpacked1, mask_vec);
+}
+
+template<int nbit>
+MLLM_CPU_ARM_FORCE_INLINE void vec_unpack_128_lut_indices(uint8x16_t& unpacked0, uint8x16_t& unpacked1, uint8x16_t& unpacked2,
+                                                          uint8x16_t& unpacked3, uint8x16_t& unpacked4, uint8x16_t& unpacked5,
+                                                          uint8x16_t& unpacked6, uint8x16_t& unpacked7, const uint8_t* packed) {
+  // Unpacks 128 tightly packed n-bit values into 8-bit LUT indices using ARM
+  // NEON. For n-bit < 8, this function first spreads the bits into bytes and
+  // then applies a mask to zero out the unused upper bits, ensuring each index
+  // is valid. For the n-bit == 8 case, it's a direct memory load, as no
+  // unpacking is needed.
+
+  static_assert(nbit <= 8);
+  static_assert(nbit >= 1);
+
+  // For 8-bit, the data is already unpacked. Just load directly.
+  if constexpr (nbit == 8) {
+    unpacked0 = vld1q_u8(packed + 0);
+    unpacked1 = vld1q_u8(packed + 16);
+    unpacked2 = vld1q_u8(packed + 32);
+    unpacked3 = vld1q_u8(packed + 48);
+    unpacked4 = vld1q_u8(packed + 64);
+    unpacked5 = vld1q_u8(packed + 80);
+    unpacked6 = vld1q_u8(packed + 96);
+    unpacked7 = vld1q_u8(packed + 112);
+    return;
+  }
+
+  vec_unpack_128_uintx_values<nbit>(unpacked0, unpacked1, unpacked2, unpacked3, unpacked4, unpacked5, unpacked6, unpacked7,
+                                    packed);
+  const uint8_t mask = (1 << nbit) - 1;
+  uint8x16_t mask_vec = vdupq_n_u8(mask);
+
+  unpacked0 = vandq_u8(unpacked0, mask_vec);
+  unpacked1 = vandq_u8(unpacked1, mask_vec);
+  unpacked2 = vandq_u8(unpacked2, mask_vec);
+  unpacked3 = vandq_u8(unpacked3, mask_vec);
+  unpacked4 = vandq_u8(unpacked4, mask_vec);
+  unpacked5 = vandq_u8(unpacked5, mask_vec);
+  unpacked6 = vandq_u8(unpacked6, mask_vec);
+  unpacked7 = vandq_u8(unpacked7, mask_vec);
+}
+
 }  // namespace mllm::cpu::arm::bitspack
 #endif

--- a/mllm/backends/cpu/kernels/arm/quantize/bitspack/ux.hpp
+++ b/mllm/backends/cpu/kernels/arm/quantize/bitspack/ux.hpp
@@ -30,7 +30,7 @@
 #include "mllm/backends/cpu/kernels/arm/quantize/bitspack/u6.hpp"
 #include "mllm/backends/cpu/kernels/arm/quantize/bitspack/u7.hpp"
 
-namespace mllm::cpu::arm {
+namespace mllm::cpu::arm::bitspack {
 
 MLLM_CPU_ARM_FORCE_INLINE void vec_store_32_uint8_values(uint8_t* dest, const uint8x8_t& vec0, const uint8x8_t& vec1,
                                                          const uint8x8_t& vec2, const uint8x8_t& vec3) {
@@ -433,5 +433,5 @@ MLLM_CPU_ARM_FORCE_INLINE void vec_unpack_128_lowbit_values(int8x16_t& unpacked0
     unpacked7 = vaddq_s8(vreinterpretq_s8_u8(shifted7), unshift);
   }
 }
-}  // namespace mllm::cpu::arm
+}  // namespace mllm::cpu::arm::bitspack
 #endif

--- a/mllm/backends/cpu/kernels/arm/quantize/bitspack/ux_packing.cpp
+++ b/mllm/backends/cpu/kernels/arm/quantize/bitspack/ux_packing.cpp
@@ -1,0 +1,77 @@
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
+
+// Inspired by torchao's valpack.
+
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "mllm/backends/cpu/kernels/arm/quantize/bitspack/ux_packing.hpp"
+
+#include <cassert>
+#include <cstring>
+#include <cstdint>
+
+// Interleaves data across channels (row/column) and groups.
+// Each channel is the same size (vals_per_channel) and is
+// divided into groups (vals_per_channel % vals_per_group == 0).
+// Each group is divided into chunks (vals_per_group % vals_per_chunk == 0).
+// Chunks are interleaved.
+//
+// Data is interleaved by iterating over chunks, then groups, and then channels.
+//
+// For example, given original data (depicted below with channels as
+// rows, vals_per_channel=12, vals_per_group = 4, vals_per_chunk=2):
+//
+//  group0                  group1                  group2
+//  chunk0      chunk1      chunk0      chunk1      chunk0      chunk1
+// [(v00, v01 | v02, v03) | (v04, v05 | v06, v07) | (v08, v09 | v0a, v0b)] ch0
+// [(v10, v11 | v12, v13) | (v14, v15 | v16, v17) | (v18, v19 | v1a, v1b)] ch1
+// [(v20, v21 | v22, v23) | (v24, v25 | v26, v27) | (v28, v29 | v2a, v2b)] ch2
+// [(v30, v31 | v32, v33) | (v34, v35 | v36, v37) | (v38, v39 | v3a, v3b)] ch3
+//
+// The output of this method is:
+//
+// v00, v01 | v10, v11 | v20, v21 | v30, v31 // chunk0, group0 channels
+// v04, v05 | v14, v15 | v24, v25 | v34, v35 // chunk0, group1 channels
+// v08, v09 | v18, v19 | v28, v29 | v38, v39 // chunk0, group2 channels
+// v02, v03 | v12, v13 | v22, v23 | v32, v33 // chunk1, group0 channels
+// v06, v07 | v16, v17 | v26, v27 | v36, v37 // chunk1, group1 channels
+// v0a, v0b | v1a, v1b | v2a, v2b | v3a, v3b // chunk1, group2 channels
+//
+// For a given value, the value in the next channel is offset by
+// channel_stride_in_vals.
+// It may be that channel_stride_in_vals = vals_per_channel,
+// but it can be something else if we are applying this method
+// to a matrix tile.
+
+namespace mllm::cpu::arm::bitspack {
+void interleave_data(void* data_interleaved, const void* data, int bytes_per_val, int vals_per_channel, int vals_per_group,
+                     int vals_per_chunk, int channels, int channel_stride_in_vals) {
+  assert(vals_per_channel % vals_per_group == 0);
+  assert(vals_per_group % vals_per_chunk == 0);
+
+  int chunks_per_group = vals_per_group / vals_per_chunk;
+  int groups_per_channel = vals_per_channel / vals_per_group;
+  int bytes_per_chunk = vals_per_chunk * bytes_per_val;
+
+  int8_t* output_byte_ptr = (int8_t*)(data_interleaved);
+  const int8_t* input_byte_ptr = (int8_t*)(data);
+
+  for (int chunk_idx = 0; chunk_idx < chunks_per_group; chunk_idx++) {
+    for (int group_idx = 0; group_idx < groups_per_channel; group_idx++) {
+      for (int channel_idx = 0; channel_idx < channels; channel_idx++) {
+        // Index of first value in chunk we're moving
+        int val_idx = (channel_idx * channel_stride_in_vals) + (group_idx * vals_per_group) + (chunk_idx * vals_per_chunk);
+
+        // Copy chunk to correct location
+        std::memcpy(output_byte_ptr, input_byte_ptr + val_idx * bytes_per_val, bytes_per_chunk);
+        output_byte_ptr += bytes_per_chunk;
+      }
+    }
+  }
+}
+}  // namespace mllm::cpu::arm::bitspack

--- a/mllm/backends/cpu/kernels/arm/quantize/bitspack/ux_packing.hpp
+++ b/mllm/backends/cpu/kernels/arm/quantize/bitspack/ux_packing.hpp
@@ -1,0 +1,19 @@
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
+
+// Inspired by torchao's valpack.
+
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+namespace mllm::cpu::arm::bitspack {
+
+void interleave_data(void* data_interleaved, const void* data, int bytes_per_val, int vals_per_channel, int vals_per_group,
+                     int vals_per_chunk, int channels, int channel_stride_in_vals);
+
+}

--- a/mllm/backends/cpu/kernels/arm/quantize/bitspack/ux_packing.hpp
+++ b/mllm/backends/cpu/kernels/arm/quantize/bitspack/ux_packing.hpp
@@ -11,9 +11,52 @@
 
 #pragma once
 
+#include <cassert>
+#include <cstring>
+
 namespace mllm::cpu::arm::bitspack {
 
 void interleave_data(void* data_interleaved, const void* data, int bytes_per_val, int vals_per_channel, int vals_per_group,
                      int vals_per_chunk, int channels, int channel_stride_in_vals);
 
+template<typename T>
+void pack_values(
+    // Output
+    T* packed_values,
+    // Inputs
+    const T* values, int nr, int kr, int sr) {
+  assert(kr % sr == 0);
+  int kr_per_sr = kr / sr;
+  int dst_idx = 0;
+  for (int sr_idx = 0; sr_idx < sr; sr_idx++) {
+    for (int n_idx = 0; n_idx < nr; n_idx++) {
+      // Take kr_per_sr values from column n_idx
+      std::memcpy(packed_values + dst_idx, values + n_idx * kr + sr_idx * kr_per_sr, sizeof(T) * kr_per_sr);
+      dst_idx += kr_per_sr;
+    }
+  }
 }
+
+// Undoes pack_values
+template<typename T>
+void unpack_values(
+    // Output
+    T* values,
+    // Inputs
+    const T* packed_values, int nr, int kr, int sr) {
+  // packed_values and values should have size nr * kr
+  // This function takes (kr / sr) from each column of nr columns and writes to
+  // output This is repeated sr times
+  assert(kr % sr == 0);
+  int kr_per_sr = kr / sr;
+  int dst_idx = 0;
+  for (int sr_idx = 0; sr_idx < sr; sr_idx++) {
+    for (int n_idx = 0; n_idx < nr; n_idx++) {
+      // Take kr_per_sr values from column n_idx
+      std::memcpy(values + n_idx * kr + sr_idx * kr_per_sr, packed_values + dst_idx, sizeof(T) * kr_per_sr);
+      dst_idx += kr_per_sr;
+    }
+  }
+}
+
+}  // namespace mllm::cpu::arm::bitspack

--- a/mllm/ffi/vendors/dlpack/include/dlpack/dlpack.h
+++ b/mllm/ffi/vendors/dlpack/include/dlpack/dlpack.h
@@ -1,0 +1,368 @@
+/*!
+ *  Copyright (c) 2017 by Contributors
+ * \file dlpack.h
+ * \brief The common header of DLPack.
+ */
+#ifndef DLPACK_DLPACK_H_
+#define DLPACK_DLPACK_H_
+
+/**
+ * \brief Compatibility with C++
+ */
+#ifdef __cplusplus
+#define DLPACK_EXTERN_C extern "C"
+#else
+#define DLPACK_EXTERN_C
+#endif
+
+/*! \brief The current major version of dlpack */
+#define DLPACK_MAJOR_VERSION 1
+
+/*! \brief The current minor version of dlpack */
+#define DLPACK_MINOR_VERSION 1
+
+/*! \brief DLPACK_DLL prefix for windows */
+#ifdef _WIN32
+#ifdef DLPACK_EXPORTS
+#define DLPACK_DLL __declspec(dllexport)
+#else
+#define DLPACK_DLL __declspec(dllimport)
+#endif
+#else
+#define DLPACK_DLL
+#endif
+
+#include <stdint.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*!
+ * \brief The DLPack version.
+ *
+ * A change in major version indicates that we have changed the
+ * data layout of the ABI - DLManagedTensorVersioned.
+ *
+ * A change in minor version indicates that we have added new
+ * code, such as a new device type, but the ABI is kept the same.
+ *
+ * If an obtained DLPack tensor has a major version that disagrees
+ * with the version number specified in this header file
+ * (i.e. major != DLPACK_MAJOR_VERSION), the consumer must call the deleter
+ * (and it is safe to do so). It is not safe to access any other fields
+ * as the memory layout will have changed.
+ *
+ * In the case of a minor version mismatch, the tensor can be safely used as
+ * long as the consumer knows how to interpret all fields. Minor version
+ * updates indicate the addition of enumeration values.
+ */
+typedef struct {
+  /*! \brief DLPack major version. */
+  uint32_t major;
+  /*! \brief DLPack minor version. */
+  uint32_t minor;
+} DLPackVersion;
+
+/*!
+ * \brief The device type in DLDevice.
+ */
+#ifdef __cplusplus
+typedef enum : int32_t {
+#else
+typedef enum {
+#endif
+  /*! \brief CPU device */
+  kDLCPU = 1,
+  /*! \brief CUDA GPU device */
+  kDLCUDA = 2,
+  /*!
+   * \brief Pinned CUDA CPU memory by cudaMallocHost
+   */
+  kDLCUDAHost = 3,
+  /*! \brief OpenCL devices. */
+  kDLOpenCL = 4,
+  /*! \brief Vulkan buffer for next generation graphics. */
+  kDLVulkan = 7,
+  /*! \brief Metal for Apple GPU. */
+  kDLMetal = 8,
+  /*! \brief Verilog simulator buffer */
+  kDLVPI = 9,
+  /*! \brief ROCm GPUs for AMD GPUs */
+  kDLROCM = 10,
+  /*!
+   * \brief Pinned ROCm CPU memory allocated by hipMallocHost
+   */
+  kDLROCMHost = 11,
+  /*!
+   * \brief Reserved extension device type,
+   * used for quickly test extension device
+   * The semantics can differ depending on the implementation.
+   */
+  kDLExtDev = 12,
+  /*!
+   * \brief CUDA managed/unified memory allocated by cudaMallocManaged
+   */
+  kDLCUDAManaged = 13,
+  /*!
+   * \brief Unified shared memory allocated on a oneAPI non-partititioned
+   * device. Call to oneAPI runtime is required to determine the device
+   * type, the USM allocation type and the sycl context it is bound to.
+   *
+   */
+  kDLOneAPI = 14,
+  /*! \brief GPU support for next generation WebGPU standard. */
+  kDLWebGPU = 15,
+  /*! \brief Qualcomm Hexagon DSP */
+  kDLHexagon = 16,
+  /*! \brief Microsoft MAIA devices */
+  kDLMAIA = 17,
+  /*! \brief AWS Trainium */
+  kDLTrn = 18,
+} DLDeviceType;
+
+/*!
+ * \brief A Device for Tensor and operator.
+ */
+typedef struct {
+  /*! \brief The device type used in the device. */
+  DLDeviceType device_type;
+  /*!
+   * \brief The device index.
+   * For vanilla CPU memory, pinned memory, or managed memory, this is set to 0.
+   */
+  int32_t device_id;
+} DLDevice;
+
+/*!
+ * \brief The type code options DLDataType.
+ */
+typedef enum {
+  /*! \brief signed integer */
+  kDLInt = 0U,
+  /*! \brief unsigned integer */
+  kDLUInt = 1U,
+  /*! \brief IEEE floating point */
+  kDLFloat = 2U,
+  /*!
+   * \brief Opaque handle type, reserved for testing purposes.
+   * Frameworks need to agree on the handle data type for the exchange to be well-defined.
+   */
+  kDLOpaqueHandle = 3U,
+  /*! \brief bfloat16 */
+  kDLBfloat = 4U,
+  /*!
+   * \brief complex number
+   * (C/C++/Python layout: compact struct per complex number)
+   */
+  kDLComplex = 5U,
+  /*! \brief boolean */
+  kDLBool = 6U,
+  /*! \brief FP8 data types */
+  kDLFloat8_e3m4 = 7U,
+  kDLFloat8_e4m3 = 8U,
+  kDLFloat8_e4m3b11fnuz = 9U,
+  kDLFloat8_e4m3fn = 10U,
+  kDLFloat8_e4m3fnuz = 11U,
+  kDLFloat8_e5m2 = 12U,
+  kDLFloat8_e5m2fnuz = 13U,
+  kDLFloat8_e8m0fnu = 14U,
+  /*! \brief FP6 data types
+   * Setting bits != 6 is currently unspecified, and the producer must ensure it is set
+   * while the consumer must stop importing if the value is unexpected.
+   */
+  kDLFloat6_e2m3fn = 15U,
+  kDLFloat6_e3m2fn = 16U,
+  /*! \brief FP4 data types
+   * Setting bits != 4 is currently unspecified, and the producer must ensure it is set
+   * while the consumer must stop importing if the value is unexpected.
+   */
+  kDLFloat4_e2m1fn = 17U,
+} DLDataTypeCode;
+
+/*!
+ * \brief The data type the tensor can hold. The data type is assumed to follow the
+ * native endian-ness. An explicit error message should be raised when attempting to
+ * export an array with non-native endianness
+ *
+ *  Examples
+ *   - float: type_code = 2, bits = 32, lanes = 1
+ *   - float4(vectorized 4 float): type_code = 2, bits = 32, lanes = 4
+ *   - int8: type_code = 0, bits = 8, lanes = 1
+ *   - std::complex<float>: type_code = 5, bits = 64, lanes = 1
+ *   - bool: type_code = 6, bits = 8, lanes = 1 (as per common array library convention, the underlying storage size of bool is 8 bits)
+ *   - float8_e4m3: type_code = 8, bits = 8, lanes = 1 (packed in memory)
+ *   - float6_e3m2fn: type_code = 16, bits = 6, lanes = 1 (packed in memory)
+ *   - float4_e2m1fn: type_code = 17, bits = 4, lanes = 1 (packed in memory)
+ *
+ *  When a sub-byte type is packed, DLPack requires the data to be in little bit-endian, i.e.,
+ *  for a packed data set D ((D >> (i * bits)) && bit_mask) stores the i-th element.
+ */
+typedef struct {
+  /*!
+   * \brief Type code of base types.
+   * We keep it uint8_t instead of DLDataTypeCode for minimal memory
+   * footprint, but the value should be one of DLDataTypeCode enum values.
+   * */
+  uint8_t code;
+  /*!
+   * \brief Number of bits, common choices are 8, 16, 32.
+   */
+  uint8_t bits;
+  /*! \brief Number of lanes in the type, used for vector types. */
+  uint16_t lanes;
+} DLDataType;
+
+/*!
+ * \brief Plain C Tensor object, does not manage memory.
+ */
+typedef struct {
+  /*!
+   * \brief The data pointer points to the allocated data. This will be CUDA
+   * device pointer or cl_mem handle in OpenCL. It may be opaque on some device
+   * types. This pointer is always aligned to 256 bytes as in CUDA. The
+   * `byte_offset` field should be used to point to the beginning of the data.
+   *
+   * Note that as of Nov 2021, multiple libraries (CuPy, PyTorch, TensorFlow,
+   * TVM, perhaps others) do not adhere to this 256 byte alignment requirement
+   * on CPU/CUDA/ROCm, and always use `byte_offset=0`.  This must be fixed
+   * (after which this note will be updated); at the moment it is recommended
+   * to not rely on the data pointer being correctly aligned.
+   *
+   * For given DLTensor, the size of memory required to store the contents of
+   * data is calculated as follows:
+   *
+   * \code{.c}
+   * static inline size_t GetDataSize(const DLTensor* t) {
+   *   size_t size = 1;
+   *   for (tvm_index_t i = 0; i < t->ndim; ++i) {
+   *     size *= t->shape[i];
+   *   }
+   *   size *= (t->dtype.bits * t->dtype.lanes + 7) / 8;
+   *   return size;
+   * }
+   * \endcode
+   *
+   * Note that if the tensor is of size zero, then the data pointer should be
+   * set to `NULL`.
+   */
+  void* data;
+  /*! \brief The device of the tensor */
+  DLDevice device;
+  /*! \brief Number of dimensions */
+  int32_t ndim;
+  /*! \brief The data type of the pointer*/
+  DLDataType dtype;
+  /*! \brief The shape of the tensor */
+  int64_t* shape;
+  /*!
+   * \brief strides of the tensor (in number of elements, not bytes)
+   *  can be NULL, indicating tensor is compact and row-majored.
+   */
+  int64_t* strides;
+  /*! \brief The offset in bytes to the beginning pointer to data */
+  uint64_t byte_offset;
+} DLTensor;
+
+/*!
+ * \brief C Tensor object, manage memory of DLTensor. This data structure is
+ *  intended to facilitate the borrowing of DLTensor by another framework. It is
+ *  not meant to transfer the tensor. When the borrowing framework doesn't need
+ *  the tensor, it should call the deleter to notify the host that the resource
+ *  is no longer needed.
+ *
+ * \note This data structure is used as Legacy DLManagedTensor
+ *       in DLPack exchange and is deprecated after DLPack v0.8
+ *       Use DLManagedTensorVersioned instead.
+ *       This data structure may get renamed or deleted in future versions.
+ *
+ * \sa DLManagedTensorVersioned
+ */
+typedef struct DLManagedTensor {
+  /*! \brief DLTensor which is being memory managed */
+  DLTensor dl_tensor;
+  /*! \brief the context of the original host framework of DLManagedTensor in
+   *   which DLManagedTensor is used in the framework. It can also be NULL.
+   */
+  void * manager_ctx;
+  /*!
+   * \brief Destructor - this should be called
+   * to destruct the manager_ctx  which backs the DLManagedTensor. It can be
+   * NULL if there is no way for the caller to provide a reasonable destructor.
+   * The destructor deletes the argument self as well.
+   */
+  void (*deleter)(struct DLManagedTensor * self);
+} DLManagedTensor;
+
+// bit masks used in the DLManagedTensorVersioned
+
+/*! \brief bit mask to indicate that the tensor is read only. */
+#define DLPACK_FLAG_BITMASK_READ_ONLY (1UL << 0UL)
+
+/*!
+ * \brief bit mask to indicate that the tensor is a copy made by the producer.
+ *
+ * If set, the tensor is considered solely owned throughout its lifetime by the
+ * consumer, until the producer-provided deleter is invoked.
+ */
+#define DLPACK_FLAG_BITMASK_IS_COPIED (1UL << 1UL)
+
+/*!
+ * \brief bit mask to indicate that whether a sub-byte type is packed or padded.
+ *
+ * The default for sub-byte types (ex: fp4/fp6) is assumed packed. This flag can
+ * be set by the producer to signal that a tensor of sub-byte type is padded.
+ */
+#define DLPACK_FLAG_BITMASK_IS_SUBBYTE_TYPE_PADDED (1UL << 2UL)
+
+/*!
+ * \brief A versioned and managed C Tensor object, manage memory of DLTensor.
+ *
+ * This data structure is intended to facilitate the borrowing of DLTensor by
+ * another framework. It is not meant to transfer the tensor. When the borrowing
+ * framework doesn't need the tensor, it should call the deleter to notify the
+ * host that the resource is no longer needed.
+ *
+ * \note This is the current standard DLPack exchange data structure.
+ */
+struct DLManagedTensorVersioned {
+  /*!
+   * \brief The API and ABI version of the current managed Tensor
+   */
+  DLPackVersion version;
+  /*!
+   * \brief the context of the original host framework.
+   *
+   * Stores DLManagedTensorVersioned is used in the
+   * framework. It can also be NULL.
+   */
+  void *manager_ctx;
+  /*!
+   * \brief Destructor.
+   *
+   * This should be called to destruct manager_ctx which holds the DLManagedTensorVersioned.
+   * It can be NULL if there is no way for the caller to provide a reasonable
+   * destructor. The destructor deletes the argument self as well.
+   */
+  void (*deleter)(struct DLManagedTensorVersioned *self);
+  /*!
+   * \brief Additional bitmask flags information about the tensor.
+   *
+   * By default the flags should be set to 0.
+   *
+   * \note Future ABI changes should keep everything until this field
+   *       stable, to ensure that deleter can be correctly called.
+   *
+   * \sa DLPACK_FLAG_BITMASK_READ_ONLY
+   * \sa DLPACK_FLAG_BITMASK_IS_COPIED
+   */
+  uint64_t flags;
+  /*! \brief DLTensor which is being memory managed */
+  DLTensor dl_tensor;
+};
+
+#ifdef __cplusplus
+}  // DLPACK_EXTERN_C
+#endif
+#endif  // DLPACK_DLPACK_H_


### PR DESCRIPTION
feat(cpu): u1-u7 bitspack packing
- Implement bitspack kernel for ARM architecture
- Add support for per-channel int8 activations and x bits per group quantized weights
- Include functions for packing and unpacking weights and activations
- Optimize performance using ARM Neon intrinsics