### PR TITLE
ci(pymllm-macos-nightly): simplify workflow trigger conditions

### DIFF
--- a/.github/workflows/pymllm-macos-nightly.yml
+++ b/.github/workflows/pymllm-macos-nightly.yml
@@ -16,9 +16,7 @@ on:
 
 jobs:
   build:
-    if: |
-      github.event.pull_request.merged == true &&
-      github.repository == 'UbiquitousLearning/mllm'
+    if: github.repository == 'UbiquitousLearning/mllm'
     runs-on: macos-latest
     permissions:
       id-token: write
@@ -62,9 +60,7 @@ jobs:
           retention-days: 1
 
   publish:
-    if: |
-      github.event.pull_request.merged == true &&
-      github.repository == 'UbiquitousLearning/mllm'
+    if: github.repository == 'UbiquitousLearning/mllm'
     runs-on: ubuntu-latest
     needs: build
     permissions:


### PR DESCRIPTION
Remove redundant pull request merge check from workflow conditions. The workflows will now only check if the repository matches 'UbiquitousLearning/mllm' before running, instead of also verifying that the pull request was merged.