### PR TITLE
Add compressed-tensors Marlin support for Qwen3-VL AWQ in pymllm

### DIFF
--- a/mllm-kernel/cmake/CPM.cmake
+++ b/mllm-kernel/cmake/CPM.cmake
@@ -1,29 +1,30 @@
 # SPDX-License-Identifier: MIT
-# Download CPM.cmake on-the-fly
-# This is a lightweight bootstrap that downloads the actual CPM.cmake
+# Prefer the vendored CPM.cmake from the parent mllm repo. This avoids relying
+# on network access for editable builds while keeping standalone fallback logic.
 
 set(CPM_VERSION 0.42.0)
 set(CPM_DOWNLOAD_LOCATION "${CMAKE_BINARY_DIR}/cmake/CPM_${CPM_VERSION}.cmake")
+set(PARENT_CPM "${CMAKE_CURRENT_LIST_DIR}/../../cmake/CPM.cmake")
 
-if(NOT EXISTS ${CPM_DOWNLOAD_LOCATION})
-  message(STATUS "Downloading CPM.cmake v${CPM_VERSION}...")
-  file(DOWNLOAD
-    https://github.com/cpm-cmake/CPM.cmake/releases/download/v${CPM_VERSION}/CPM.cmake
-    ${CPM_DOWNLOAD_LOCATION}
-    STATUS download_status
-  )
-  list(GET download_status 0 download_status_code)
-  if(NOT download_status_code EQUAL 0)
-    # Fallback: copy from parent mllm project if available
-    set(PARENT_CPM "${CMAKE_CURRENT_SOURCE_DIR}/../cmake/CPM.cmake")
-    if(EXISTS ${PARENT_CPM})
-      message(STATUS "Using CPM.cmake from parent project")
-      file(COPY ${PARENT_CPM} DESTINATION "${CMAKE_BINARY_DIR}/cmake/")
-      file(RENAME "${CMAKE_BINARY_DIR}/cmake/CPM.cmake" ${CPM_DOWNLOAD_LOCATION})
-    else()
+if(EXISTS "${PARENT_CPM}")
+  include("${PARENT_CPM}")
+else()
+  if(NOT EXISTS "${CPM_DOWNLOAD_LOCATION}")
+    message(STATUS "Downloading CPM.cmake v${CPM_VERSION}...")
+    file(DOWNLOAD
+      https://github.com/cpm-cmake/CPM.cmake/releases/download/v${CPM_VERSION}/CPM.cmake
+      "${CPM_DOWNLOAD_LOCATION}"
+      STATUS download_status
+    )
+    list(GET download_status 0 download_status_code)
+    if(NOT download_status_code EQUAL 0)
       message(FATAL_ERROR "Failed to download CPM.cmake")
     endif()
   endif()
+
+  include("${CPM_DOWNLOAD_LOCATION}")
 endif()
 
-include(${CPM_DOWNLOAD_LOCATION})
+if(NOT COMMAND CPMAddPackage)
+  message(FATAL_ERROR "CPM.cmake loaded, but CPMAddPackage is not available")
+endif()

--- a/mllm-kernel/include/mllm_kernel/scalar_type.hpp
+++ b/mllm-kernel/include/mllm_kernel/scalar_type.hpp
@@ -6,7 +6,7 @@
 #include <variant>
 #endif
 
-namespace host {
+namespace mllm_kernel::host {
 
 //
 //  ScalarType can represent a wide range of floating point and integer types,
@@ -257,4 +257,6 @@ static inline constexpr auto kFloat16 = kHalf;
 static inline constexpr auto kBFloat16 = kFE8M7;
 
 static inline constexpr auto kFloat16Id = kFloat16.id();
-}  // namespace host
+}  // namespace mllm_kernel::host
+
+namespace host = ::mllm_kernel::host;

--- a/mllm-kernel/mllm_kernel/cuda/csrc/gemm/marlin/marlin.cuh
+++ b/mllm-kernel/mllm_kernel/cuda/csrc/gemm/marlin/marlin.cuh
@@ -1,12 +1,9 @@
 #pragma once
 
 #include <mllm_kernel/utils.cuh>
+#include <mllm_kernel/scalar_type.hpp>
 
 #include <iostream>
-
-// Bridge the mllm_kernel::host namespace to the `host` namespace expected by
-// Marlin code (originally from sglang).
-namespace host = ::mllm_kernel::host;
 
 namespace device::marlin {
 // Marlin params

--- a/mllm-kernel/mllm_kernel/cuda/jit/__init__.py
+++ b/mllm-kernel/mllm_kernel/cuda/jit/__init__.py
@@ -2,11 +2,13 @@ from .add_constant import add_constant
 from .awq_marlin_repack import awq_marlin_repack
 from .gdn_decode import gdn_decode
 from .gptq_marlin import gptq_marlin_gemm
+from .gptq_marlin_repack import gptq_marlin_repack
 from .store_cache import can_use_store_cache, store_cache
 
 __all__ = [
     "add_constant",
     "awq_marlin_repack",
+    "gptq_marlin_repack",
     "can_use_store_cache",
     "gdn_decode",
     "gptq_marlin_gemm",

--- a/mllm-kernel/mllm_kernel/cuda/jit/gptq_marlin.py
+++ b/mllm-kernel/mllm_kernel/cuda/jit/gptq_marlin.py
@@ -29,13 +29,14 @@ _MAX_THREAD_N = 256
 @cache_once
 def _make_gptq_marlin_gemm_kernel(dtype: torch.dtype):
     """JIT-compile the GPTQ Marlin GEMM kernel for a specific dtype."""
-    args = make_cpp_args(dtype)
+    cpp_args = make_cpp_args(dtype)
 
     @jit(
-        args=args,
+        args=[dtype],
         device="cuda",
         cuda_files=["gemm/marlin/gptq_marlin.cuh"],
-        cuda_wrappers=[("gptq_marlin_gemm", f"gptq_marlin_gemm<{args}>")],
+        cpp_wrappers=[],
+        cuda_wrappers=[("gptq_marlin_gemm", f"gptq_marlin_gemm<{cpp_args}>")],
         func_name="gptq_marlin_gemm",
     )
     def _kernel(

--- a/mllm-kernel/mllm_kernel/cuda/jit/gptq_marlin_repack.py
+++ b/mllm-kernel/mllm_kernel/cuda/jit/gptq_marlin_repack.py
@@ -1,0 +1,75 @@
+"""GPTQ/Compressed-Tensors Marlin repack CUDA JIT kernel."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+
+from mllm_kernel.jit_utils import cache_once, jit
+
+
+def _normalize_perm(
+    perm: Optional[torch.Tensor], size_k: int, device: torch.device
+) -> torch.Tensor:
+    if perm is None or perm.numel() == 0:
+        return torch.empty(0, dtype=torch.int32, device=device)
+    if perm.device != device:
+        raise ValueError("perm must live on the same device as b_q_weight")
+    if perm.dtype != torch.int32:
+        raise ValueError("perm must be int32")
+    if perm.numel() != size_k:
+        raise ValueError("perm length must equal size_k")
+    if torch.any(perm < 0) or torch.any(perm >= size_k):
+        raise ValueError("perm values must be in [0, size_k)")
+    return perm.contiguous()
+
+
+@cache_once
+def _make_gptq_marlin_repack_kernel():
+    """JIT-compile the GPTQ repack kernel."""
+
+    @jit(
+        args=[],
+        device="cuda",
+        cuda_files=["gemm/marlin/gptq_marlin_repack.cuh"],
+        cpp_wrappers=[],
+        cuda_wrappers=[("gptq_marlin_repack", "gptq_marlin_repack")],
+        func_name="gptq_marlin_repack",
+    )
+    def _kernel(
+        compiled_module,
+        b_q_weight: torch.Tensor,
+        perm: torch.Tensor,
+        out: torch.Tensor,
+        size_k: int,
+        size_n: int,
+        num_bits: int,
+    ) -> None:
+        compiled_module.gptq_marlin_repack(
+            b_q_weight, perm, out, size_k, size_n, num_bits
+        )
+
+    return _kernel
+
+
+def gptq_marlin_repack(
+    b_q_weight: torch.Tensor,
+    perm: Optional[torch.Tensor],
+    size_k: int,
+    size_n: int,
+    num_bits: int,
+) -> torch.Tensor:
+    """Repack GPTQ/Compressed-Tensors weights into Marlin layout."""
+
+    pack_factor = 32 // num_bits
+    tile_size = 16
+    out = torch.empty(
+        (size_k // tile_size, size_n * tile_size // pack_factor),
+        dtype=b_q_weight.dtype,
+        device=b_q_weight.device,
+    )
+    kernel = _make_gptq_marlin_repack_kernel()
+    perm_t = _normalize_perm(perm, size_k, b_q_weight.device)
+    kernel(b_q_weight, perm_t, out, size_k, size_n, num_bits)
+    return out

--- a/mllm-kernel/tests/test_gptq_marlin.py
+++ b/mllm-kernel/tests/test_gptq_marlin.py
@@ -1,0 +1,151 @@
+import pytest
+import torch
+import torch.nn.functional as F
+
+from mllm_kernel.cuda.jit import gptq_marlin_gemm, gptq_marlin_repack
+
+
+CUDA_ONLY = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="requires CUDA"
+)
+
+
+def _compute_scalar_type_id(
+    exponent: int,
+    mantissa: int,
+    signed: bool,
+    bias: int,
+    finite_values_only: bool = False,
+    nan_repr: int = 1,
+) -> int:
+    bit_offset = 0
+    result = 0
+    for value, width in [
+        (exponent, 8),
+        (mantissa, 8),
+        (signed, 1),
+        (bias, 32),
+        (finite_values_only, 1),
+        (nan_repr, 8),
+    ]:
+        result |= (int(value) & ((1 << width) - 1)) << bit_offset
+        bit_offset += width
+    return result
+
+
+SCALAR_TYPE_UINT4B8_ID = _compute_scalar_type_id(0, 4, False, 8)
+
+
+def _pack_checkpoint_weight(q_weight: torch.Tensor, num_bits: int) -> torch.Tensor:
+    pack_factor = 32 // num_bits
+    size_n, size_k = q_weight.shape
+    packed = torch.zeros(
+        (size_n, size_k // pack_factor),
+        dtype=torch.int32,
+        device=q_weight.device,
+    )
+    for i in range(pack_factor):
+        packed.bitwise_or_(q_weight[:, i::pack_factor].int() << (num_bits * i))
+    return packed
+
+
+def _get_scale_perms() -> tuple[list[int], list[int]]:
+    scale_perm: list[int] = []
+    for i in range(8):
+        scale_perm.extend([i + 8 * j for j in range(8)])
+    scale_perm_single: list[int] = []
+    for i in range(4):
+        scale_perm_single.extend(
+            [2 * i + j for j in [0, 1, 8, 9, 16, 17, 24, 25]]
+        )
+    return scale_perm, scale_perm_single
+
+
+def _marlin_permute_scales(
+    s: torch.Tensor, size_k: int, size_n: int, group_size: int
+) -> torch.Tensor:
+    scale_perm, scale_perm_single = _get_scale_perms()
+    if group_size < size_k and group_size != -1:
+        s = s.reshape((-1, len(scale_perm)))[:, scale_perm]
+    else:
+        s = s.reshape((-1, len(scale_perm_single)))[:, scale_perm_single]
+    return s.reshape((-1, size_n)).contiguous()
+
+
+def _marlin_make_workspace(device: torch.device) -> torch.Tensor:
+    sms = torch.cuda.get_device_properties(device).multi_processor_count
+    return torch.zeros(sms, dtype=torch.int, device=device, requires_grad=False)
+
+
+@CUDA_ONLY
+def test_gptq_marlin_gemm_matches_reference_for_uint4b8() -> None:
+    torch.manual_seed(2026)
+    device = torch.device("cuda")
+    size_m = 13
+    size_n = 64
+    size_k = 128
+    group_size = 32
+    num_bits = 4
+
+    q_weight = torch.randint(
+        0,
+        1 << num_bits,
+        (size_n, size_k),
+        dtype=torch.int32,
+        device=device,
+    )
+    scales = (
+        torch.rand(
+            (size_n, size_k // group_size),
+            dtype=torch.float16,
+            device=device,
+        )
+        + 0.5
+    )
+    packed = _pack_checkpoint_weight(q_weight, num_bits=num_bits)
+    empty = torch.empty(0, dtype=torch.int32, device=device)
+    marlin_q = gptq_marlin_repack(
+        packed.t().contiguous(),
+        perm=empty,
+        size_k=size_k,
+        size_n=size_n,
+        num_bits=num_bits,
+    )
+    marlin_s = _marlin_permute_scales(
+        scales.t().contiguous(),
+        size_k=size_k,
+        size_n=size_n,
+        group_size=group_size,
+    )
+    x = torch.randn((size_m, size_k), dtype=torch.float16, device=device)
+    workspace = _marlin_make_workspace(device)
+
+    out = gptq_marlin_gemm(
+        a=x,
+        c=None,
+        b_q_weight=marlin_q,
+        b_scales=marlin_s,
+        global_scale=None,
+        b_zeros=empty,
+        g_idx=empty,
+        perm=empty,
+        workspace=workspace,
+        b_q_type_id=SCALAR_TYPE_UINT4B8_ID,
+        size_m=size_m,
+        size_n=size_n,
+        size_k=size_k,
+        is_k_full=True,
+        use_atomic_add=False,
+        use_fp32_reduce=False,
+        is_zp_float=False,
+    )
+
+    ref_weight = (q_weight.to(torch.float16) - 8) * scales.repeat_interleave(
+        group_size, dim=1
+    )
+    ref_out = F.linear(x, ref_weight)
+    rel_mean_err = torch.mean(torch.abs(out - ref_out)) / torch.mean(
+        torch.abs(ref_out)
+    )
+
+    assert rel_mean_err < 0.04

--- a/mllm-kernel/tests/test_gptq_marlin_repack.py
+++ b/mllm-kernel/tests/test_gptq_marlin_repack.py
@@ -1,0 +1,305 @@
+import pytest
+import torch
+
+from mllm_kernel.cuda.jit import gptq_marlin_repack
+
+
+CUDA_ONLY = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="requires CUDA"
+)
+
+
+def _pack_rows(q_weight: torch.Tensor, num_bits: int) -> torch.Tensor:
+    pack_factor = 32 // num_bits
+    size_k, size_n = q_weight.shape
+    packed = torch.zeros(
+        (size_k // pack_factor, size_n),
+        dtype=torch.int32,
+        device=q_weight.device,
+    )
+    for i in range(pack_factor):
+        packed.bitwise_or_(q_weight[i::pack_factor].int() << (num_bits * i))
+    return packed
+
+
+def _reference_gptq_marlin_repack_cpu(
+    b_q_weight: torch.Tensor,
+    perm: torch.Tensor,
+    size_k: int,
+    size_n: int,
+    num_bits: int,
+) -> torch.Tensor:
+    pack_factor = 32 // num_bits
+    mask = (1 << num_bits) - 1
+    q_weight = torch.empty((size_k, size_n), dtype=torch.int32)
+    for i in range(pack_factor):
+        q_weight[i::pack_factor] = (
+            (b_q_weight >> (num_bits * i)) & mask
+        )[0 : q_weight[i::pack_factor].shape[0]]
+
+    if perm.numel() == 0:
+        perm = torch.arange(size_k, dtype=torch.int32)
+
+    out = torch.empty(
+        (size_k // 16, size_n * 16 // pack_factor),
+        dtype=torch.int32,
+    )
+    n_tiles = size_n // 64
+    tc_offsets = [0, 1, 8, 9]
+    pack_idx = [0, 2, 4, 6, 1, 3, 5, 7]
+    tile_size = 16 * 64 // pack_factor
+
+    for k_tile in range(size_k // 16):
+        for n_tile in range(n_tiles):
+            tile = torch.empty((16, 64), dtype=torch.int32)
+            for local_k in range(16):
+                src_k = int(perm[k_tile * 16 + local_k].item())
+                tile[local_k] = q_weight[src_k, n_tile * 64 : (n_tile + 1) * 64]
+
+            flat = torch.empty(tile_size, dtype=torch.int32)
+            for warp_id in range(4):
+                for th_id in range(32):
+                    tc_col = th_id // 4
+                    tc_row = (th_id % 4) * 2
+                    cur_n = warp_id * 16 + tc_col
+
+                    vals = [int(tile[tc_row + off, cur_n].item()) for off in tc_offsets]
+                    vals.extend(
+                        int(tile[tc_row + off, cur_n + 8].item())
+                        for off in tc_offsets
+                    )
+
+                    res = 0
+                    for i, src_idx in enumerate(pack_idx):
+                        res |= vals[src_idx] << (i * num_bits)
+                    if res >= 1 << 31:
+                        res -= 1 << 32
+                    flat[th_id * 4 + warp_id] = res
+
+            out[k_tile, n_tile * tile_size : (n_tile + 1) * tile_size] = flat
+
+    return out
+
+
+@CUDA_ONLY
+@pytest.mark.parametrize(
+    ("size_k", "size_n", "num_bits"),
+    [(128, 64, 4), (256, 128, 4)],
+)
+def test_gptq_marlin_repack_outputs_shape(size_k: int, size_n: int, num_bits: int) -> None:
+    pack_factor = 32 // num_bits
+    b_q_weight = torch.empty(
+        (size_k // pack_factor, size_n),
+        dtype=torch.int32,
+        device="cuda",
+    )
+    perm = torch.empty(0, dtype=torch.int32, device="cuda")
+
+    out = gptq_marlin_repack(
+        b_q_weight,
+        perm,
+        size_k=size_k,
+        size_n=size_n,
+        num_bits=num_bits,
+    )
+
+    assert out.dtype == torch.int32
+    assert out.shape == (size_k // 16, size_n * 16 // pack_factor)
+
+
+@CUDA_ONLY
+@pytest.mark.parametrize(
+    ("size_k", "size_n", "num_bits"),
+    [(128, 64, 4), (256, 128, 4)],
+)
+def test_gptq_marlin_repack_accepts_explicit_perm(
+    size_k: int,
+    size_n: int,
+    num_bits: int,
+) -> None:
+    pack_factor = 32 // num_bits
+    b_q_weight = torch.empty(
+        (size_k // pack_factor, size_n),
+        dtype=torch.int32,
+        device="cuda",
+    )
+    perm = torch.arange(size_k, dtype=torch.int32, device="cuda")
+
+    out1 = gptq_marlin_repack(
+        b_q_weight,
+        perm,
+        size_k=size_k,
+        size_n=size_n,
+        num_bits=num_bits,
+    )
+    out2 = gptq_marlin_repack(
+        b_q_weight,
+        perm,
+        size_k=size_k,
+        size_n=size_n,
+        num_bits=num_bits,
+    )
+
+    assert torch.equal(out1, out2)
+
+
+@CUDA_ONLY
+@pytest.mark.parametrize(
+    ("size_k", "size_n", "num_bits"),
+    [(128, 64, 4), (256, 128, 4)],
+)
+def test_gptq_marlin_repack_identity_perm_matches_empty_perm(
+    size_k: int,
+    size_n: int,
+    num_bits: int,
+) -> None:
+    pack_factor = 32 // num_bits
+    b_q_weight = torch.empty(
+        (size_k // pack_factor, size_n),
+        dtype=torch.int32,
+        device="cuda",
+    )
+    empty_perm = torch.empty(0, dtype=torch.int32, device="cuda")
+    perm = torch.arange(size_k, dtype=torch.int32, device="cuda")
+
+    baseline = gptq_marlin_repack(
+        b_q_weight,
+        empty_perm,
+        size_k=size_k,
+        size_n=size_n,
+        num_bits=num_bits,
+    )
+    with_perm = gptq_marlin_repack(
+        b_q_weight,
+        perm,
+        size_k=size_k,
+        size_n=size_n,
+        num_bits=num_bits,
+    )
+
+    assert torch.equal(baseline, with_perm)
+
+
+@CUDA_ONLY
+def test_gptq_marlin_repack_non_identity_perm_matches_reference() -> None:
+    size_k, size_n, num_bits = 128, 64, 4
+    torch.manual_seed(2026)
+    q_weight = torch.randint(
+        0,
+        1 << num_bits,
+        (size_k, size_n),
+        dtype=torch.int32,
+    )
+    b_q_weight_cpu = _pack_rows(q_weight, num_bits)
+    perm_cpu = torch.roll(torch.arange(size_k, dtype=torch.int32), 1)
+
+    out = gptq_marlin_repack(
+        b_q_weight_cpu.to(device="cuda"),
+        perm_cpu.to(device="cuda"),
+        size_k=size_k,
+        size_n=size_n,
+        num_bits=num_bits,
+    )
+    ref = _reference_gptq_marlin_repack_cpu(
+        b_q_weight_cpu,
+        perm_cpu,
+        size_k=size_k,
+        size_n=size_n,
+        num_bits=num_bits,
+    )
+
+    assert torch.equal(out.cpu(), ref)
+
+
+@CUDA_ONLY
+@pytest.mark.parametrize(
+    ("size_k", "size_n", "num_bits"),
+    [(128, 64, 4), (256, 128, 4)],
+)
+def test_gptq_marlin_repack_handles_noncontiguous_perm(
+    size_k: int,
+    size_n: int,
+    num_bits: int,
+) -> None:
+    pack_factor = 32 // num_bits
+    b_q_weight = torch.empty(
+        (size_k // pack_factor, size_n),
+        dtype=torch.int32,
+        device="cuda",
+    )
+
+    buffer = torch.empty(
+        size_k * 2,
+        dtype=torch.int32,
+        device="cuda",
+    )
+    indices = torch.arange(size_k, dtype=torch.int32, device="cuda")
+    buffer[::2] = indices
+    buffer[1::2] = indices
+    perm = buffer.as_strided((size_k,), (2,))
+    assert not perm.is_contiguous()
+
+    perm_contig = perm.contiguous()
+
+    out_noncontig = gptq_marlin_repack(
+        b_q_weight,
+        perm,
+        size_k=size_k,
+        size_n=size_n,
+        num_bits=num_bits,
+    )
+    out_contig = gptq_marlin_repack(
+        b_q_weight,
+        perm_contig,
+        size_k=size_k,
+        size_n=size_n,
+        num_bits=num_bits,
+    )
+
+    assert torch.equal(out_noncontig, out_contig)
+
+
+@CUDA_ONLY
+@pytest.mark.parametrize(
+    ("size_k", "size_n", "num_bits"),
+    [(128, 64, 4), (256, 128, 4)],
+)
+@pytest.mark.parametrize(
+    "perm_factory",
+    [
+        lambda size_k: torch.arange(size_k, dtype=torch.int32, device="cpu"),
+        lambda size_k: torch.arange(size_k, dtype=torch.int64, device="cuda"),
+        lambda size_k: torch.arange(size_k - 16, dtype=torch.int32, device="cuda"),
+        lambda size_k: torch.full((size_k,), size_k, dtype=torch.int32, device="cuda"),
+        lambda size_k: torch.full((size_k,), -1, dtype=torch.int32, device="cuda"),
+    ],
+    ids=[
+        "device-mismatch",
+        "dtype-mismatch",
+        "length-mismatch",
+        "out-of-range",
+        "negative-index",
+    ],
+)
+def test_gptq_marlin_repack_rejects_invalid_perm(
+    size_k: int,
+    size_n: int,
+    num_bits: int,
+    perm_factory,
+) -> None:
+    pack_factor = 32 // num_bits
+    b_q_weight = torch.empty(
+        (size_k // pack_factor, size_n),
+        dtype=torch.int32,
+        device="cuda",
+    )
+    perm = perm_factory(size_k)
+
+    with pytest.raises(ValueError):
+        gptq_marlin_repack(
+            b_q_weight,
+            perm,
+            size_k=size_k,
+            size_n=size_n,
+            num_bits=num_bits,
+        )

--- a/pymllm/README-ZH.md
+++ b/pymllm/README-ZH.md
@@ -2,18 +2,20 @@
 
 ![pymllm-arch](../assets/pymllm-arch.png)
 
-## 环境配置 ToDo
+## 已验证环境
 
-以下内容暂时留白，留给另一位同学按当前 Jetson Orin 实际环境补充：
+本文档中的命令基于 Jetson Orin 上已验证通过的如下环境整理：
 
-- [ ] JetPack / L4T 版本
-- [ ] CUDA / cuDNN / TensorRT 版本
-- [ ] Python / pip / venv 或 conda 环境信息
-- [ ] PyTorch / torchvision / transformers / safetensors 版本
-- [ ] flashinfer 版本与安装方式
-- [ ] 其他系统依赖与 apt 包
-- [ ] 显存与内存相关建议配置
-- [ ] 需要的环境变量
+- JetPack / L4T：`R36.4.4`（来自 `/etc/nv_tegra_release`）
+- Python：`3.10.12`
+- pip：`26.0.1`
+- PyTorch：`2.4.0`
+- torchvision：`0.19.0a0+48b1edf`
+- transformers：`5.3.0`
+- safetensors：`0.7.0`
+- flashinfer：`0.6.7`
+- CUDA：`12.6`
+- `torch.cuda.is_available()`：`True`
 
 ## 适用范围
 

--- a/pymllm/README-ZH.md
+++ b/pymllm/README-ZH.md
@@ -2,33 +2,31 @@
 
 ![pymllm-arch](../assets/pymllm-arch.png)
 
-## Environment TODO
+## 环境配置 ToDo
 
-The items below are intentionally left blank for a teammate to fill in for the
-current Jetson Orin environment:
+以下内容暂时留白，留给另一位同学按当前 Jetson Orin 实际环境补充：
 
-- [ ] JetPack / L4T version
-- [ ] CUDA / cuDNN / TensorRT versions
-- [ ] Python / pip / venv or conda environment details
-- [ ] PyTorch / torchvision / transformers / safetensors versions
-- [ ] flashinfer version and installation method
-- [ ] Extra system dependencies and apt packages
-- [ ] Memory and VRAM tuning notes
-- [ ] Required environment variables
+- [ ] JetPack / L4T 版本
+- [ ] CUDA / cuDNN / TensorRT 版本
+- [ ] Python / pip / venv 或 conda 环境信息
+- [ ] PyTorch / torchvision / transformers / safetensors 版本
+- [ ] flashinfer 版本与安装方式
+- [ ] 其他系统依赖与 apt 包
+- [ ] 显存与内存相关建议配置
+- [ ] 需要的环境变量
 
-## Scope
+## 适用范围
 
-This document covers `pymllm` usage on Jetson Orin based on the workflows
-validated in this repository.
+本文档面向 Jetson Orin 上的 `pymllm` 使用，内容基于当前仓库内已验证流程整理。
 
-The current validated paths are:
+当前只覆盖两条已验证路径：
 
-- Base model: `Qwen3-VL-2B-Instruct`
-- Quantized model: `Qwen3-VL-2B-Instruct-AWQ-4bit` with `compressed-tensors`
+- 原生模型：`Qwen3-VL-2B-Instruct`
+- 量化模型：`Qwen3-VL-2B-Instruct-AWQ-4bit` + `compressed-tensors`
 
-## Install the editable development environment
+## 安装 editable 开发环境
 
-Run the following from the repository root:
+在仓库根目录执行：
 
 ```bash
 cd <repo-root>
@@ -36,7 +34,7 @@ SKBUILD_WHEEL_CMAKE=false python3 -m pip install -e .
 python3 -m pip install -e <repo-root>/mllm-kernel --no-deps --no-build-isolation
 ```
 
-After installation, run a minimal import check:
+安装完成后，可以用下面的命令做最小检查：
 
 ```bash
 python3 - <<'PY'
@@ -48,11 +46,11 @@ print("mllm_kernel import ok")
 PY
 ```
 
-## Launch the pymllm server
+## 启动 pymllm server
 
-### Launch the quantized model
+### 启动量化模型服务
 
-The following `compressed-tensors` command has been validated on Jetson Orin:
+当前 Jetson Orin 上已验证的 `compressed-tensors` 启动命令如下：
 
 ```bash
 python3 -m pymllm.server.launch \
@@ -76,15 +74,14 @@ python3 -m pymllm.server.launch \
   2>&1 | tee /tmp/pymllm_qwen3_vl_awq_ct.log
 ```
 
-Notes:
+说明：
 
-- If port `30000` is already in use, switch to another free port such as
-  `30001`.
-- This validated quantized path uses `float16`.
+- 若 `30000` 已被占用，可改成其他空闲端口，例如 `30001`。
+- 当前这条量化路径按已验证配置使用 `float16`。
 
-### Launch the base model
+### 启动原生模型服务
 
-To run the base `Qwen3-VL-2B-Instruct` model:
+如果要运行原生 `Qwen3-VL-2B-Instruct`，可使用：
 
 ```bash
 python3 -m pymllm.server.launch \
@@ -107,34 +104,33 @@ python3 -m pymllm.server.launch \
   2>&1 | tee /tmp/pymllm_server.log
 ```
 
-## Request examples
+## 调用示例
 
-The examples below use the OpenAI-compatible API and work with `curl` or any
-SGLang/OpenAI-compatible client:
+以下示例使用 OpenAI-compatible 接口，适合直接用 `curl` 或兼容 SGLang/OpenAI API 的客户端访问：
 
 ```text
 /v1/chat/completions
 ```
 
-### Text inference
+### 文本推理示例
 
-Use the following minimal text request as a smoke test:
+服务启动后，可以用下面的最小文本请求做 smoke test：
 
 ```bash
 curl -s --noproxy '*' http://127.0.0.1:30000/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
     "model": "<served-model-name-or-path>",
-    "messages": [{"role": "user", "content": "Reply with: ok"}],
+    "messages": [{"role": "user", "content": "你好，只回复：ok"}],
     "max_tokens": 8,
     "temperature": 0.0,
     "stream": false
   }' ; echo
 ```
 
-### Image inference
+### 图片推理示例
 
-First, prepare a request payload that references a local image path:
+先构造一个包含本地图片路径的请求：
 
 ```bash
 python3 - <<'PY'
@@ -146,7 +142,7 @@ payload = {
         {
             "role": "user",
             "content": [
-                {"type": "text", "text": "Please describe this image in detail."},
+                {"type": "text", "text": "请详细描述这张图片。"},
                 {
                     "type": "image_url",
                     "image_url": {"url": "<image-path>"},
@@ -166,7 +162,7 @@ print("saved /tmp/mm_req_path.json")
 PY
 ```
 
-Then send the request:
+然后发送请求：
 
 ```bash
 curl -s --noproxy '*' \
@@ -175,15 +171,13 @@ curl -s --noproxy '*' \
   --data @/tmp/mm_req_path.json ; echo
 ```
 
-## Validated configuration
+## 当前已验证配置
 
-The validated quantized setup described in this document uses:
+当前文档对应的量化路径，已验证的是下面这组模型与配置：
 
-- Model family: `Qwen3-VL-2B-Instruct-AWQ-4bit`
-- Quantization method: `compressed-tensors`
-- Load format: `safetensors`
-- Dtype: `float16`
+- 模型类型：`Qwen3-VL-2B-Instruct-AWQ-4bit`
+- quantization method：`compressed-tensors`
+- load format：`safetensors`
+- dtype：`float16`
 
-If this repository later adds validated instructions for other models,
-precisions, or quantization variants, extend this README with the new commands
-and notes.
+如果后续扩展到其他模型、精度或量化变体，建议继续补充新的实测命令与说明。

--- a/pymllm/README.md
+++ b/pymllm/README.md
@@ -2,19 +2,21 @@
 
 ![pymllm-arch](../assets/pymllm-arch.png)
 
-## Environment TODO
+## Validated environment
 
-The items below are intentionally left blank for a teammate to fill in for the
-current Jetson Orin environment:
+The commands in this document were validated on Jetson Orin with the following
+environment baseline:
 
-- [ ] JetPack / L4T version
-- [ ] CUDA / cuDNN / TensorRT versions
-- [ ] Python / pip / venv or conda environment details
-- [ ] PyTorch / torchvision / transformers / safetensors versions
-- [ ] flashinfer version and installation method
-- [ ] Extra system dependencies and apt packages
-- [ ] Memory and VRAM tuning notes
-- [ ] Required environment variables
+- JetPack / L4T: `R36.4.4` (`/etc/nv_tegra_release`)
+- Python: `3.10.12`
+- pip: `26.0.1`
+- PyTorch: `2.4.0`
+- torchvision: `0.19.0a0+48b1edf`
+- transformers: `5.3.0`
+- safetensors: `0.7.0`
+- flashinfer: `0.6.7`
+- CUDA: `12.6`
+- `torch.cuda.is_available()`: `True`
 
 ## Scope
 

--- a/pymllm/executor/model_runner.py
+++ b/pymllm/executor/model_runner.py
@@ -487,7 +487,12 @@ class ModelRunner:
             fpath = model_path / fname
             if fpath.exists():
                 with open(fpath) as fp:
-                    return json.load(fp)
+                    cfg = json.load(fp)
+                # config.json stores model metadata at the top level and
+                # nests quantization details under quantization_config.
+                if fname == "config.json" and "quantization_config" in cfg:
+                    return cfg["quantization_config"]
+                return cfg
 
         # Fallback: config.json → quantization_config section
         config_path = model_path / "config.json"

--- a/pymllm/layers/rms_norm.py
+++ b/pymllm/layers/rms_norm.py
@@ -10,6 +10,17 @@ from pymllm.layers.base import MllmBaseLayer
 from pymllm.layers.utils import set_weight_attrs
 
 
+def _torch_rmsnorm(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+) -> torch.Tensor:
+    x_fp32 = x.float()
+    var = x_fp32.pow(2).mean(dim=-1, keepdim=True)
+    x_norm = x_fp32 * torch.rsqrt(var + eps)
+    return x_norm.to(dtype=x.dtype) * weight
+
+
 class RMSNorm(MllmBaseLayer):
     """RMSNorm layer implemented with FlashInfer kernel."""
 
@@ -26,24 +37,33 @@ class RMSNorm(MllmBaseLayer):
         x: torch.Tensor,
         residual: Optional[torch.Tensor] = None,
     ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
-        if residual is not None:
-            flashinfer.norm.fused_add_rmsnorm(x, residual, self.weight.data, self.eps)
-            return x, residual
-
         if x.shape[-1] != self.hidden_size:
             raise ValueError(
                 f"Expected last dim == hidden_size ({self.hidden_size}), "
                 f"but got input shape {tuple(x.shape)}"
             )
 
-        # FlashInfer rmsnorm accepts 2D/3D input; flatten higher-rank tensors to 2D.
-        if x.dim() in (2, 3):
-            return flashinfer.norm.rmsnorm(x, self.weight, self.eps)
+        if residual is not None:
+            try:
+                flashinfer.norm.fused_add_rmsnorm(
+                    x, residual, self.weight.data, self.eps
+                )
+                return x, residual
+            except Exception:
+                x = x + residual
+                return _torch_rmsnorm(x, self.weight, self.eps), residual
 
-        original_shape = x.shape
-        x_2d = x.reshape(-1, self.hidden_size)
-        out = flashinfer.norm.rmsnorm(x_2d, self.weight, self.eps)
-        return out.reshape(original_shape)
+        try:
+            # FlashInfer rmsnorm accepts 2D/3D input; flatten higher-rank tensors to 2D.
+            if x.dim() in (2, 3):
+                return flashinfer.norm.rmsnorm(x, self.weight, self.eps)
+
+            original_shape = x.shape
+            x_2d = x.reshape(-1, self.hidden_size)
+            out = flashinfer.norm.rmsnorm(x_2d, self.weight, self.eps)
+            return out.reshape(original_shape)
+        except Exception:
+            return _torch_rmsnorm(x, self.weight, self.eps)
 
 
 class GemmaRMSNorm(MllmBaseLayer):

--- a/pymllm/models/qwen3_vl.py
+++ b/pymllm/models/qwen3_vl.py
@@ -1012,11 +1012,7 @@ class Qwen3VLForConditionalGeneration(nn.Module):
 
         text_config = getattr(config, "text_config", config)
         vision_config = getattr(config, "vision_config", None)
-        logger.warning("INIT DEBUG: enter Qwen3VLForConditionalGeneration.__init__")
-        logger.warning("INIT DEBUG: text_config=%s vision_config_is_none=%s", type(text_config).__name__, vision_config is None)
-
         # Vision encoder — NOT quantized
-        logger.warning("INIT DEBUG: before build visual")
         if vision_config is not None:
             self.visual = Qwen3VLVisionModel(
                 depth=getattr(vision_config, "depth", 27),
@@ -1039,7 +1035,6 @@ class Qwen3VLForConditionalGeneration(nn.Module):
             )
         else:
             self.visual = None
-        logger.warning("INIT DEBUG: after build visual visual_is_none=%s", self.visual is None)
 
         # Text decoder
         hidden_size = getattr(text_config, "hidden_size", 4096)
@@ -1056,7 +1051,6 @@ class Qwen3VLForConditionalGeneration(nn.Module):
             mrope_interleaved = getattr(rope_scaling, "mrope_interleaved", True)
         max_position_embeddings = getattr(text_config, "max_position_embeddings", 32768)
 
-        logger.warning("INIT DEBUG: before build text model")
         self.model = Qwen3VLTextModel(
             vocab_size=vocab_size,
             hidden_size=hidden_size,
@@ -1072,8 +1066,6 @@ class Qwen3VLForConditionalGeneration(nn.Module):
             max_position_embeddings=max_position_embeddings,
             quant_config=quant_config,
         )
-        logger.warning("INIT DEBUG: after build text model")
-
         # LM head — following sglang's pattern: always use lm_head.weight
         # for matmul in forward(), so it works whether lm_head is nn.Embedding
         # (tied) or nn.Linear (untied).
@@ -1103,7 +1095,6 @@ class Qwen3VLForConditionalGeneration(nn.Module):
             self.num_deepstack_embeddings = 0
 
         self._hidden_size = hidden_size
-        logger.warning("INIT DEBUG: __init__ finished")
 
     def get_input_embeddings(self) -> nn.Module:
         return self.model.embed_tokens
@@ -1181,8 +1172,6 @@ class Qwen3VLForConditionalGeneration(nn.Module):
 
         input_embeds = None
         input_deepstack_embeds = None
-        vit_prefill_ms = 0.0
-        llm_prefill_ms = 0.0
 
         if (
             pixel_values is not None
@@ -1206,20 +1195,7 @@ class Qwen3VLForConditionalGeneration(nn.Module):
             # Get text embeddings and replace image tokens with vision features
             input_embeds = self.model.embed_tokens(input_ids)
             image_mask = input_ids == self.image_token_id
-            logger.warning(
-                "VISION DEBUG: pixel_values=%s image_grid_thw=%s vision_features=%s image_token_id=%s image_mask_sum=%s input_ids_head=%s",
-                None if pixel_values is None else tuple(pixel_values.shape),
-                None if image_grid_thw is None else image_grid_thw.tolist(),
-                tuple(vision_features.shape),
-                self.image_token_id,
-                int(image_mask.sum().item()),
-                input_ids[:40].tolist(),
-            )
             forward_batch.vit_prefill_ms = float(vit_prefill_ms)
-            logger.warning(
-                "TIMING DEBUG: vit_prefill_ms=%.3f",
-                vit_prefill_ms,
-            )
             if image_mask.any():
                 input_embeds[image_mask] = vision_embeds.to(input_embeds.dtype)
 
@@ -1248,16 +1224,8 @@ class Qwen3VLForConditionalGeneration(nn.Module):
 
         if forward_batch.forward_mode.is_extend():
             forward_batch.llm_prefill_ms = float(llm_ms)
-            logger.warning(
-                "TIMING DEBUG: llm_prefill_ms=%.3f",
-                llm_ms,
-            )
         else:
             forward_batch.llm_decode_ms = float(llm_ms)
-            logger.warning(
-                "TIMING DEBUG: llm_decode_ms=%.3f",
-                llm_ms,
-            )
 
         # Prune hidden_states before lm_head to avoid a wasteful
         # [total_tokens, vocab] matmul during prefill.
@@ -1296,7 +1264,6 @@ class Qwen3VLForConditionalGeneration(nn.Module):
         Handles weight name remapping between HuggingFace Qwen3-VL
         checkpoints and this model's parameter names.
         """
-        # logger.warning("LOAD DEBUG: enter load_weights")
         # When quantized, the model has separate q/k/v and gate/up projections
         # (no fused qkv_proj / gate_up_proj), so skip the stacking logic.
         if self.quant_config is not None:
@@ -1316,8 +1283,6 @@ class Qwen3VLForConditionalGeneration(nn.Module):
         tie_word_embeddings = getattr(self.config, "tie_word_embeddings", False)
 
         for name, loaded_weight in weights:
-            # logger.warning("LOAD DEBUG: weight=%s shape=%s", name, tuple(loaded_weight.shape))
-            # logger.warning("LOAD DEBUG: before remap raw_name=%s", name)
             if "rotary_emb.inv_freq" in name:
                 continue
 
@@ -1363,16 +1328,11 @@ class Qwen3VLForConditionalGeneration(nn.Module):
             # Direct parameter loading
             if name in params_dict:
                 param = params_dict[name]
-                # logger.warning("LOAD DEBUG: resolved_name=%s param_shape=%s loaded_shape=%s", name, tuple(param.data.shape), tuple(loaded_weight.shape))
                 loader = getattr(param, "weight_loader", None)
                 if loader is not None:
-                    # logger.warning("LOAD DEBUG: before custom loader name=%s", name)
                     loader(param, loaded_weight)
-                    # logger.warning("LOAD DEBUG: after custom loader name=%s", name)
                 elif param.data.shape == loaded_weight.shape:
-                    # logger.warning("LOAD DEBUG: before copy_ name=%s", name)
                     param.data.copy_(loaded_weight)
-                    # logger.warning("LOAD DEBUG: after copy_ name=%s", name)
                 else:
                     logger.warning(
                         "Shape mismatch: param %s (%s) vs loaded (%s), skipping.",

--- a/pymllm/models/qwen3_vl.py
+++ b/pymllm/models/qwen3_vl.py
@@ -162,8 +162,8 @@ class Qwen3VisionAttention(nn.Module):
             cos = torch.cat([cos, cos], dim=-1)
             sin = torch.cat([sin, sin], dim=-1)
 
-        cos = cos.unsqueeze(1)  # [seq, 1, head_dim]
-        sin = sin.unsqueeze(1)  # [seq, 1, head_dim]
+        cos = cos.unsqueeze(1).to(dtype=q.dtype, device=q.device)  # [seq, 1, head_dim]
+        sin = sin.unsqueeze(1).to(dtype=q.dtype, device=q.device)  # [seq, 1, head_dim]
 
         q = q * cos + _rotate_half(q) * sin
         k = k * cos + _rotate_half(k) * sin
@@ -977,6 +977,22 @@ def _get_deepstack_embeds(
 # ---------------------------------------------------------------------------
 
 
+def _cuda_timed_run(fn):
+    if torch.cuda.is_available():
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        out = fn()
+        end.record()
+        torch.cuda.synchronize()
+        return out, float(start.elapsed_time(end))
+    else:
+        import time
+        t0 = time.perf_counter()
+        out = fn()
+        t1 = time.perf_counter()
+        return out, float((t1 - t0) * 1000.0)
+
 class Qwen3VLForConditionalGeneration(nn.Module):
     """Qwen3-VL multimodal model for conditional generation.
 
@@ -996,8 +1012,11 @@ class Qwen3VLForConditionalGeneration(nn.Module):
 
         text_config = getattr(config, "text_config", config)
         vision_config = getattr(config, "vision_config", None)
+        logger.warning("INIT DEBUG: enter Qwen3VLForConditionalGeneration.__init__")
+        logger.warning("INIT DEBUG: text_config=%s vision_config_is_none=%s", type(text_config).__name__, vision_config is None)
 
         # Vision encoder — NOT quantized
+        logger.warning("INIT DEBUG: before build visual")
         if vision_config is not None:
             self.visual = Qwen3VLVisionModel(
                 depth=getattr(vision_config, "depth", 27),
@@ -1020,6 +1039,7 @@ class Qwen3VLForConditionalGeneration(nn.Module):
             )
         else:
             self.visual = None
+        logger.warning("INIT DEBUG: after build visual visual_is_none=%s", self.visual is None)
 
         # Text decoder
         hidden_size = getattr(text_config, "hidden_size", 4096)
@@ -1036,6 +1056,7 @@ class Qwen3VLForConditionalGeneration(nn.Module):
             mrope_interleaved = getattr(rope_scaling, "mrope_interleaved", True)
         max_position_embeddings = getattr(text_config, "max_position_embeddings", 32768)
 
+        logger.warning("INIT DEBUG: before build text model")
         self.model = Qwen3VLTextModel(
             vocab_size=vocab_size,
             hidden_size=hidden_size,
@@ -1051,6 +1072,7 @@ class Qwen3VLForConditionalGeneration(nn.Module):
             max_position_embeddings=max_position_embeddings,
             quant_config=quant_config,
         )
+        logger.warning("INIT DEBUG: after build text model")
 
         # LM head — following sglang's pattern: always use lm_head.weight
         # for matmul in forward(), so it works whether lm_head is nn.Embedding
@@ -1081,6 +1103,7 @@ class Qwen3VLForConditionalGeneration(nn.Module):
             self.num_deepstack_embeddings = 0
 
         self._hidden_size = hidden_size
+        logger.warning("INIT DEBUG: __init__ finished")
 
     def get_input_embeddings(self) -> nn.Module:
         return self.model.embed_tokens
@@ -1158,6 +1181,8 @@ class Qwen3VLForConditionalGeneration(nn.Module):
 
         input_embeds = None
         input_deepstack_embeds = None
+        vit_prefill_ms = 0.0
+        llm_prefill_ms = 0.0
 
         if (
             pixel_values is not None
@@ -1166,7 +1191,9 @@ class Qwen3VLForConditionalGeneration(nn.Module):
             and not forward_batch.forward_mode.is_decode()
         ):
             # Run vision encoder
-            vision_features = self.visual(pixel_values, grid_thw=image_grid_thw)
+            vision_features, vit_prefill_ms = _cuda_timed_run(
+                lambda: self.visual(pixel_values, grid_thw=image_grid_thw)
+            )
 
             # Separate main embeddings and deepstack embeddings
             if self.num_deepstack_embeddings > 0:
@@ -1179,6 +1206,20 @@ class Qwen3VLForConditionalGeneration(nn.Module):
             # Get text embeddings and replace image tokens with vision features
             input_embeds = self.model.embed_tokens(input_ids)
             image_mask = input_ids == self.image_token_id
+            logger.warning(
+                "VISION DEBUG: pixel_values=%s image_grid_thw=%s vision_features=%s image_token_id=%s image_mask_sum=%s input_ids_head=%s",
+                None if pixel_values is None else tuple(pixel_values.shape),
+                None if image_grid_thw is None else image_grid_thw.tolist(),
+                tuple(vision_features.shape),
+                self.image_token_id,
+                int(image_mask.sum().item()),
+                input_ids[:40].tolist(),
+            )
+            forward_batch.vit_prefill_ms = float(vit_prefill_ms)
+            logger.warning(
+                "TIMING DEBUG: vit_prefill_ms=%.3f",
+                vit_prefill_ms,
+            )
             if image_mask.any():
                 input_embeds[image_mask] = vision_embeds.to(input_embeds.dtype)
 
@@ -1195,13 +1236,28 @@ class Qwen3VLForConditionalGeneration(nn.Module):
                 )
 
         # Text decoder
-        hidden_states = self.model(
-            input_ids,
-            positions,
-            forward_batch,
-            input_embeds=input_embeds,
-            input_deepstack_embeds=input_deepstack_embeds,
+        hidden_states, llm_ms = _cuda_timed_run(
+            lambda: self.model(
+                input_ids,
+                positions,
+                forward_batch,
+                input_embeds=input_embeds,
+                input_deepstack_embeds=input_deepstack_embeds,
+            )
         )
+
+        if forward_batch.forward_mode.is_extend():
+            forward_batch.llm_prefill_ms = float(llm_ms)
+            logger.warning(
+                "TIMING DEBUG: llm_prefill_ms=%.3f",
+                llm_ms,
+            )
+        else:
+            forward_batch.llm_decode_ms = float(llm_ms)
+            logger.warning(
+                "TIMING DEBUG: llm_decode_ms=%.3f",
+                llm_ms,
+            )
 
         # Prune hidden_states before lm_head to avoid a wasteful
         # [total_tokens, vocab] matmul during prefill.
@@ -1240,6 +1296,7 @@ class Qwen3VLForConditionalGeneration(nn.Module):
         Handles weight name remapping between HuggingFace Qwen3-VL
         checkpoints and this model's parameter names.
         """
+        # logger.warning("LOAD DEBUG: enter load_weights")
         # When quantized, the model has separate q/k/v and gate/up projections
         # (no fused qkv_proj / gate_up_proj), so skip the stacking logic.
         if self.quant_config is not None:
@@ -1259,6 +1316,8 @@ class Qwen3VLForConditionalGeneration(nn.Module):
         tie_word_embeddings = getattr(self.config, "tie_word_embeddings", False)
 
         for name, loaded_weight in weights:
+            # logger.warning("LOAD DEBUG: weight=%s shape=%s", name, tuple(loaded_weight.shape))
+            # logger.warning("LOAD DEBUG: before remap raw_name=%s", name)
             if "rotary_emb.inv_freq" in name:
                 continue
 
@@ -1304,11 +1363,16 @@ class Qwen3VLForConditionalGeneration(nn.Module):
             # Direct parameter loading
             if name in params_dict:
                 param = params_dict[name]
+                # logger.warning("LOAD DEBUG: resolved_name=%s param_shape=%s loaded_shape=%s", name, tuple(param.data.shape), tuple(loaded_weight.shape))
                 loader = getattr(param, "weight_loader", None)
                 if loader is not None:
+                    # logger.warning("LOAD DEBUG: before custom loader name=%s", name)
                     loader(param, loaded_weight)
+                    # logger.warning("LOAD DEBUG: after custom loader name=%s", name)
                 elif param.data.shape == loaded_weight.shape:
+                    # logger.warning("LOAD DEBUG: before copy_ name=%s", name)
                     param.data.copy_(loaded_weight)
+                    # logger.warning("LOAD DEBUG: after copy_ name=%s", name)
                 else:
                     logger.warning(
                         "Shape mismatch: param %s (%s) vs loaded (%s), skipping.",
@@ -1332,9 +1396,10 @@ def _remap_weight_name(name: str) -> str:
     elif name.startswith("model.visual."):
         name = name.replace("model.visual.", "visual.", 1)
 
-    # Vision attention QKV renaming (fused weights in checkpoint)
+    # Vision attention param renaming (checkpoint -> pymllm names)
     if "visual" in name:
         name = name.replace("attn.qkv.", "attn.qkv_proj.")
+        name = name.replace("attn.proj.", "attn.out_proj.")
 
     return name
 

--- a/pymllm/models/qwen3_vl.py
+++ b/pymllm/models/qwen3_vl.py
@@ -27,6 +27,7 @@ Designed for a single accelerator card — no tensor / pipeline parallelism.
 from __future__ import annotations
 
 import logging
+import time
 from typing import TYPE_CHECKING, Iterable, List, Optional, Tuple
 
 import numpy as np
@@ -977,22 +978,6 @@ def _get_deepstack_embeds(
 # ---------------------------------------------------------------------------
 
 
-def _cuda_timed_run(fn):
-    if torch.cuda.is_available():
-        start = torch.cuda.Event(enable_timing=True)
-        end = torch.cuda.Event(enable_timing=True)
-        start.record()
-        out = fn()
-        end.record()
-        torch.cuda.synchronize()
-        return out, float(start.elapsed_time(end))
-    else:
-        import time
-        t0 = time.perf_counter()
-        out = fn()
-        t1 = time.perf_counter()
-        return out, float((t1 - t0) * 1000.0)
-
 class Qwen3VLForConditionalGeneration(nn.Module):
     """Qwen3-VL multimodal model for conditional generation.
 
@@ -1172,6 +1157,10 @@ class Qwen3VLForConditionalGeneration(nn.Module):
 
         input_embeds = None
         input_deepstack_embeds = None
+        vit_prefill_ms = None
+        vit_prefill_tokens = None
+        llm_prefill_ms = None
+        llm_decode_ms = None
 
         if (
             pixel_values is not None
@@ -1180,9 +1169,11 @@ class Qwen3VLForConditionalGeneration(nn.Module):
             and not forward_batch.forward_mode.is_decode()
         ):
             # Run vision encoder
-            vision_features, vit_prefill_ms = _cuda_timed_run(
-                lambda: self.visual(pixel_values, grid_thw=image_grid_thw)
+            _vit_t0 = time.perf_counter()
+            vision_features = (
+                self.visual(pixel_values, grid_thw=image_grid_thw)
             )
+            vit_prefill_ms = (time.perf_counter() - _vit_t0) * 1000.0
 
             # Separate main embeddings and deepstack embeddings
             if self.num_deepstack_embeddings > 0:
@@ -1195,8 +1186,8 @@ class Qwen3VLForConditionalGeneration(nn.Module):
             # Get text embeddings and replace image tokens with vision features
             input_embeds = self.model.embed_tokens(input_ids)
             image_mask = input_ids == self.image_token_id
-            forward_batch.vit_prefill_ms = float(vit_prefill_ms)
             if image_mask.any():
+                vit_prefill_tokens = int(image_mask.sum().item())
                 input_embeds[image_mask] = vision_embeds.to(input_embeds.dtype)
 
             # Build per-token deepstack embeddings
@@ -1212,8 +1203,9 @@ class Qwen3VLForConditionalGeneration(nn.Module):
                 )
 
         # Text decoder
-        hidden_states, llm_ms = _cuda_timed_run(
-            lambda: self.model(
+        _llm_t0 = time.perf_counter()
+        hidden_states = (
+            self.model(
                 input_ids,
                 positions,
                 forward_batch,
@@ -1221,11 +1213,17 @@ class Qwen3VLForConditionalGeneration(nn.Module):
                 input_deepstack_embeds=input_deepstack_embeds,
             )
         )
+        _llm_ms = (time.perf_counter() - _llm_t0) * 1000.0
 
         if forward_batch.forward_mode.is_extend():
-            forward_batch.llm_prefill_ms = float(llm_ms)
+            llm_prefill_ms = _llm_ms
+            forward_batch.vit_prefill_ms = vit_prefill_ms
+            forward_batch.vit_prefill_tokens = vit_prefill_tokens
+            forward_batch.llm_prefill_ms = llm_prefill_ms
+            forward_batch.llm_decode_ms = None
         else:
-            forward_batch.llm_decode_ms = float(llm_ms)
+            llm_decode_ms = _llm_ms
+            forward_batch.llm_decode_ms = llm_decode_ms
 
         # Prune hidden_states before lm_head to avoid a wasteful
         # [total_tokens, vocab] matmul during prefill.

--- a/pymllm/orchestrator/detokenizer_process.py
+++ b/pymllm/orchestrator/detokenizer_process.py
@@ -117,6 +117,7 @@ class DetokenizerProcess:
         prompt_tokens_list: List[int] = token_id_out.get("prompt_tokens", [])
         completion_tokens_list: List[int] = token_id_out.get("completion_tokens", [])
         vit_prefill_ms_list = token_id_out.get("vit_prefill_ms", [])
+        vit_prefill_tokens_list = token_id_out.get("vit_prefill_tokens", [])
         llm_prefill_ms_list = token_id_out.get("llm_prefill_ms", [])
         llm_decode_ms_list = token_id_out.get("llm_decode_ms", [])
 
@@ -136,6 +137,9 @@ class DetokenizerProcess:
             )
             vit_prefill_ms = (
                 vit_prefill_ms_list[i] if i < len(vit_prefill_ms_list) else None
+            )
+            vit_prefill_tokens = (
+                vit_prefill_tokens_list[i] if i < len(vit_prefill_tokens_list) else None
             )
             llm_prefill_ms = (
                 llm_prefill_ms_list[i] if i < len(llm_prefill_ms_list) else None
@@ -174,6 +178,8 @@ class DetokenizerProcess:
             }
             if vit_prefill_ms is not None:
                 result["vit_prefill_ms"] = vit_prefill_ms
+            if vit_prefill_tokens is not None:
+                result["vit_prefill_tokens"] = vit_prefill_tokens
             if llm_prefill_ms is not None:
                 result["llm_prefill_ms"] = llm_prefill_ms
             if llm_decode_ms is not None:

--- a/pymllm/orchestrator/detokenizer_process.py
+++ b/pymllm/orchestrator/detokenizer_process.py
@@ -116,6 +116,9 @@ class DetokenizerProcess:
         )
         prompt_tokens_list: List[int] = token_id_out.get("prompt_tokens", [])
         completion_tokens_list: List[int] = token_id_out.get("completion_tokens", [])
+        vit_prefill_ms_list = token_id_out.get("vit_prefill_ms", [])
+        llm_prefill_ms_list = token_id_out.get("llm_prefill_ms", [])
+        llm_decode_ms_list = token_id_out.get("llm_decode_ms", [])
 
         results: List[Dict[str, Any]] = []
 
@@ -130,6 +133,15 @@ class DetokenizerProcess:
             prompt_tokens = prompt_tokens_list[i] if i < len(prompt_tokens_list) else 0
             completion_tokens = (
                 completion_tokens_list[i] if i < len(completion_tokens_list) else 0
+            )
+            vit_prefill_ms = (
+                vit_prefill_ms_list[i] if i < len(vit_prefill_ms_list) else None
+            )
+            llm_prefill_ms = (
+                llm_prefill_ms_list[i] if i < len(llm_prefill_ms_list) else None
+            )
+            llm_decode_ms = (
+                llm_decode_ms_list[i] if i < len(llm_decode_ms_list) else None
             )
 
             # Decode text from output_ids
@@ -160,6 +172,12 @@ class DetokenizerProcess:
                 "prompt_tokens": prompt_tokens,
                 "completion_tokens": completion_tokens,
             }
+            if vit_prefill_ms is not None:
+                result["vit_prefill_ms"] = vit_prefill_ms
+            if llm_prefill_ms is not None:
+                result["llm_prefill_ms"] = llm_prefill_ms
+            if llm_decode_ms is not None:
+                result["llm_decode_ms"] = llm_decode_ms
             results.append(result)
 
         return results

--- a/pymllm/orchestrator/model_runner_process.py
+++ b/pymllm/orchestrator/model_runner_process.py
@@ -20,6 +20,7 @@ RadixCache lifecycle
 """
 
 import logging
+import time
 from typing import Any, Dict, List, Optional, Tuple
 
 import torch
@@ -373,12 +374,21 @@ class ModelRunnerProcess:
                 mrope_position_deltas=mrope_deltas_tensor,
             )
 
+        _forward_t0 = time.perf_counter()
         logits_output = runner.forward(fb)
+        _forward_ms = (time.perf_counter() - _forward_t0) * 1000.0
 
         # Extract timing info written by multimodal models onto ForwardBatch.
         vit_prefill_ms = getattr(fb, "vit_prefill_ms", None)
+        vit_prefill_tokens = getattr(fb, "vit_prefill_tokens", None)
         llm_prefill_ms = getattr(fb, "llm_prefill_ms", None)
         llm_decode_ms = getattr(fb, "llm_decode_ms", None)
+
+        # Decode may run through CUDA graph / non-Python execution paths where
+        # model-level Python timing hooks do not fire. Fall back to the outer
+        # runner.forward wall-clock time for decode batches.
+        if forward_mode == "decode" and llm_decode_ms is None:
+            llm_decode_ms = _forward_ms
 
         # Persist M-RoPE position deltas for multimodal models (Qwen3-VL).
         # The model sets mrope_position_deltas on the ForwardBatch during
@@ -432,6 +442,8 @@ class ModelRunnerProcess:
 
             if vit_prefill_ms is not None:
                 out["vit_prefill_ms"] = float(vit_prefill_ms)
+            if vit_prefill_tokens is not None:
+                out["vit_prefill_tokens"] = int(vit_prefill_tokens)
             if llm_prefill_ms is not None:
                 out["llm_prefill_ms"] = float(llm_prefill_ms)
             if llm_decode_ms is not None:

--- a/pymllm/orchestrator/model_runner_process.py
+++ b/pymllm/orchestrator/model_runner_process.py
@@ -375,6 +375,11 @@ class ModelRunnerProcess:
 
         logits_output = runner.forward(fb)
 
+        # Extract timing info written by multimodal models onto ForwardBatch.
+        vit_prefill_ms = getattr(fb, "vit_prefill_ms", None)
+        llm_prefill_ms = getattr(fb, "llm_prefill_ms", None)
+        llm_decode_ms = getattr(fb, "llm_decode_ms", None)
+
         # Persist M-RoPE position deltas for multimodal models (Qwen3-VL).
         # The model sets mrope_position_deltas on the ForwardBatch during
         # prefill; we store them here so decode steps can retrieve them.
@@ -424,6 +429,13 @@ class ModelRunnerProcess:
                 "rid": rid,
                 "output_token_ids": [token_id],
             }
+
+            if vit_prefill_ms is not None:
+                out["vit_prefill_ms"] = float(vit_prefill_ms)
+            if llm_prefill_ms is not None:
+                out["llm_prefill_ms"] = float(llm_prefill_ms)
+            if llm_decode_ms is not None:
+                out["llm_decode_ms"] = float(llm_decode_ms)
             # Report actual prefix_len back to the scheduler so it can
             # update its token budget tracking accurately.
             if actual_prefix_lens is not None:
@@ -565,6 +577,11 @@ class ModelRunnerProcess:
                     len(new_indices),
                     new_indices[: min(len(new_indices), 8)].tolist(),
                 )
+            if not hasattr(cache, "page_size"):
+                # ChunkCache / no-op cache when disable_radix_cache=True.
+                self._rid_to_cache_protected_len[rid] = 0
+                continue
+
             if cache.page_size == 1:
                 assert len(new_indices) == seq_len, (
                     f"Re-match length mismatch after insert: "

--- a/pymllm/orchestrator/scheduler_process.py
+++ b/pymllm/orchestrator/scheduler_process.py
@@ -125,8 +125,10 @@ class Req:
         "prompt_len",
         # Timing stats
         "vit_prefill_ms",
+        "vit_prefill_tokens",
         "llm_prefill_ms",
         "llm_decode_ms",
+        "decode_start_tic",
     )
 
     def __init__(
@@ -181,8 +183,10 @@ class Req:
 
         # Timing stats
         self.vit_prefill_ms = None
+        self.vit_prefill_tokens = None
         self.llm_prefill_ms = None
         self.llm_decode_ms = None
+        self.decode_start_tic = None
 
     def check_finished(self) -> bool:
         """Check if this request has reached a finish condition.
@@ -787,10 +791,12 @@ class SchedulerProcess:
             # get_next_batch_to_run; correct the over-reservation now.
             if "vit_prefill_ms" in out:
                 req.vit_prefill_ms = out["vit_prefill_ms"]
+            if "vit_prefill_tokens" in out:
+                req.vit_prefill_tokens = out["vit_prefill_tokens"]
             if "llm_prefill_ms" in out:
                 req.llm_prefill_ms = out["llm_prefill_ms"]
             if "llm_decode_ms" in out:
-                req.llm_decode_ms = out["llm_decode_ms"]
+                req.llm_decode_ms = (req.llm_decode_ms or 0.0) + out["llm_decode_ms"]
 
             if "prefix_len" in out and batch.forward_mode.is_extend():
                 actual_prefix_len = out["prefix_len"]
@@ -824,6 +830,12 @@ class SchedulerProcess:
             # Check finish conditions (EOS tokens already in stop_token_ids)
             req.check_finished()
 
+        if batch.forward_mode.is_decode():
+            _decode_now = time.perf_counter()
+            for req in batch.reqs:
+                if req.decode_start_tic is not None:
+                    req.llm_decode_ms = (_decode_now - req.decode_start_tic) * 1000.0
+
         # Process batch requests based on forward mode
         if batch.forward_mode.is_extend():
             # Prefill batch: mark as prefilled and route
@@ -834,6 +846,9 @@ class SchedulerProcess:
                     self._model_runner._free_rid_resources(req.rid)
                     self._free_req_resources(req)
                 else:
+                    if req.decode_start_tic is None:
+                        req.decode_start_tic = time.perf_counter()
+                        req.llm_decode_ms = 0.0
                     self._running_batch.append(req)
 
             # --- Accumulate prefill metrics ---
@@ -893,6 +908,7 @@ class SchedulerProcess:
                     "prompt_tokens": [req.prompt_len],
                     "completion_tokens": [len(req.output_ids)],
                     "vit_prefill_ms": [req.vit_prefill_ms],
+                    "vit_prefill_tokens": [req.vit_prefill_tokens],
                     "llm_prefill_ms": [req.llm_prefill_ms],
                     "llm_decode_ms": [req.llm_decode_ms],
                 }
@@ -972,6 +988,7 @@ class SchedulerProcess:
             "prompt_tokens": [req.prompt_len],
             "completion_tokens": [len(req.output_ids)],
             "vit_prefill_ms": [req.vit_prefill_ms],
+            "vit_prefill_tokens": [req.vit_prefill_tokens],
             "llm_prefill_ms": [req.llm_prefill_ms],
             "llm_decode_ms": [req.llm_decode_ms],
         }

--- a/pymllm/orchestrator/scheduler_process.py
+++ b/pymllm/orchestrator/scheduler_process.py
@@ -123,6 +123,10 @@ class Req:
         "read_offset",
         # Prompt length (for token accounting)
         "prompt_len",
+        # Timing stats
+        "vit_prefill_ms",
+        "llm_prefill_ms",
+        "llm_decode_ms",
     )
 
     def __init__(
@@ -174,6 +178,11 @@ class Req:
 
         # Prompt length
         self.prompt_len: int = len(input_ids)
+
+        # Timing stats
+        self.vit_prefill_ms = None
+        self.llm_prefill_ms = None
+        self.llm_decode_ms = None
 
     def check_finished(self) -> bool:
         """Check if this request has reached a finish condition.
@@ -776,6 +785,13 @@ class SchedulerProcess:
             # The model runner reports the actual prefix_len it found.
             # The scheduler originally reserved full input_len in
             # get_next_batch_to_run; correct the over-reservation now.
+            if "vit_prefill_ms" in out:
+                req.vit_prefill_ms = out["vit_prefill_ms"]
+            if "llm_prefill_ms" in out:
+                req.llm_prefill_ms = out["llm_prefill_ms"]
+            if "llm_decode_ms" in out:
+                req.llm_decode_ms = out["llm_decode_ms"]
+
             if "prefix_len" in out and batch.forward_mode.is_extend():
                 actual_prefix_len = out["prefix_len"]
                 if actual_prefix_len > req.prefix_len:
@@ -876,6 +892,9 @@ class SchedulerProcess:
                     "skip_special_tokens": [True],
                     "prompt_tokens": [req.prompt_len],
                     "completion_tokens": [len(req.output_ids)],
+                    "vit_prefill_ms": [req.vit_prefill_ms],
+                    "llm_prefill_ms": [req.llm_prefill_ms],
+                    "llm_decode_ms": [req.llm_decode_ms],
                 }
                 req.read_offset = len(req.output_ids)
                 self._send_to_detokenizer.send_pyobj(output)
@@ -952,6 +971,9 @@ class SchedulerProcess:
             "skip_special_tokens": [True],
             "prompt_tokens": [req.prompt_len],
             "completion_tokens": [len(req.output_ids)],
+            "vit_prefill_ms": [req.vit_prefill_ms],
+            "llm_prefill_ms": [req.llm_prefill_ms],
+            "llm_decode_ms": [req.llm_decode_ms],
         }
         self._finished.append(output)
         logger.debug(

--- a/pymllm/orchestrator/tokenizer_process.py
+++ b/pymllm/orchestrator/tokenizer_process.py
@@ -371,6 +371,20 @@ class TokenizerProcess:
         # ------------------------------------------------------------------ #
         mm_inputs = self._collect_mm_inputs(raw_request, text=input_text)
 
+        # If AutoProcessor produced multimodal input_ids, they must override
+        # the plain tokenizer result. Otherwise the prompt contains only a
+        # single image placeholder token and won't match the visual features.
+        if mm_inputs is not None:
+            image_inputs = mm_inputs.get("image_inputs")
+            if image_inputs is not None and "input_ids" in image_inputs:
+                proc_input_ids = image_inputs["input_ids"]
+                if hasattr(proc_input_ids, "ndim") and proc_input_ids.ndim > 1:
+                    proc_input_ids = proc_input_ids[0]
+                if hasattr(proc_input_ids, "tolist"):
+                    input_ids = proc_input_ids.tolist()
+                else:
+                    input_ids = list(proc_input_ids)
+
         # ------------------------------------------------------------------ #
         # 3. Pack into the typed dataclass
         # ------------------------------------------------------------------ #

--- a/pymllm/quantization/methods/__init__.py
+++ b/pymllm/quantization/methods/__init__.py
@@ -8,8 +8,14 @@ from pymllm.quantization.methods.awq_marlin import (
     AWQMarlinConfig,
     AWQMarlinLinearMethod,
 )
+from pymllm.quantization.methods.compressed_tensors import (
+    CompressedTensorsConfig,
+    CompressedTensorsLinearMethod,
+)
 
 __all__ = [
     "AWQMarlinConfig",
     "AWQMarlinLinearMethod",
+    "CompressedTensorsConfig",
+    "CompressedTensorsLinearMethod",
 ]

--- a/pymllm/quantization/methods/compressed_tensors.py
+++ b/pymllm/quantization/methods/compressed_tensors.py
@@ -1,0 +1,360 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+import torch
+from torch.nn import Parameter
+
+from mllm_kernel.cuda.jit import gptq_marlin_gemm, gptq_marlin_repack
+from pymllm.layers.quantize_base import LinearMethodBase
+from pymllm.layers.utils import set_weight_attrs
+from pymllm.quantization.quant_config import QuantizationConfig, register_quantization
+
+MARLIN_SUPPORTED_GROUP_SIZES = [-1, 32, 64, 128]
+GPTQ_MARLIN_MIN_THREAD_N = 64
+GPTQ_MARLIN_MIN_THREAD_K = 128
+GPTQ_MARLIN_TILE = 16
+
+
+class _ScalarTypeInfo:
+    def __init__(self, name: str, size_bits: int, type_id: int):
+        self.name = name
+        self.size_bits = size_bits
+        self.id = type_id
+
+
+def _compute_scalar_type_id(
+    exponent: int,
+    mantissa: int,
+    signed: bool,
+    bias: int,
+    finite_values_only: bool = False,
+    nan_repr: int = 1,
+) -> int:
+    bit_offset = 0
+    result = 0
+    for value, width in [
+        (exponent, 8),
+        (mantissa, 8),
+        (signed, 1),
+        (bias, 32),
+        (finite_values_only, 1),
+        (nan_repr, 8),
+    ]:
+        result |= (int(value) & ((1 << width) - 1)) << bit_offset
+        bit_offset += width
+    return result
+
+
+SCALAR_TYPE_UINT4 = _ScalarTypeInfo(
+    "uint4", 4, _compute_scalar_type_id(0, 4, False, 0)
+)
+SCALAR_TYPE_UINT4B8 = _ScalarTypeInfo(
+    "uint4b8", 4, _compute_scalar_type_id(0, 4, False, 8)
+)
+
+
+def _weights_cfg(config: Dict[str, Any]) -> Dict[str, Any]:
+    return config["config_groups"]["group_0"]["weights"]
+
+
+def verify_marlin_supported(group_size: int) -> None:
+    if group_size not in MARLIN_SUPPORTED_GROUP_SIZES:
+        raise ValueError(
+            f"Unsupported compressed-tensors group_size: {group_size}"
+        )
+    if not torch.cuda.is_available():
+        return
+    major, minor = torch.cuda.get_device_capability()
+    if major * 10 + minor < 80:
+        raise ValueError("compressed-tensors Marlin requires SM80+")
+
+
+def verify_marlin_supports_shape(
+    output_size_per_partition: int,
+    input_size_per_partition: int,
+    input_size: int,
+    group_size: int,
+) -> None:
+    if output_size_per_partition % GPTQ_MARLIN_MIN_THREAD_N != 0:
+        raise ValueError("output_size_per_partition must be divisible by 64")
+    if input_size_per_partition % GPTQ_MARLIN_MIN_THREAD_K != 0:
+        raise ValueError("input_size_per_partition must be divisible by 128")
+    if group_size < input_size and input_size_per_partition % group_size != 0:
+        raise ValueError(
+            "input_size_per_partition must be divisible by group_size"
+        )
+
+
+def marlin_make_workspace(device: torch.device) -> torch.Tensor:
+    sms = torch.cuda.get_device_properties(device).multi_processor_count
+    return torch.zeros(sms, dtype=torch.int, device=device, requires_grad=False)
+
+
+def marlin_make_empty_g_idx(device: torch.device) -> torch.Tensor:
+    return Parameter(
+        torch.empty(0, dtype=torch.int32, device=device), requires_grad=False
+    )
+
+
+def get_scale_perms():
+    scale_perm: list[int] = []
+    for i in range(8):
+        scale_perm.extend([i + 8 * j for j in range(8)])
+    scale_perm_single: list[int] = []
+    for i in range(4):
+        scale_perm_single.extend(
+            [2 * i + j for j in [0, 1, 8, 9, 16, 17, 24, 25]]
+        )
+    return scale_perm, scale_perm_single
+
+
+def marlin_permute_scales(
+    s: torch.Tensor, size_k: int, size_n: int, group_size: int
+) -> torch.Tensor:
+    scale_perm, scale_perm_single = get_scale_perms()
+    if group_size < size_k and group_size != -1:
+        s = s.reshape((-1, len(scale_perm)))[:, scale_perm]
+    else:
+        s = s.reshape((-1, len(scale_perm_single)))[:, scale_perm_single]
+    return s.reshape((-1, size_n)).contiguous()
+
+
+def replace_parameter(
+    layer: torch.nn.Module, name: str, new_data: torch.Tensor
+) -> None:
+    layer.register_parameter(name, Parameter(new_data, requires_grad=False))
+
+
+def _validate_supported_signature(config: "CompressedTensorsConfig") -> None:
+    if config.quant_format != "pack-quantized":
+        raise ValueError(
+            f"Unsupported compressed-tensors format: {config.quant_format}"
+        )
+    if config.weight_bits != 4:
+        raise ValueError(
+            f"Unsupported compressed-tensors num_bits: {config.weight_bits}"
+        )
+    if config.group_size != 32:
+        raise ValueError(
+            f"Unsupported compressed-tensors group_size: {config.group_size}"
+        )
+    if not config.symmetric:
+        raise ValueError("v1 only supports symmetric compressed-tensors")
+    if config.actorder is not None:
+        raise ValueError(
+            f"Unsupported compressed-tensors actorder: {config.actorder}"
+        )
+    verify_marlin_supported(config.group_size)
+
+
+class CompressedTensorsWNA16Scheme:
+    def __init__(
+        self,
+        *,
+        weight_bits: int,
+        group_size: int,
+        symmetric: bool,
+        actorder: Optional[str],
+    ) -> None:
+        self.weight_bits = weight_bits
+        self.group_size = group_size
+        self.symmetric = symmetric
+        self.actorder = actorder
+        self.pack_factor = 32 // weight_bits
+        self.quant_type = (
+            SCALAR_TYPE_UINT4B8 if symmetric else SCALAR_TYPE_UINT4
+        )
+
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        input_size_per_partition: int,
+        output_partition_sizes: List[int],
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs: Any,
+    ) -> None:
+        del output_size
+        output_size_per_partition = sum(output_partition_sizes)
+        verify_marlin_supports_shape(
+            output_size_per_partition=output_size_per_partition,
+            input_size_per_partition=input_size_per_partition,
+            input_size=input_size,
+            group_size=self.group_size,
+        )
+
+        weight_packed = Parameter(
+            torch.empty(
+                output_size_per_partition,
+                input_size_per_partition // self.pack_factor,
+                dtype=torch.int32,
+            ),
+            requires_grad=False,
+        )
+        set_weight_attrs(weight_packed, {"output_dim": 0, **extra_weight_attrs})
+        layer.register_parameter("weight_packed", weight_packed)
+
+        weight_scale = Parameter(
+            torch.empty(
+                output_size_per_partition,
+                input_size_per_partition // self.group_size,
+                dtype=params_dtype,
+            ),
+            requires_grad=False,
+        )
+        set_weight_attrs(weight_scale, {"output_dim": 0, **extra_weight_attrs})
+        layer.register_parameter("weight_scale", weight_scale)
+
+        weight_shape = Parameter(torch.empty(2, dtype=torch.int64), requires_grad=False)
+        set_weight_attrs(weight_shape, extra_weight_attrs)
+        layer.register_parameter("weight_shape", weight_shape)
+
+        layer.input_size_per_partition = input_size_per_partition
+        layer.output_size_per_partition = output_size_per_partition
+        layer.group_size = self.group_size
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        device = layer.weight_packed.device
+        size_k = layer.input_size_per_partition
+        size_n = layer.output_size_per_partition
+
+        verify_marlin_supports_shape(
+            output_size_per_partition=size_n,
+            input_size_per_partition=size_k,
+            input_size=size_k,
+            group_size=self.group_size,
+        )
+
+        layer.workspace = marlin_make_workspace(device)
+        layer.weight_zero_point = marlin_make_empty_g_idx(device)
+        layer.weight_g_idx = marlin_make_empty_g_idx(device)
+        layer.g_idx_sort_indices = marlin_make_empty_g_idx(device)
+
+        repacked_qweight = gptq_marlin_repack(
+            layer.weight_packed.data.t().contiguous(),
+            perm=layer.g_idx_sort_indices,
+            size_k=size_k,
+            size_n=size_n,
+            num_bits=self.weight_bits,
+        )
+        repacked_scales = marlin_permute_scales(
+            layer.weight_scale.data.t().contiguous(),
+            size_k=size_k,
+            size_n=size_n,
+            group_size=self.group_size,
+        )
+
+        replace_parameter(layer, "weight_packed", repacked_qweight)
+        replace_parameter(layer, "weight_scale", repacked_scales)
+
+    def apply(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        bias: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        reshaped_x = x.reshape(-1, x.shape[-1])
+        out_shape = x.shape[:-1] + (layer.output_size_per_partition,)
+        output = gptq_marlin_gemm(
+            a=reshaped_x,
+            c=None,
+            b_q_weight=layer.weight_packed,
+            b_scales=layer.weight_scale,
+            global_scale=None,
+            b_zeros=layer.weight_zero_point,
+            g_idx=layer.weight_g_idx,
+            perm=layer.g_idx_sort_indices,
+            workspace=layer.workspace,
+            b_q_type_id=self.quant_type.id,
+            size_m=reshaped_x.shape[0],
+            size_n=layer.output_size_per_partition,
+            size_k=layer.input_size_per_partition,
+            is_k_full=True,
+            use_fp32_reduce=True,
+            is_zp_float=False,
+        )
+        if bias is not None:
+            output.add_(bias)
+        return output.reshape(out_shape)
+
+
+class CompressedTensorsLinearMethod(LinearMethodBase):
+    def __init__(self, quant_config: "CompressedTensorsConfig") -> None:
+        self.quant_config = quant_config
+        self.scheme = CompressedTensorsWNA16Scheme(
+            weight_bits=quant_config.weight_bits,
+            group_size=quant_config.group_size,
+            symmetric=quant_config.symmetric,
+            actorder=quant_config.actorder,
+        )
+
+    def create_weights(self, *args: Any, **kwargs: Any) -> None:
+        self.scheme.create_weights(*args, **kwargs)
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        self.scheme.process_weights_after_loading(layer)
+
+    def apply(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        bias: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        return self.scheme.apply(layer, x, bias)
+
+
+@register_quantization("compressed-tensors")
+class CompressedTensorsConfig(QuantizationConfig):
+    def __init__(
+        self,
+        *,
+        quant_format: str,
+        ignore: List[str],
+        weight_bits: int,
+        group_size: int,
+        symmetric: bool,
+        actorder: Optional[str],
+    ) -> None:
+        super().__init__()
+        self.quant_format = quant_format
+        self.ignore = ignore
+        self.weight_bits = weight_bits
+        self.group_size = group_size
+        self.symmetric = symmetric
+        self.actorder = actorder
+
+    def get_name(self) -> str:
+        return "compressed-tensors"
+
+    def get_supported_act_dtypes(self) -> List[torch.dtype]:
+        return [torch.float16, torch.bfloat16]
+
+    @classmethod
+    def get_min_capability(cls) -> int:
+        return 80
+
+    @staticmethod
+    def get_config_filenames() -> List[str]:
+        return ["config.json"]
+
+    @classmethod
+    def from_config(cls, config: Dict[str, Any]) -> "CompressedTensorsConfig":
+        weights = _weights_cfg(config)
+        return cls(
+            quant_format=config["format"],
+            ignore=list(config.get("ignore", [])),
+            weight_bits=weights["num_bits"],
+            group_size=weights["group_size"],
+            symmetric=weights["symmetric"],
+            actorder=weights.get("actorder"),
+        )
+
+    def get_quant_method(
+        self, layer: torch.nn.Module, prefix: str = ""
+    ) -> Optional[CompressedTensorsLinearMethod]:
+        _validate_supported_signature(self)
+        if any(ignored and prefix.startswith(ignored) for ignored in self.ignore):
+            return None
+        return CompressedTensorsLinearMethod(self)

--- a/pymllm/server/launch.py
+++ b/pymllm/server/launch.py
@@ -470,14 +470,21 @@ def _messages_to_prompt(
         Extra keyword arguments forwarded to ``apply_chat_template``
         (e.g. ``enable_thinking=True`` for Qwen3).
     """
-    # Flatten each message into a plain dict for the tokenizer.
+    # Preserve multimodal message structure for tokenizer.apply_chat_template.
     msg_dicts: List[Dict[str, Any]] = []
     for msg in messages:
         content = msg.content
         if isinstance(content, list):
-            # Multimodal: extract only text parts for the prompt string.
-            text_parts = [p.text for p in content if p.type == "text" and p.text]
-            content = "\n".join(text_parts) if text_parts else ""
+            mm_parts: List[Dict[str, Any]] = []
+            for part in content:
+                if part.type == "text" and part.text is not None:
+                    mm_parts.append({"type": "text", "text": part.text})
+                elif part.type == "image_url" and part.image_url is not None:
+                    # Keep image content so chat template can emit vision tokens.
+                    mm_parts.append(
+                        {"type": "image", "image": part.image_url.url}
+                    )
+            content = mm_parts
         elif content is None:
             content = ""
         d: Dict[str, Any] = {"role": msg.role, "content": content}
@@ -978,6 +985,11 @@ async def openai_chat_completions(obj: ChatCompletionRequest, request: Request):
                     "prompt_tokens": prompt_tokens,
                     "completion_tokens": completion_tokens,
                     "total_tokens": prompt_tokens + completion_tokens,
+                },
+                "timing": {
+                    "vit_prefill_ms": r.get("vit_prefill_ms"),
+                    "llm_prefill_ms": r.get("llm_prefill_ms"),
+                    "llm_decode_ms": r.get("llm_decode_ms"),
                 },
             }
         )

--- a/pymllm/server/launch.py
+++ b/pymllm/server/launch.py
@@ -740,6 +740,31 @@ async def openai_completions(obj: CompletionRequest, request: Request):
                     "completion_tokens": completion_tokens,
                     "total_tokens": prompt_tokens + completion_tokens,
                 },
+                "timing": {
+                    "vit_prefill_ms": r.get("vit_prefill_ms"),
+                    "llm_prefill_ms": r.get("llm_prefill_ms"),
+                    "llm_decode_ms": r.get("llm_decode_ms"),
+                    "prefill_tokens": prompt_tokens,
+                    "vit_prefill_tps": (
+                        None
+                        if r.get("vit_prefill_ms") is None
+                        or r.get("vit_prefill_ms") <= 0
+                        or r.get("vit_prefill_tokens") is None
+                        else r.get("vit_prefill_tokens") / (r.get("vit_prefill_ms") / 1000.0)
+                    ),
+                    "llm_prefill_tps": (
+                        None
+                        if r.get("llm_prefill_ms") is None
+                        or r.get("llm_prefill_ms") <= 0
+                        else prompt_tokens / (r.get("llm_prefill_ms") / 1000.0)
+                    ),
+                    "llm_decode_tps": (
+                        None
+                        if r.get("llm_decode_ms") is None
+                        or r.get("llm_decode_ms") <= 0
+                        else completion_tokens / (r.get("llm_decode_ms") / 1000.0)
+                    ),
+                },
             }
         )
     except ValueError as e:
@@ -990,6 +1015,26 @@ async def openai_chat_completions(obj: ChatCompletionRequest, request: Request):
                     "vit_prefill_ms": r.get("vit_prefill_ms"),
                     "llm_prefill_ms": r.get("llm_prefill_ms"),
                     "llm_decode_ms": r.get("llm_decode_ms"),
+                    "prefill_tokens": prompt_tokens,
+                    "vit_prefill_tps": (
+                        None
+                        if r.get("vit_prefill_ms") is None
+                        or r.get("vit_prefill_ms") <= 0
+                        or r.get("vit_prefill_tokens") is None
+                        else r.get("vit_prefill_tokens") / (r.get("vit_prefill_ms") / 1000.0)
+                    ),
+                    "llm_prefill_tps": (
+                        None
+                        if r.get("llm_prefill_ms") is None
+                        or r.get("llm_prefill_ms") <= 0
+                        else prompt_tokens / (r.get("llm_prefill_ms") / 1000.0)
+                    ),
+                    "llm_decode_tps": (
+                        None
+                        if r.get("llm_decode_ms") is None
+                        or r.get("llm_decode_ms") <= 0
+                        else completion_tokens / (r.get("llm_decode_ms") / 1000.0)
+                    ),
                 },
             }
         )

--- a/pymllm/tests/test_compressed_tensors_config.py
+++ b/pymllm/tests/test_compressed_tensors_config.py
@@ -1,0 +1,87 @@
+import copy
+import json
+import pytest
+
+from pymllm.executor.model_runner import ModelRunner
+from pymllm.quantization import get_quantization_config, list_quantization_methods
+from pymllm.quantization.methods.compressed_tensors import (
+    CompressedTensorsConfig,
+    CompressedTensorsLinearMethod,
+)
+
+
+def _current_ct_config():
+    return {
+        "quant_method": "compressed-tensors",
+        "format": "pack-quantized",
+        "config_groups": {
+            "group_0": {
+                "targets": ["Linear"],
+                "weights": {
+                    "num_bits": 4,
+                    "group_size": 32,
+                    "strategy": "group",
+                    "symmetric": True,
+                    "actorder": None,
+                },
+            },
+        },
+        "ignore": ["ignore_prefix"],
+    }
+
+
+def test_compressed_tensors_is_registered():
+    assert "compressed-tensors" in list_quantization_methods()
+    assert get_quantization_config("compressed-tensors") is CompressedTensorsConfig
+
+
+def test_from_config_parses_current_signature():
+    config = CompressedTensorsConfig.from_config(
+        copy.deepcopy(_current_ct_config())
+    )
+
+    assert config.quant_format == "pack-quantized"
+    assert config.weight_bits == 4
+    assert config.group_size == 32
+    assert config.symmetric is True
+    assert config.actorder is None
+    assert config.ignore == ["ignore_prefix"]
+
+
+def test_load_quant_config_dict_unwraps_quantization_config_from_config_json(
+    tmp_path,
+):
+    root_config = {
+        "architectures": ["Qwen3VLForConditionalGeneration"],
+        "quantization_config": copy.deepcopy(_current_ct_config()),
+    }
+    (tmp_path / "config.json").write_text(json.dumps(root_config))
+
+    loaded = ModelRunner._load_quant_config_dict(tmp_path)
+
+    assert loaded == root_config["quantization_config"]
+
+
+def test_get_quant_method_respects_ignore():
+    config = CompressedTensorsConfig.from_config(
+        copy.deepcopy(_current_ct_config())
+    )
+    assert config.get_quant_method(layer=None, prefix="ignore_prefix.layer") is None
+
+    method = config.get_quant_method(
+        layer=None,
+        prefix="model.language_model.layers.0.self_attn.q_proj",
+    )
+    assert isinstance(method, CompressedTensorsLinearMethod)
+
+def test_get_quant_method_rejects_unsupported_signature():
+    checkpoint_config = copy.deepcopy(_current_ct_config())
+    checkpoint_config["config_groups"]["group_0"]["weights"]["group_size"] = 128
+
+    config = CompressedTensorsConfig.from_config(checkpoint_config)
+
+    with pytest.raises(ValueError, match="group_size"):
+        config.get_quant_method(
+            layer=None,
+            prefix="model.language_model.layers.0.self_attn.q_proj",
+        )

--- a/pymllm/tests/test_compressed_tensors_runtime.py
+++ b/pymllm/tests/test_compressed_tensors_runtime.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import pytest
+import torch
+from torch import nn
+
+import pymllm.quantization.methods.compressed_tensors as ct
+
+
+def _current_ct_config() -> dict:
+    return {
+        "quant_method": "compressed-tensors",
+        "format": "pack-quantized",
+        "ignore": ["lm_head"],
+        "config_groups": {
+            "group_0": {
+                "targets": ["Linear"],
+                "weights": {
+                    "num_bits": 4,
+                    "group_size": 32,
+                    "strategy": "group",
+                    "symmetric": True,
+                    "actorder": None,
+                    "type": "int",
+                },
+            }
+        },
+    }
+
+
+class _DummyLayer(nn.Module):
+    pass
+
+
+def _build_quant_method() -> ct.CompressedTensorsLinearMethod:
+    cfg = ct.CompressedTensorsConfig.from_config(_current_ct_config())
+    qm = cfg.get_quant_method(
+        layer=None,
+        prefix="model.language_model.layers.0.self_attn.q_proj",
+    )
+    assert isinstance(qm, ct.CompressedTensorsLinearMethod)
+    return qm
+
+
+def _weight_loader(param: torch.nn.Parameter, loaded_weight: torch.Tensor) -> None:
+    param.data.copy_(loaded_weight)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_create_weights_registers_checkpoint_parameter_names():
+    layer = _DummyLayer()
+    qm = _build_quant_method()
+
+    with torch.device("cuda"):
+        qm.create_weights(
+            layer=layer,
+            input_size_per_partition=2048,
+            output_partition_sizes=[2048],
+            input_size=2048,
+            output_size=2048,
+            params_dtype=torch.bfloat16,
+            weight_loader=_weight_loader,
+        )
+
+    assert {"weight_packed", "weight_scale", "weight_shape"} <= set(
+        layer._parameters
+    )
+    assert tuple(layer.weight_packed.shape) == (2048, 256)
+    assert tuple(layer.weight_scale.shape) == (2048, 64)
+    assert tuple(layer.weight_shape.shape) == (2,)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_process_and_apply_use_gptq_repack_and_uint4b8(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    layer = _DummyLayer()
+    qm = _build_quant_method()
+
+    with torch.device("cuda"):
+        qm.create_weights(
+            layer=layer,
+            input_size_per_partition=2048,
+            output_partition_sizes=[2048],
+            input_size=2048,
+            output_size=2048,
+            params_dtype=torch.bfloat16,
+            weight_loader=_weight_loader,
+        )
+
+    with torch.no_grad():
+        layer.weight_packed.copy_(
+            torch.arange(
+                layer.weight_packed.numel(),
+                device="cuda",
+                dtype=torch.int32,
+            ).reshape_as(layer.weight_packed)
+        )
+        layer.weight_scale.fill_(1)
+        layer.weight_shape.copy_(
+            torch.tensor([2048, 2048], device="cuda", dtype=torch.int64)
+        )
+
+    repack_calls: dict[str, object] = {}
+    scale_calls: dict[str, object] = {}
+    workspace = torch.zeros(1, dtype=torch.int32, device="cuda")
+    empty_tensors: list[torch.Tensor] = []
+
+    monkeypatch.setattr(ct, "verify_marlin_supports_shape", lambda **_: None)
+    monkeypatch.setattr(
+        ct,
+        "marlin_make_workspace",
+        lambda device: workspace,
+    )
+    monkeypatch.setattr(
+        ct,
+        "marlin_make_empty_g_idx",
+        lambda device: empty_tensors.append(
+            torch.empty(0, dtype=torch.int32, device=device)
+        )
+        or empty_tensors[-1],
+    )
+    monkeypatch.setattr(
+        ct,
+        "gptq_marlin_repack",
+        lambda b_q_weight, perm, size_k, size_n, num_bits: repack_calls.update(
+            {
+                "b_q_weight": b_q_weight,
+                "perm": perm,
+                "size_k": size_k,
+                "size_n": size_n,
+                "num_bits": num_bits,
+            }
+        )
+        or torch.zeros(
+            (size_k // 16, size_n * 16 // (32 // num_bits)),
+            dtype=torch.int32,
+            device=b_q_weight.device,
+        ),
+    )
+    monkeypatch.setattr(
+        ct,
+        "marlin_permute_scales",
+        lambda s, size_k, size_n, group_size: scale_calls.update(
+            {
+                "s": s,
+                "size_k": size_k,
+                "size_n": size_n,
+                "group_size": group_size,
+            }
+        )
+        or torch.zeros(
+            (size_k // group_size, size_n),
+            dtype=s.dtype,
+            device=s.device,
+        ),
+    )
+
+    calls: dict[str, object] = {}
+
+    def fake_gemm(**kwargs):
+        calls.update(kwargs)
+        return torch.zeros(
+            (kwargs["size_m"], kwargs["size_n"]),
+            dtype=kwargs["a"].dtype,
+            device=kwargs["a"].device,
+        )
+
+    monkeypatch.setattr(ct, "gptq_marlin_gemm", fake_gemm)
+
+    qm.process_weights_after_loading(layer)
+    x = torch.randn(2, 2048, device="cuda", dtype=torch.bfloat16)
+    out = qm.apply(layer, x)
+
+    assert out.shape == (2, 2048)
+    assert repack_calls["perm"] is layer.g_idx_sort_indices
+    assert repack_calls["size_k"] == 2048
+    assert repack_calls["size_n"] == 2048
+    assert repack_calls["num_bits"] == 4
+    assert scale_calls["size_k"] == 2048
+    assert scale_calls["size_n"] == 2048
+    assert scale_calls["group_size"] == 32
+    assert calls["workspace"] is workspace
+    assert calls["b_zeros"] is layer.weight_zero_point
+    assert calls["g_idx"] is layer.weight_g_idx
+    assert calls["perm"] is layer.g_idx_sort_indices
+    assert calls["b_q_type_id"] == ct.SCALAR_TYPE_UINT4B8.id
+    assert calls["b_q_weight"] is layer.weight_packed


### PR DESCRIPTION
## Summary

- add compressed-tensors Marlin support for Qwen3-VL AWQ in `pymllm`
- add the missing `gptq_marlin_repack` Python JIT wrapper in `mllm-kernel`
- add kernel and runtime tests for the new quantized path
- add bilingual `pymllm` README documents for the validated Jetson Orin workflow

## Why

`Qwen3-VL-2B-Instruct-AWQ-4bit` uses `compressed-tensors`, but `pymllm + mllm-kernel` previously
did not provide a complete formal Marlin-backed path for loading and serving this model.

This PR adds the missing kernel wrapper, quantization runtime integration, config parsing fix, and
usage documentation needed for the validated Jetson Orin workflow.

## Key Changes

- register a new `compressed-tensors` quantization method in `pymllm`
- implement `CompressedTensorsConfig`, `CompressedTensorsLinearMethod`, and the Marlin-backed
weight scheme
- add `gptq_marlin_repack` to the Python JIT wrapper layer in `mllm-kernel`
- add tests for Marlin kernel wrappers and compressed-tensors runtime/config behavior
- fix quantization config loading from `config.json -> quantization_config`
- add `pymllm/README.md` and `pymllm/README-ZH.md` for the current Jetson Orin usage flow

## Testing

```bash
pytest -q \
  mllm-kernel/tests/test_gptq_marlin.py \
  mllm-kernel/tests/test_gptq_marlin_repack.py \
  pymllm/tests/test_compressed_tensors_config.py \
  pymllm/tests/test_compressed_tensors_runtime.py

Result:

- 27 passed

## Validated Configuration

Validated with:

- Qwen3-VL-2B-Instruct-AWQ-4bit
- compressed-tensors
- safetensors
- float16

## Notes

- the current implementation targets the validated compressed-tensors signature used by the target
  AWQ checkpoint
- the Jetson Orin setup is documented in pymllm/README.md and pymllm/README-ZH.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Compressed‑tensors 4‑bit GPTQ support with Marlin kernels and new repack kernel; public Python entrypoint exported
  * Timing metrics (vit_prefill_ms, llm_prefill_ms, llm_decode_ms) propagated and included in API responses
  * Multimodal message content preserved as structured parts for tokenization

* **Bug Fixes**
  * RMSNorm: added robust PyTorch fallback when FlashInfer fails
  * Quant config loading: now unwraps nested quantization_config from config.json

* **Documentation**
  * Added Jetson Orin–targeted docs (README and README‑ZH)

* **Tests**
  * New CUDA test suites for Marlin GEMM and repack, plus compressed‑tensors runtime/config tests
<!-- end of auto-generated comment: release notes by coderabbit.ai -->