### PR TITLE
fix(pymllm): qnn_aot_env.py针对x86的改进

### DIFF
--- a/pymllm/backends/qualcomm/qnn_aot_env.py
+++ b/pymllm/backends/qualcomm/qnn_aot_env.py
@@ -1,9 +1,21 @@
-from pymllm.ffi import (
-    QnnDeviceAndContext,
-    QnnAOTEnv,
-    QcomChipset,
-    QcomHTPArch,
-    QcomSecurityPDSession,
-    QcomTargetMachine,
-    QcomTryBestPerformance,
-)
+from pymllm.ffi import is_qnn_aot_on_x86_enabled
+
+if is_qnn_aot_on_x86_enabled():
+    from pymllm.ffi import (
+        QnnDeviceAndContext,
+        QnnAOTEnv,
+        QcomChipset,
+        QcomHTPArch,
+        QcomSecurityPDSession,
+        QcomTargetMachine,
+        QcomTryBestPerformance,
+    )
+else:
+    # Define placeholder classes when QNN AOT is not enabled
+    QnnDeviceAndContext = None
+    QnnAOTEnv = None
+    QcomChipset = None
+    QcomHTPArch = None
+    QcomSecurityPDSession = None
+    QcomTargetMachine = None
+    QcomTryBestPerformance = None


### PR DESCRIPTION
<!--
Thank you for your contribution to the MLLM framework!

To help us review your Pull Request efficiently, please check out this template.
A clear and complete description will significantly speed up the review process.
-->

针对mllm v2模型在x86架构上转换报错的问题对代码进行改进。对于QnnDeviceAndContext 导入错误问题，修改了 mllm/pymllm/backends/qualcomm/qnn_aot_env.py，使其只在 is_qnn_aot_on_x86_enabled() 为 True 时才导入这些类，否则设置为 None。但是修改只针对x86架构，在别的架构中运行应该会跳到错误的分支，所以最后应用时判断条件要改的考虑条件更多一点。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved environment compatibility by gracefully handling cases where certain platform-specific optimization features may not be available, preventing initialization errors while preserving full functionality in supported configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->