### PR TITLE
Add datasets compatibility checks for Qualcomm calibration runners

### DIFF
--- a/pymllm/mobile/backends/qualcomm/transformers/llama/runner.py
+++ b/pymllm/mobile/backends/qualcomm/transformers/llama/runner.py
@@ -1,6 +1,7 @@
 import torch
 from tqdm import tqdm
-from modelscope.msdatasets import MsDataset
+from importlib.metadata import PackageNotFoundError, version
+from packaging.version import Version
 from transformers import AutoTokenizer
 from pymllm.mobile.backends.qualcomm.transformers.core.qdq import (
     ActivationQDQ,
@@ -193,6 +194,21 @@ def convert_weight(m):
     if isinstance(m, QEmbedding):
         m.convert_to_deploy()
 
+def _check_datasets_compatibility():
+    try:
+        ds_ver = version("datasets")
+    except PackageNotFoundError as e:
+        raise RuntimeError(
+            "datasets is required for calibration. "
+            "Please install a compatible version such as datasets==2.21.0."
+        ) from e
+
+    if Version(ds_ver) >= Version("3.0.0"):
+        raise RuntimeError(
+            f"Incompatible datasets version detected: {ds_ver}. "
+            "Current Qualcomm calibration depends on a modelscope-compatible "
+            "datasets version. Please use datasets==2.21.0."
+        )
 
 class LlamaQuantizer:
     def __init__(self, model_path: str, mllm_qualcomm_max_length=2048):
@@ -274,6 +290,8 @@ class LlamaQuantizer:
 
         # 2. Load Wikipedia dataset (English version example)
         # Use streaming=True to download and process on the fly, without downloading the full几十G dataset
+        _check_datasets_compatibility()
+        from modelscope.msdatasets import MsDataset
         dataset = MsDataset.load(
             "modelscope/wikitext",
             subset_name="wikitext-103-v1",

--- a/pymllm/mobile/backends/qualcomm/transformers/qwen2/runner.py
+++ b/pymllm/mobile/backends/qualcomm/transformers/qwen2/runner.py
@@ -1,6 +1,7 @@
 import torch
 from tqdm import tqdm
-from modelscope.msdatasets import MsDataset
+from importlib.metadata import PackageNotFoundError, version
+from packaging.version import Version
 from transformers import AutoTokenizer
 from pymllm.mobile.backends.qualcomm.transformers.core.qdq import (
     ActivationQDQ,
@@ -193,6 +194,21 @@ def convert_weight(m):
     if isinstance(m, QEmbedding):
         m.convert_to_deploy()
 
+def _check_datasets_compatibility():
+    try:
+        ds_ver = version("datasets")
+    except PackageNotFoundError as e:
+        raise RuntimeError(
+            "datasets is required for calibration. "
+            "Please install a compatible version such as datasets==2.21.0."
+        ) from e
+
+    if Version(ds_ver) >= Version("3.0.0"):
+        raise RuntimeError(
+            f"Incompatible datasets version detected: {ds_ver}. "
+            "Current Qualcomm calibration depends on a modelscope-compatible "
+            "datasets version. Please use datasets==2.21.0."
+        )
 
 class Qwen2Quantizer:
     def __init__(self, model_path: str, mllm_qualcomm_max_length=2048):
@@ -277,6 +293,8 @@ class Qwen2Quantizer:
 
         # 2. Load Wikipedia dataset (English version example)
         # Use streaming=True to download and process on the fly, without downloading the full几十G dataset
+        _check_datasets_compatibility()
+        from modelscope.msdatasets import MsDataset
         dataset = MsDataset.load(
             "modelscope/wikitext",
             subset_name="wikitext-103-v1",

--- a/pymllm/mobile/backends/qualcomm/transformers/qwen3/runner.py
+++ b/pymllm/mobile/backends/qualcomm/transformers/qwen3/runner.py
@@ -1,6 +1,7 @@
 import torch
 from tqdm import tqdm
-from modelscope.msdatasets import MsDataset
+from importlib.metadata import PackageNotFoundError, version
+from packaging.version import Version
 from transformers import AutoTokenizer
 from pymllm.mobile.backends.qualcomm.transformers.core.qdq import (
     ActivationQDQ,
@@ -193,7 +194,22 @@ def convert_weight(m):
     if isinstance(m, QEmbedding):
         m.convert_to_deploy()
 
+def _check_datasets_compatibility():
+    try:
+        ds_ver = version("datasets")
+    except PackageNotFoundError as e:
+        raise RuntimeError(
+            "datasets is required for calibration. "
+            "Please install a compatible version such as datasets==2.21.0."
+        ) from e
 
+    if Version(ds_ver) >= Version("3.0.0"):
+        raise RuntimeError(
+            f"Incompatible datasets version detected: {ds_ver}. "
+            "Current Qualcomm calibration depends on a modelscope-compatible "
+            "datasets version. Please use datasets==2.21.0."
+        )
+        
 class Qwen3Quantizer:
     def __init__(self, model_path: str, mllm_qualcomm_max_length=2048):
         self.tokenizer = AutoTokenizer.from_pretrained(model_path)
@@ -290,6 +306,9 @@ class Qwen3Quantizer:
 
         # 2. Load Wikipedia dataset (English version example)
         # Use streaming=True to download and process on the fly, without downloading the full几十G dataset
+        _check_datasets_compatibility()
+        from modelscope.msdatasets import MsDataset
+        
         dataset = MsDataset.load(
             "modelscope/wikitext",
             subset_name="wikitext-103-v1",


### PR DESCRIPTION
This PR adds a small compatibility check for datasets in the Qualcomm calibration runners for Qwen3, Qwen2, and Llama.

Based on the discussion in #646, calibration may hit low-level import errors under the known modelscope / datasets incompatibility. A workaround mentioned there is to use datasets==2.21.0.

This change delays the MsDataset import and raises a clearer error message suggesting datasets==2.21.0 when needed.

Validated with python -m py_compile on the modified runner files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced calibration process with early validation for the `datasets` package dependency. Calibration now fails immediately with clear error messages if the required package is missing or using an incompatible version, preventing obscure runtime failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->