### PR TITLE
fix: reshape tensor weight to 2d

### DIFF
--- a/pymllm/__init__.py
+++ b/pymllm/__init__.py
@@ -10,6 +10,7 @@ from . import quantize
 from . import nn
 from . import compile
 from . import service
+from . import backends
 from .ffi import (
     float32,
     float16,

--- a/pymllm/backends/qualcomm/__init__.py
+++ b/pymllm/backends/qualcomm/__init__.py
@@ -2,3 +2,4 @@
 # Licensed under the MIT License.
 
 from . import qnn_aot_env
+from . import transformers

--- a/pymllm/backends/qualcomm/transformers/__init__.py
+++ b/pymllm/backends/qualcomm/transformers/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) MLLM Team.
+# Licensed under the MIT License.
+
+from . import core

--- a/pymllm/backends/qualcomm/transformers/core/qlinear.py
+++ b/pymllm/backends/qualcomm/transformers/core/qlinear.py
@@ -196,7 +196,10 @@ class QLinearLPBQ(QLinear):
             return
 
         del self.weight
-        self.register_buffer("weight", self.weight_quant.weight_q)
+        self.register_buffer(
+            "weight",
+            self.weight_quant.weight_q.reshape(self.weight_quant.weight_q.shape[0], -1),
+        )
         self.register_buffer("scale1", self.weight_quant.scale_1_uint4)
         self.register_buffer("scale2", self.weight_quant.scale_2_fp32)
         del self.weight_quant


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Backends submodule now accessible at the package level.
  * Transformers module now available within the Qualcomm backend.

* **Refactor**
  * Optimized weight buffer storage format during model deployment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->