### PR TITLE
feat(build): install mllm-ext-opset headers and libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -334,6 +334,15 @@ install(
   PATTERN "*.inl"
   PATTERN "Vendors/*" EXCLUDE)
 
+install(
+  DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/mllm-ext-opset/
+  DESTINATION include/mllm-ext-opset
+  FILES_MATCHING
+  PATTERN "*.h"
+  PATTERN "*.hpp"
+  PATTERN "*.inl"
+  PATTERN "Vendors/*" EXCLUDE)
+
 # Embedding fmt lib into mllm packages to avoid fetching fmt.
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/third_party/fmt
         DESTINATION packages)

--- a/mllm-ext-opset/cpu/fa2_swa_sink/CMakeLists.txt
+++ b/mllm-ext-opset/cpu/fa2_swa_sink/CMakeLists.txt
@@ -2,6 +2,13 @@ add_library(MllmExtOpSet_CPU_FlashAttn2SwaSink SHARED FlashAttn2SwaSink.cpp)
 target_link_libraries(MllmExtOpSet_CPU_FlashAttn2SwaSink PRIVATE MllmRT MllmCPUBackend)
 target_include_directories(MllmExtOpSet_CPU_FlashAttn2SwaSink PRIVATE ${MLLM_INCLUDE_DIR})
 
+install(
+  TARGETS MllmExtOpSet_CPU_FlashAttn2SwaSink
+  EXPORT MllmTargets
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+  RUNTIME DESTINATION bin)
+
 if(MLLM_BUILD_EXT_OP_SET_TEST)
   add_executable(Mllm-Test-ExtOpSet-CPU-FlashAttn2SwaSink tests/main.cpp)
   target_link_libraries(Mllm-Test-ExtOpSet-CPU-FlashAttn2SwaSink PRIVATE gtest_main MllmRT MllmCPUBackend)

--- a/mllm-ext-opset/cpu/radix_swa_sink/CMakeLists.txt
+++ b/mllm-ext-opset/cpu/radix_swa_sink/CMakeLists.txt
@@ -2,6 +2,13 @@ add_library(MllmExtOpSet_CPU_RadixAttnSwaSink SHARED RadixAttnSwaSink.cpp)
 target_link_libraries(MllmExtOpSet_CPU_RadixAttnSwaSink PRIVATE MllmRT MllmCPUBackend)
 target_include_directories(MllmExtOpSet_CPU_RadixAttnSwaSink PRIVATE ${MLLM_INCLUDE_DIR})
 
+install(
+  TARGETS MllmExtOpSet_CPU_RadixAttnSwaSink
+  EXPORT MllmTargets
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+  RUNTIME DESTINATION bin)
+
 if(MLLM_BUILD_EXT_OP_SET_TEST)
   add_executable(Mllm-Test-ExtOpSet-CPU-RadixAttnSwaSink tests/main.cpp)
   target_link_libraries(Mllm-Test-ExtOpSet-CPU-RadixAttnSwaSink PRIVATE gtest_main MllmRT MllmCPUBackend)


### PR DESCRIPTION
Added installation rules for mllm-ext-opset header files and shared libraries. This ensures that the extended operator set components are properly included in the build output and can be consumed by downstream projects. Specifically, the headers from mllm-ext-opset directory are now installed, along with the FlashAttn2SwaSink and RadixAttnSwaSink shared libraries.