### PR TITLE
fix: resolve type mismatch in Smollm3Attention KV cache update

### DIFF
--- a/mllm/models/smollm3_3B/modeling_smollm3.hpp
+++ b/mllm/models/smollm3_3B/modeling_smollm3.hpp
@@ -154,7 +154,9 @@ class Smollm3Attention final : public nn::Module {
     query_states = q_rope_(query_states, llm_embedding_sin, llm_embedding_cos);
     key_states = k_rope_(key_states, llm_embedding_sin, llm_embedding_cos);
 
-    std::tie(key_states, value_states) = past_kv_cache->updateKVCache(layer_idx_, key_states, value_states);
+    auto [key_states_result, value_states_result] = past_kv_cache->updateKVCache(layer_idx_, key_states, value_states);
+    key_states = std::move(key_states_result);
+    value_states = std::move(value_states_result);
 
     Tensor attn;
     if (key_states.dtype() == kFloat32) {


### PR DESCRIPTION
Fixed compilation error in modeling_smollm3.hpp:157 where std::tie could not handle assignment from std::array<Tensor, 2> return type.

Tested with GCC and Clang on x86 (WSL) with C++17/20 standards. Changes:
- Replace std::tie with structured bindings (C++17)
- Use std::move for efficient tensor transfer
- Maintain same functionality while fixing type compatibility

Related Issue: #522  