### PR TITLE
fix(mllm-cli): correct return value check in isOk function

### DIFF
--- a/mllm-cli/mllm/c.go
+++ b/mllm-cli/mllm/c.go
@@ -16,7 +16,7 @@ package mllm
 import "C"
 
 func isOk(any C.MllmCAny) bool {
-	return C.isOk(any) == 0
+	return C.isOk(any) == 1
 }
 
 func InitializeContext() bool {

--- a/task.py
+++ b/task.py
@@ -482,12 +482,7 @@ class MllmCliBuildTask(Task):
         original_cwd = os.getcwd()
         try:
             os.chdir(work_dir)
-            result = throw_error_if_failed(
-                os.system(self.make_command_str(go_build_cmd))
-            )
-            if result != 0:
-                logging.error("Go build failed")
-                return
+            throw_error_if_failed(os.system(self.make_command_str(go_build_cmd)))
         finally:
             os.chdir(original_cwd)
 


### PR DESCRIPTION
The isOk function was incorrectly checking for 0 as success, but the C library returns 1 for success. This change aligns the Go code with the expected C library behavior.

fix(task.py): remove redundant error handling in build task

The redundant error checking and logging has been removed from the build task as the throw_error_if_failed function already handles error cases appropriately.