### PR TITLE
feat(mllm-ext-opset): add radix attention relax implementation for flexible tensor dims

### DIFF
--- a/mllm-ext-opset/CMakeLists.txt
+++ b/mllm-ext-opset/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(cpu/fa2_swa_sink)
 add_subdirectory(cpu/radix_swa_sink)
+add_subdirectory(cpu/radix_attn_relax)

--- a/mllm-ext-opset/cpu/radix_attn_relax/CMakeLists.txt
+++ b/mllm-ext-opset/cpu/radix_attn_relax/CMakeLists.txt
@@ -1,0 +1,17 @@
+add_library(MllmExtOpSet_CPU_RadixAttnRelax SHARED RadixAttnRelax.cpp)
+target_link_libraries(MllmExtOpSet_CPU_RadixAttnRelax PRIVATE MllmRT MllmCPUBackend)
+target_include_directories(MllmExtOpSet_CPU_RadixAttnRelax PRIVATE ${MLLM_INCLUDE_DIR})
+
+install(
+  TARGETS MllmExtOpSet_CPU_RadixAttnRelax
+  EXPORT MllmTargets
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+  RUNTIME DESTINATION bin)
+
+# if(MLLM_BUILD_EXT_OP_SET_TEST)
+#   add_executable(Mllm-Test-ExtOpSet-CPU-RadixAttnRelax tests/main.cpp)
+#   target_link_libraries(Mllm-Test-ExtOpSet-CPU-RadixAttnRelax PRIVATE gtest_main MllmRT MllmCPUBackend)
+#   target_include_directories(Mllm-Test-ExtOpSet-CPU-RadixAttnRelax PRIVATE ${MLLM_INCLUDE_DIR})
+#   include(GoogleTest)
+# endif()

--- a/mllm-ext-opset/cpu/radix_attn_relax/README.md
+++ b/mllm-ext-opset/cpu/radix_attn_relax/README.md
@@ -1,0 +1,3 @@
+# Radix Attention Relax
+
+The radix attention in mllm suppose that qkv has some dim. But some models does not match this assumption. So we create a relax version of radix attention to support any dim.

--- a/mllm-ext-opset/cpu/radix_attn_relax/RadixAttnRelax.cpp
+++ b/mllm-ext-opset/cpu/radix_attn_relax/RadixAttnRelax.cpp
@@ -1,0 +1,108 @@
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
+
+#include "mllm/mllm.hpp"
+#include "mllm/utils/CPUArchHelper.hpp"
+#include "mllm/compile/ir/linalg/Op.hpp"
+#include "mllm/backends/cpu/kernels/common/radix_attn/arch.hpp"
+#include "mllm-ext-opset/cpu/radix_attn_relax/RadixAttnRelax.hpp"
+#include "mllm-ext-opset/cpu/radix_attn_relax/radix_attn_relax_fwd_bshd.hpp"
+
+namespace mllm::ext_opset::cpu {
+
+void RadixAttnRelax::load(const mllm::ParameterFile::ptr_t& ploader) { MLLM_EMPTY_SCOPE; };
+
+void RadixAttnRelax::trace(void* trace_context, const std::vector<mllm::Tensor>& inputs, std::vector<mllm::Tensor>& outputs) {
+  auto ir_ctx = (mllm::ir::IRContext*)trace_context;
+  auto i_irs = mllm::ir::tensor::wrapTensors2TensorIR(ir_ctx, inputs);
+  auto o_irs = mllm::ir::tensor::wrapTensors2TensorIR(ir_ctx, outputs);
+  ir_ctx->create<mllm::ir::linalg::CustomizedOp>(shared_from_this(), i_irs, o_irs);
+};
+
+void RadixAttnRelax::forward(const std::vector<mllm::Tensor>& inputs, std::vector<mllm::Tensor>& outputs) {
+  auto& Q = inputs[0];
+  auto& K = inputs[1];
+  auto& V = inputs[2];
+  auto& S_AUX = inputs[3];
+  auto& O = outputs[0];
+
+  // Only Support Contiguous Tensor
+  MLLM_RT_ASSERT(Q.isContiguous());
+
+  // NOTE:
+  //
+  // K, V is in flexible layout, no contiguous is OK.
+  //
+  // MLLM_RT_ASSERT(K.isContiguous());
+  // MLLM_RT_ASSERT(V.isContiguous());
+
+  auto B = Q.shape()[0];
+  auto S_Q = Q.shape()[1];
+  auto H_Q = Q.shape()[2];
+  auto D_QK = Q.shape()[3];
+  auto D_V = V.shape()[3];
+  MLLM_RT_ASSERT_EQ(H_Q, options_.q_head);
+  auto S_KV = K.shape()[1];
+  MLLM_RT_ASSERT_EQ(S_KV, V.shape()[1]);
+
+  switch (Q.dtype()) {
+    case mllm::kFloat32: {
+#if defined(MLLM_HOST_ARCH_ARM64) || defined(MLLM_HOST_ARCH)
+      fwd_bshd<::mllm::cpu::radix_attn::details::__ArmArchTag, mllm_fp32_t, mllm_fp32_t, mllm_fp32_t, mllm_fp32_t, mllm_fp32_t>(
+          B, options_.q_head, options_.kv_head, S_Q, S_KV, options_.D_QK, options_.D_V, Q.ptr<mllm_fp32_t>(),
+          K.ptr<mllm_fp32_t*>(), V.ptr<mllm_fp32_t*>(), O.ptr<mllm_fp32_t>(), options_.getThreads());
+#elif defined(MLLM_HOST_ARCH_X86) || defined(MLLM_HOST_ARCH_X86_64)
+      fwd_bshd<::mllm::cpu::radix_attn::details::__X86ArchTag, mllm_fp32_t, mllm_fp32_t, mllm_fp32_t, mllm_fp32_t, mllm_fp32_t>(
+          B, options_.q_head, options_.kv_head, S_Q, S_KV, options_.D_QK, options_.D_V, Q.ptr<mllm_fp32_t>(),
+          K.ptr<mllm_fp32_t*>(), V.ptr<mllm_fp32_t*>(), O.ptr<mllm_fp32_t>(), options_.getThreads());
+#endif
+      break;
+    }
+    default: NYI("RadixAttnRelax::forward not support dtype {}", nameOfType(Q.dtype())); break;
+  }
+}
+
+void RadixAttnRelax::reshape(const std::vector<mllm::Tensor>& inputs, std::vector<mllm::Tensor>& outputs) {
+  // CHECK inputs
+  MLLM_RT_ASSERT(inputs.size() >= 3);
+  // CHECK QKV [B, S, H, D]
+  auto& q = inputs[0];
+  auto& k = inputs[1];
+  auto& v = inputs[2];
+  MLLM_RT_ASSERT(q.rank() == 4 && k.rank() == 1 && v.rank() == 1);
+  outputs.emplace_back(mllm::Tensor::empty({options_.B, q.size(1), options_.q_head, options_.D_V}, q.dtype(), q.device()));
+}
+
+void RadixAttnRelax::setup(const std::vector<mllm::Tensor>& inputs, std::vector<mllm::Tensor>& outputs) {
+  BaseOp::setup(inputs, outputs);
+}
+
+}  // namespace mllm::ext_opset::cpu
+
+MLLM_PLUGIN_OP_INTERFACE_DEFINE_BEGIN
+void* createRadixAttnRelaxFactory() { return new mllm::ext_opset::cpu::RadixAttnRelaxFactory(); };
+
+void freeRadixAttnRelaxFactory(void* factory) { delete static_cast<mllm::ext_opset::cpu::RadixAttnRelaxFactory*>(factory); };
+
+void* opPackageDescriptor() {
+  auto package = new PluginOpPackageDescriptor{
+      .version = MLLM_PLUGIN_OP_PACKAGE_DESCRIPTOR_VERSION,
+      .name = "MllmExtOpSet.CPU.RadixAttnRelax",
+      .device_type = 1,
+      .op_factories_count = 1,
+      .op_factories_names =
+          {
+              "radix_attn_relax",
+          },
+      .op_factory_create_funcs =
+          {
+              createRadixAttnRelaxFactory,
+          },
+      .op_factory_free_funcs =
+          {
+              freeRadixAttnRelaxFactory,
+          },
+  };
+  return package;
+}
+MLLM_PLUGIN_OP_INTERFACE_DEFINE_END

--- a/mllm-ext-opset/cpu/radix_attn_relax/RadixAttnRelax.hpp
+++ b/mllm-ext-opset/cpu/radix_attn_relax/RadixAttnRelax.hpp
@@ -1,0 +1,43 @@
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
+#include "mllm/mllm.hpp"
+#include "mllm/backends/base/PluginInterface.hpp"
+
+namespace mllm::ext_opset::cpu {
+
+struct RadixAttnRelaxOptions : public mllm::BaseOpOptions<RadixAttnRelaxOptions> {
+  int32_t B;
+  int32_t q_head;
+  int32_t kv_head;
+  int32_t D_QK;
+  int32_t D_V;
+};
+
+class RadixAttnRelax final : public mllm::plugin::interface::CustomizedOp {
+ public:
+  explicit RadixAttnRelax(const RadixAttnRelaxOptions& options) : CustomizedOp("radix_attn_relax"), options_(options) {}
+
+  void load(const mllm::ParameterFile::ptr_t& ploader) override;
+
+  void trace(void* trace_context, const std::vector<mllm::Tensor>& inputs, std::vector<mllm::Tensor>& outputs) override;
+
+  void forward(const std::vector<mllm::Tensor>& inputs, std::vector<mllm::Tensor>& outputs) override;
+
+  void reshape(const std::vector<mllm::Tensor>& inputs, std::vector<mllm::Tensor>& outputs) override;
+
+  void setup(const std::vector<mllm::Tensor>& inputs, std::vector<mllm::Tensor>& outputs) override;
+
+ protected:
+  RadixAttnRelaxOptions options_;
+};
+
+class RadixAttnRelaxFactory final : public mllm::plugin::interface::CustomizedOpFactory<RadixAttnRelaxOptions> {
+ public:
+  inline std::shared_ptr<mllm::BaseOp> createOpImpl(const RadixAttnRelaxOptions& cargo) override {
+    auto p = std::make_shared<RadixAttnRelax>(cargo);
+    p->setOpType(opType());
+    return p;
+  }
+};
+
+}  // namespace mllm::ext_opset::cpu

--- a/mllm-ext-opset/cpu/radix_attn_relax/radix_attn_relax_fwd_bshd.hpp
+++ b/mllm-ext-opset/cpu/radix_attn_relax/radix_attn_relax_fwd_bshd.hpp
@@ -1,0 +1,96 @@
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <cmath>
+#include <limits>
+#include <cstdint>
+#include <numbers>
+#include "mllm/core/Parallel.hpp"
+#include "mllm/utils/CPUArchHelper.hpp"
+#include "mllm/backends/cpu/kernels/common/radix_attn/arch.hpp"
+
+#if defined(MLLM_HOST_ARCH_ARM64) || defined(MLLM_HOST_ARCH)
+#include "mllm/backends/cpu/kernels/common/radix_attn/impl-arm.hpp"
+#else
+#include "mllm/backends/cpu/kernels/common/radix_attn/impl-any-simd.hpp"
+#endif
+#include "mllm/backends/cpu/kernels/common/radix_attn/impl-any.hpp"
+
+// BSHD
+// K: [S_KV], address, not contiguous
+// V: [S_KV], address, not contiguous
+// Q: [B, S_Q, H_Q, D], contiguous
+//
+// After find KV Tokens, KV is [B, 1, H_KV, D]
+//
+// H_KV should <= H_Q
+template<typename __ArchTag, typename __QDType, typename __KDType, typename __VDType, typename __ODType, typename __AccDType,
+         bool high_precession_exp = true>
+void fwd_bshd(int32_t B, int32_t H_Q, int32_t H_KV, int32_t S_Q, int32_t S_KV, int32_t D_QK, int32_t D_V,
+              const __QDType* __restrict__ __q, __KDType** __k, __VDType** __v, __ODType* __restrict__ __out,
+              int32_t thread_count) {
+  int32_t head_repeat_times = H_Q / H_KV;
+
+  __AccDType scale = scale = std::sqrt(1.0 / D_QK) * (__AccDType)std::numbers::log2e;
+
+  // Loop on batch size.
+  for (int b_idx = 0; b_idx < B; ++b_idx) {
+    // Loop on HEAD dim, should be made parallel
+    MLLM_CONDITIONAL_PARALLEL_FOR(thread_count > 1, thread_count, h_q_idx, 0, H_Q, 1, {
+      int h_kv_id = h_q_idx / head_repeat_times;
+
+      // FA2's Loop
+      for (int s_q_idx = 0; s_q_idx < S_Q; ++s_q_idx) {
+        const __QDType* q_token = __q + b_idx * H_Q * S_Q * D_QK + s_q_idx * H_Q * D_QK + h_q_idx * D_QK;
+        __ODType* acc_o = __out + b_idx * H_Q * S_Q * D_V + s_q_idx * H_Q * D_V + h_q_idx * D_V;
+
+        mllm::cpu::radix_attn::details::FilledWithConst<__ArchTag, __ODType>::run(acc_o, 0, D_V);
+
+        __AccDType scores_max = -std::numeric_limits<__AccDType>::infinity();
+        __AccDType scores_max_prev = -std::numeric_limits<__AccDType>::infinity();
+        __AccDType logsum = 0;
+        __AccDType scores_sum = 0;
+        __AccDType scores_scale = 0;
+
+        int __delta = S_KV - S_Q;
+        int S_KV_BOUND = std::min(__delta + s_q_idx + 1, S_KV);
+
+        for (int s_kv_idx = 0; s_kv_idx < S_KV_BOUND; ++s_kv_idx) {
+          // k_token and v_token shape is [B, 1, H, D]
+          __KDType* k_token = __k[s_kv_idx];
+          __VDType* v_token = __v[s_kv_idx];
+
+          // Offset to one head.
+          // k_token and v_token shape is [D]
+          k_token = k_token + b_idx * H_KV * D_QK + h_kv_id * D_QK;
+          v_token = v_token + b_idx * H_KV * D_V + h_kv_id * D_V;
+
+          // 1. MMA0. Q @ K -> A_i
+          __AccDType acc_s;
+          mllm::cpu::radix_attn::details::VectorDotProduct<__ArchTag, __QDType, __KDType, __AccDType>::run(q_token, k_token,
+                                                                                                           &acc_s, D_QK);
+
+          // 2. Do softmax stuff.
+          scores_max_prev = scores_max;
+          scores_max = std::max(scores_max_prev, acc_s);
+          scores_scale = std::exp2(scores_max_prev * scale - scores_max * scale);
+          acc_s = std::exp2(acc_s * scale - scores_max * scale);
+          scores_sum = acc_s;
+          logsum = logsum * scores_scale + scores_sum;
+
+          // 3. Scale
+          mllm::cpu::radix_attn::details::MulFromConst<__ArchTag, __AccDType, __AccDType>::run(acc_o, scores_scale, D_V);
+
+          // 4. MMA1.
+          mllm::cpu::radix_attn::details::FMAConstArray<__ArchTag, __AccDType, __AccDType, __AccDType>::run(acc_o, acc_s,
+                                                                                                            v_token, D_V);
+        }
+
+        // 5. Final Rescale.
+        mllm::cpu::radix_attn::details::MulFromConst<__ArchTag, __ODType, __AccDType>::run(acc_o, (1.f / logsum), D_V);
+      }
+    });
+  }
+}


### PR DESCRIPTION
Added a new relaxed version of radix attention to support models where QKV tensors do not conform to strict dimensional assumptions. This includes:

- New CMake build configuration for the relaxed radix attention module
- Implementation of forward pass with support for non-contiguous K/V tensors
- CPU-specific optimized kernels using architecture-aware implementations
- Plugin interface integration for dynamic loading
- Comprehensive reshaping and tracing logic for IR compatibility

The new implementation allows processing of QKV tensors with arbitrary dimensions while maintaining performance through SIMD-optimized compute kernels.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Radix Attention Relax operation for CPU supporting flexible QKV dimensions, removing previous dimensional constraints and enabling broader compatibility with various attention configurations.

* **Documentation**
  * Added README documenting the Radix Attention Relax variant and its enhanced dimensional flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->