### PR TITLE
ci(macOS): update nightly workflow to use python-build and improve ve…

### DIFF
--- a/.github/workflows/pymllm-macos-nightly.yml
+++ b/.github/workflows/pymllm-macos-nightly.yml
@@ -1,42 +1,37 @@
 name: pymllm macOS Nightly
 
 on:
-    workflow_dispatch:
+  workflow_dispatch:
 
 jobs:
-    build-and-publish:
-        runs-on: macos-latest
-        permissions:
-            id-token: write
-        steps:
-            - name: Checkout code
-              uses: actions/checkout@v3
+  build-and-publish:
+    runs-on: macos-latest
+    permissions:
+      id-token: write
 
-            - name: Set up Python
-              uses: actions/setup-python@v4
-              with:
-                  python-version: "3.10"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-            - name: Install dependencies
-              run: |
-                  python -m pip install --upgrade pip
-                  pip install auditwheel
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
 
-            - name: Set nightly version
-              run: |
-                  NIGHTLY_VERSION="0.1.0.dev$(date +%Y%m%d)"
-                  sed -i '' "s/version = \"0.1.0\"/version = \"$NIGHTLY_VERSION\"/" ../pyproject.toml
+      - name: Install build
+        run: |
+          python -m pip install --upgrade pip
 
-            - name: Build wheel
-              run: |
-                  pip wheel -v -w dist .
+      - name: Set nightly version
+        run: |
+          NIGHTLY_VERSION="0.1.0.dev$(date +%Y%m%d)"
+          sed -i '' -E 's/^version = "[^"]+"/version = "'$NIGHTLY_VERSION'"/' pyproject.toml
 
-            - name: Repair wheel with auditwheel
-              run: |
-                  auditwheel repair --exclude libtvm_ffi.so dist/*.whl
+      - name: Build wheel
+        run: |
+          python -m build --wheel --outdir wheelhouse .
 
-            - name: Publish to mllmTeam channel
-              uses: pypa/gh-action-pypi-publish@release/v1
-              with:
-                  repository-url: https://upload.pypi.org/legacy/
-                  packages-dir: pymllm/wheelhouse/
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: wheelhouse/


### PR DESCRIPTION
…rsioning

- Upgrade actions/checkout to v4
- Replace custom wheel building with python -m build
- Improve version regex replacement in pyproject.toml
- Remove unused auditwheel dependency and repair step
- Update publish step to directly use wheelhouse directory