### PR TITLE
feat(cpu): add partial_dim support in RoPE operation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ tasks/mllmteam*
 # Building files and binary
 build*/
 install*/
+mllm-sdk-*/
 
 # Pymllm related
 stubs/

--- a/mllm/backends/cpu/ops/RoPEOp.hpp
+++ b/mllm/backends/cpu/ops/RoPEOp.hpp
@@ -9,7 +9,7 @@
 namespace mllm::cpu {
 
 struct RoPEOpImpl {
-  void forward(const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs, Tensor& sin, Tensor& cos,
+  void forward(const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs, Tensor& sin, Tensor& cos, int32_t partial_dim,
                aops::RoPEOpOptionsInputType input_layout_type);
 };
 

--- a/mllm/core/aops/RoPEOp.hpp
+++ b/mllm/core/aops/RoPEOp.hpp
@@ -17,6 +17,7 @@ struct RoPEOpOptions : public BaseOpOptions<RoPEOpOptions> {
   float rope_theta = 10000.0F;
   int32_t max_position_embeddings = 16384;
   RoPEOpOptionsInputType input_type = RoPEOpOptionsInputType::kBHSD;
+  int32_t partial_dim = -1;
 };
 
 class RoPEOp : public BaseOp {

--- a/mllm/nn/layers/RoPE.cpp
+++ b/mllm/nn/layers/RoPE.cpp
@@ -13,4 +13,9 @@ RoPE::RoPE(float theta, int32_t max_position_embeddings, aops::RoPEOpOptionsInpu
             aops::RoPEOpOptions{
                 .rope_theta = theta, .max_position_embeddings = max_position_embeddings, .input_type = input_type}) {}
 
+RoPE::RoPE(float theta, int32_t max_position_embeddings, int32_t partial_dim, aops::RoPEOpOptionsInputType input_type)
+    : Layer(OpTypes::kRoPE, aops::RoPEOpOptions{.rope_theta = theta,
+                                                .max_position_embeddings = max_position_embeddings,
+                                                .input_type = input_type,
+                                                .partial_dim = partial_dim}) {}
 }  // namespace mllm::nn

--- a/mllm/nn/layers/RoPE.hpp
+++ b/mllm/nn/layers/RoPE.hpp
@@ -15,6 +15,9 @@ class RoPE : public Layer {
   RoPE(float theta, int32_t max_position_embeddings,
        aops::RoPEOpOptionsInputType input_type = aops::RoPEOpOptionsInputType::kBHSD);
 
+  RoPE(float theta, int32_t max_position_embeddings, int32_t partial_dim,
+       aops::RoPEOpOptionsInputType input_type = aops::RoPEOpOptionsInputType::kBHSD);
+
   MLLM_LAYER_ANY_INPUTS_1_OUTPUTS_FORWARD
   MLLM_LAYER_ENABLE_INPLACE_ATTRIBUTE(RoPE)
 


### PR DESCRIPTION
Added `partial_dim` parameter to control the dimensionality of rotary position embedding. Updated RoPE implementation to handle partial dimensions with proper concatenation logic. Extended ARM NEON optimizations to cover FP32 and FP16 vectorized operations for partial cases.

Also updated gitignore to exclude mllm-sdk build artifacts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added partial dimension parameter to rotary position embedding (RoPE) operations, enabling selective rotation of embedding dimensions while preserving tail portions.

* **Chores**
  * Updated .gitignore to exclude build artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->