### PR TITLE
fix(Qualcomm): Replace linear op with conv2d in Qualcomm backend

### DIFF
--- a/mllm/backends/qnn/QNNUtils.cpp
+++ b/mllm/backends/qnn/QNNUtils.cpp
@@ -1,18 +1,19 @@
+#include <cstdint>
+#include <memory>
+#include <dlfcn.h>
+#include <cstring>
+
 #include "QNNUtils.hpp"
 #include "QnnTypes.h"
+
 #include "mllm/backends/qnn/QNNAllocator.hpp"
 #include "mllm/backends/qnn/QNNTypeMacros.hpp"
 #include "mllm/core/DataTypes.hpp"
 #include "mllm/core/DeviceTypes.hpp"
 #include "mllm/engine/Context.hpp"
-#include "mllm/mllm.hpp"
 #include "mllm/utils/Common.hpp"
 #include "mllm/utils/Log.hpp"
 #include "mllm/compile/ir/tensor/Value.hpp"
-#include <cstdint>
-#include <memory>
-#include <dlfcn.h>
-#include <cstring>
 
 namespace mllm::qnn {
 

--- a/mllm/backends/qnn/aot/QnnWrappersAPI.cpp
+++ b/mllm/backends/qnn/aot/QnnWrappersAPI.cpp
@@ -159,22 +159,24 @@ void QnnAOTNodeTensor::setupComplexTensorQuantization(const ir::tensor::TensorVa
       break;
     }
     case ir::linalg::QuantizationSpecType::kLPBQ: {
+      // This LPBQ Type is for Conv2D Only !!! Linear has diff layout cmp with conv2d
+
       auto cfg = std::static_pointer_cast<ir::linalg::QuantizationSpecLPBQ>(quant_spec);
 
       // Prepare data
-      auto num_scale_offsets = (uint32_t)v->tensor_.size(cfg->ch_axis);
+      auto num_scale_offsets = (uint32_t)v->tensor_.size(-1);
       std::vector<Qnn_ScaleOffset_t> scale_offsets(num_scale_offsets);
-      MLLM_RT_ASSERT_EQ(num_scale_offsets, cfg->scale_level_1_fp.size(0));
+      MLLM_RT_ASSERT_EQ(num_scale_offsets, cfg->scale_level_1_fp.size(-1));
       MLLM_RT_ASSERT_EQ(cfg->scale_level_0_int.dtype(), kUInt8);
       for (int i = 0; i < num_scale_offsets; ++i) {
-        scale_offsets[i].scale = cfg->scale_level_1_fp.at<float>({i, 0, 0});
+        scale_offsets[i].scale = cfg->scale_level_1_fp.at<float>({0, 0, 0, i});
         scale_offsets[i].offset = 0;
       }
 
       Qnn_BlockwiseExpansion_t blockwise_expansion;
-      blockwise_expansion.axis = cfg->ch_axis;
+      blockwise_expansion.axis = v->tensor_.rank() - 1;
       blockwise_expansion.scaleOffsets = nullptr;  // Will be set by setBlockwiseQuantization
-      blockwise_expansion.numBlocksPerAxis = v->tensor_.size(1) / cfg->block_size;
+      blockwise_expansion.numBlocksPerAxis = v->tensor_.size(-2) / cfg->block_size;
       blockwise_expansion.blockScaleBitwidth = 4;  // 4 bits for uint4 scale
       blockwise_expansion.blockScaleStorageType = QNN_BLOCKWISE_EXPANSION_BITWIDTH_SCALE_STORAGE_8;
       blockwise_expansion.blocksScale8 = cfg->scale_level_0_int.ptr<mllm_uint8_t>();

--- a/mllm/backends/qnn/aot/passes/LLM2QnnLoweringPass.cpp
+++ b/mllm/backends/qnn/aot/passes/LLM2QnnLoweringPass.cpp
@@ -12,6 +12,7 @@
 #include "mllm/compile/passes/Pass.hpp"
 #include "mllm/utils/Common.hpp"
 
+#include "mllm/backends/qnn/aot/visitor/Conv2D.hpp"
 #include "mllm/backends/qnn/aot/visitor/Elewise.hpp"
 #include "mllm/backends/qnn/aot/visitor/Embedding.hpp"
 #include "mllm/backends/qnn/aot/visitor/Gather.hpp"
@@ -38,7 +39,7 @@ LLM2QnnLoweringPass::LLM2QnnLoweringPass() {
                    QnnAOTViewPattern, QnnAOTIndexPattern, QnnAOTGatherPattern, QnnAOTRMSNormPattern, QnnAOTLinearPattern,
                    QnnAOTTransposePattern, QnnAOTSlicePattern, QnnAOTConcatPattern, QnnAOTRepeatPattern, QnnAOTMatMulPattern,
                    QnnAOTReduceMaxPattern, QnnAOTReduceMinPattern, QnnAOTReduceMeanPattern, QnnAOTReduceSumPattern,
-                   QnnAOTEqualPattern, QnnAOTWherePattern, QnnAOTSoftmaxPattern, QnnAOTSigmoidPattern>();
+                   QnnAOTEqualPattern, QnnAOTWherePattern, QnnAOTSoftmaxPattern, QnnAOTSigmoidPattern, QnnAOTConv2DPattern>();
 }
 
 uint8_t LLM2QnnLoweringPass::run(const ir::node_ptr_t& op) {

--- a/mllm/backends/qnn/aot/passes/LLMQuantRecipePass.hpp
+++ b/mllm/backends/qnn/aot/passes/LLMQuantRecipePass.hpp
@@ -33,6 +33,20 @@ ir::linalg::LinalgIRQuantizatonSpecAttr::ptr_t cloneQuantizationSpecType(
     const ir::IRContext::ptr_t& ctx, const ir::linalg::LinalgIRQuantizatonSpecAttr::ptr_t& from);
 
 //===----------------------------------------------------------------------===//
+// Conv2D Pattern
+//===----------------------------------------------------------------------===//
+class LLMQuantRecipeConv2DPattern : public ir::Pattern {
+ public:
+  bool isMatch(const mllm::ir::op_ptr_t& op) override;
+
+  bool rewrite(ir::IRWriter& writer, const ir::op_ptr_t& node) override;
+
+  static inline std::shared_ptr<LLMQuantRecipeConv2DPattern> create() {
+    return std::make_shared<LLMQuantRecipeConv2DPattern>();
+  }
+};
+
+//===----------------------------------------------------------------------===//
 // Sigmoid Pattern
 //===----------------------------------------------------------------------===//
 class LLMQuantRecipeSigmoidPattern : public ir::Pattern {

--- a/mllm/backends/qnn/aot/passes/PTQPass.cpp
+++ b/mllm/backends/qnn/aot/passes/PTQPass.cpp
@@ -122,6 +122,10 @@ void recursiveSolveWeights(const std::shared_ptr<ir::IRContext>& ir_ctx, const i
   auto wow = ir::IRWriter(ir_ctx, call_op->getTopRegion());
   wow.walk<ir::Op>([&](ir::IRWriter& w, const ir::Op::ptr_t& op) -> ir::IRWriter::WalkResult {
     if (op->isa_<ir::linalg::LinearOp>()) { solveLinearWeight(w.getContext(), pf, op->cast_<ir::linalg::LinalgIROp>()); }
+    if (op->isa_<ir::linalg::Conv2DOp>()) {
+      // Conv2D's Check same with Linear
+      solveLinearWeight(w.getContext(), pf, op->cast_<ir::linalg::LinalgIROp>());
+    }
     if (op->isa_<ir::linalg::RMSNormOp>()) { solveRMSNormWeight(w.getContext(), pf, op->cast_<ir::linalg::LinalgIROp>()); }
     if (op->isa_<ir::linalg::EmbeddingOp>()) { solveEmbeddingWeight(w.getContext(), pf, op->cast_<ir::linalg::LinalgIROp>()); }
     if (op->isa_<ir::graph::CallGraphOp>()) {

--- a/mllm/backends/qnn/aot/visitor/Conv2D.cpp
+++ b/mllm/backends/qnn/aot/visitor/Conv2D.cpp
@@ -1,0 +1,103 @@
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
+
+#include "mllm/backends/qnn/QNNUtils.hpp"
+#include "mllm/utils/Common.hpp"
+#include "mllm/compile/ir/linalg/Op.hpp"
+#include "mllm/compile/ir/builtin/Attribute.hpp"
+#include "mllm/backends/qnn/aot/QnnWrappersAPI.hpp"
+#include "mllm/backends/qnn/aot/visitor/Conv2D.hpp"
+#include "mllm/backends/qnn/aot/passes/AOTCompileContext.hpp"
+#include "mllm/core/aops/Conv2DOp.hpp"
+
+namespace mllm::qnn::aot {
+
+bool QnnAOTConv2DPattern::isMatch(const mllm::ir::op_ptr_t& op) {
+  return op->isa_<mllm::ir::linalg::Conv2DOp>() && (op->getAttr("using_qnn") != nullptr);
+}
+
+bool QnnAOTConv2DPattern::rewrite(ir::IRWriter& writer, const ir::op_ptr_t& op) {
+  auto env = AOTCompileContext::getInstance().getEnv();
+
+  auto linear_op = op->cast_<mllm::ir::linalg::Conv2DOp>();
+  if (!linear_op) {
+    MLLM_ERROR("Failed to cast to linalg::Conv2DOp");
+    return false;
+  }
+
+  MLLM_RETURN_FALSE_IF_NOT(op->getAttr("qnn_graph_name"));
+  auto qnn_graph_name = op->getAttr("qnn_graph_name")->cast_<ir::StrAttr>()->data();
+  MLLM_RETURN_FALSE_IF_NOT(op->getAttr("qnn_context_name"));
+  auto qnn_context_name = op->getAttr("qnn_context_name")->cast_<ir::StrAttr>()->data();
+
+  auto input = op->inputs().front()->cast_<ir::tensor::TensorValue>();
+  auto output = op->outputs().front()->cast_<ir::tensor::TensorValue>();
+
+  auto base_op = linear_op->getAOp();
+  auto real_linear_op = dynamic_cast<mllm::aops::Conv2DOp*>(base_op);
+  if (!real_linear_op) {
+    MLLM_ERROR("Failed to cast BaseOp to mllm::aops::Conv2DOp");
+    return false;
+  }
+
+  // Retrieve weight from symbol table
+  auto weight_val = writer.getContext()
+                        ->lookupSymbolTable(base_op->getName() + ".weight")
+                        ->outputs()
+                        .front()
+                        ->cast_<ir::tensor::TensorValue>();
+
+  // Create QNN Conv2D Op
+  auto qnn_op_node = QnnAOTNodeOperation::create("Conv2d");
+  qnn_op_node->setPackageName("qti.aisw");
+
+  qnn_op_node->emplaceInput(env->captureQnnAOTNodeTensor(qnn_context_name, qnn_graph_name, input))
+      ->emplaceInput(env->captureQnnAOTNodeTensor(qnn_context_name, qnn_graph_name, weight_val, true));
+
+  // Handle Bias
+  if (real_linear_op->options().bias) {
+    auto bias_val = writer.getContext()
+                        ->lookupSymbolTable(base_op->getName() + ".bias")
+                        ->outputs()
+                        .front()
+                        ->cast_<ir::tensor::TensorValue>();
+    qnn_op_node->emplaceInput(env->captureQnnAOTNodeTensor(qnn_context_name, qnn_graph_name, bias_val, true));
+  }
+
+  qnn_op_node->emplaceOutput(env->captureQnnAOTNodeTensor(qnn_context_name, qnn_graph_name, output))
+      ->setName(base_op->getName());
+
+  // Add params: stride
+  {
+    auto stride_param =
+        QNNParamTensorWrapper::create("stride", base_op->getName() + ".stride", QNN_DATATYPE_UINT_32, std::vector<uint32_t>{2});
+    uint32_t* data = static_cast<uint32_t*>(stride_param->alloc());
+    data[0] = 1;
+    data[1] = 1;
+    qnn_op_node->emplaceParamTensor(stride_param);
+  }
+
+  // Add params: pad amount
+  {
+    auto pad_amount_param =
+        QNNParamTensorWrapper::create("pad_amount", base_op->getName() + ".pad_amount", QNN_DATATYPE_UINT_32,
+                                      std::vector<uint32_t>{
+                                          2,
+                                          2,
+                                      });
+    // [[height_pad_before, height_pad_after], [width_pad_before, width_pad_after]]
+    uint32_t* data = static_cast<uint32_t*>(pad_amount_param->alloc());
+    data[0] = 0;
+    data[1] = 0;
+    data[2] = 0;
+    data[3] = 0;
+    qnn_op_node->emplaceParamTensor(pad_amount_param);
+  }
+
+  // Register this op node into one graph.
+  env->captureAOTNodeOp(qnn_context_name, qnn_graph_name, qnn_op_node);
+
+  return true;
+}
+
+}  // namespace mllm::qnn::aot

--- a/mllm/backends/qnn/aot/visitor/Conv2D.hpp
+++ b/mllm/backends/qnn/aot/visitor/Conv2D.hpp
@@ -1,0 +1,23 @@
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "mllm/core/OpTypes.hpp"
+#include "mllm/compile/ir/Node.hpp"
+#include "mllm/backends/qnn/aot/visitor/Base.hpp"
+
+namespace mllm::qnn::aot {
+
+class QnnAOTConv2DPattern : public QnnAOTBasePattern {
+ public:
+  bool isMatch(const mllm::ir::op_ptr_t& op) override;
+
+  bool rewrite(ir::IRWriter& writer, const ir::op_ptr_t& op) override;
+
+  static inline std::pair<OpTypes, std::shared_ptr<QnnAOTConv2DPattern>> create() {
+    return {OpTypes::kConv2D, std::make_shared<QnnAOTConv2DPattern>()};
+  }
+};
+
+}  // namespace mllm::qnn::aot

--- a/mllm/core/aops/Conv2DOp.hpp
+++ b/mllm/core/aops/Conv2DOp.hpp
@@ -10,6 +10,10 @@ namespace mllm::aops {
 
 enum class Conv2DOpImplType {
   kDefault = 0,
+
+  // LPBQ
+  kQNN_LPBQ_w4a16o16_G32,
+  kQNN_LPBQ_w4a16o16_G64,
 };
 
 struct Conv2DOpOptions : public BaseOpOptions<Conv2DOpOptions> {

--- a/pymllm/backends/qualcomm/transformers/qwen3/runner.py
+++ b/pymllm/backends/qualcomm/transformers/qwen3/runner.py
@@ -32,11 +32,9 @@ def enable_qdq_observer(m):
 
 
 def convert_weight(m):
-    if (
-        isinstance(m, QLinearLPBQ)
-        or isinstance(m, QLinearW8A16_PerChannelSym)
-        or isinstance(m, QRMSNorm)
-    ):
+    if isinstance(m, QLinearLPBQ) or isinstance(m, QLinearW8A16_PerChannelSym):
+        m.convert_to_conv2d_deploy_hwio()
+    if isinstance(m, QRMSNorm):
         m.convert_to_deploy()
 
 
@@ -47,6 +45,7 @@ class Qwen3Quantizer:
             model_path,
             attn_implementation="eager",
         )
+        self.model.cuda()
         self.mllm_qualcomm_max_length = mllm_qualcomm_max_length
         self.model.mllm_qualcomm_max_length = mllm_qualcomm_max_length
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Conv2D operations now supported in QNN backend for enhanced model execution
  * Conv2D quantization support with LPBQ (Low Precision Block Quantization) method
  * Model deployment optimization with HWIO format for improved inference efficiency

* **Improvements**
  * Qwen3 model architecture updated with Conv2D-based layers for optimized performance
  * GPU acceleration added during model quantization initialization

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->