### PR TITLE
Add QNN AOT support for visual graph lowering

### DIFF
--- a/mllm/backends/qnn/QNNAllocator.cpp
+++ b/mllm/backends/qnn/QNNAllocator.cpp
@@ -6,6 +6,8 @@
 #include "mllm/utils/Common.hpp"
 #include "mllm/utils/Log.hpp"
 #include <dlfcn.h>
+#include <cstdio>
+#include <sstream>
 
 namespace mllm::qnn {
 
@@ -78,7 +80,25 @@ void QNNAllocator::free(Storage* storage) {
 
 void QNNAllocator::registerQnnTensorToSharedBuffer(void* ptr, Qnn_Tensor_t& qnn_tensor) {
   // Make sure there has a memory that we can register to.
-  MLLM_RT_ASSERT(qnnMemPtrSet_.count(ptr));
+  if (!qnnMemPtrSet_.count(ptr)) {
+    std::ostringstream dims;
+    dims << "[";
+    const auto rank = QNN_TENSOR_GET_RANK(qnn_tensor);
+    const auto* shape = QNN_TENSOR_GET_DIMENSIONS(qnn_tensor);
+    for (uint32_t i = 0; i < rank; ++i) { dims << (i == 0 ? "" : ",") << shape[i]; }
+    dims << "]";
+    std::fprintf(stderr,
+                 "QNN shared-buffer register failed: tensor='%s', ptr=%p, dtype=%d, rank=%u, dims=%s is not owned by "
+                 "QNNAllocator (owned ptr count=%zu)\n",
+                 QNN_TENSOR_GET_NAME(qnn_tensor) ? QNN_TENSOR_GET_NAME(qnn_tensor) : "<null>", ptr,
+                 static_cast<int>(QNN_TENSOR_GET_DATA_TYPE(qnn_tensor)), rank, dims.str().c_str(), qnnMemPtrSet_.size());
+    std::fflush(stderr);
+    MLLM_ERROR("QNN shared-buffer register failed: tensor='{}', ptr={}, dtype={}, rank={}, dims={} is not owned by "
+               "QNNAllocator (owned ptr count={})",
+               QNN_TENSOR_GET_NAME(qnn_tensor) ? QNN_TENSOR_GET_NAME(qnn_tensor) : "<null>", ptr,
+               static_cast<int>(QNN_TENSOR_GET_DATA_TYPE(qnn_tensor)), rank, dims.str(), qnnMemPtrSet_.size());
+    MLLM_RT_ASSERT(qnnMemPtrSet_.count(ptr));
+  }
 
   // if already registered, just set the mem handle
   if (ptrToFdAndMemHandleMap_.count(ptr) > 0) {
@@ -90,7 +110,14 @@ void QNNAllocator::registerQnnTensorToSharedBuffer(void* ptr, Qnn_Tensor_t& qnn_
 
   // Get the file id of this memory space.
   int mem_fd = rpcmem_to_fd(ptr);
-  MLLM_RT_ASSERT(mem_fd != -1);
+  if (mem_fd == -1) {
+    std::fprintf(stderr, "QNN shared-buffer register failed: rpcmem_to_fd returned -1 for tensor='%s', ptr=%p\n",
+                 QNN_TENSOR_GET_NAME(qnn_tensor) ? QNN_TENSOR_GET_NAME(qnn_tensor) : "<null>", ptr);
+    std::fflush(stderr);
+    MLLM_ERROR("QNN shared-buffer register failed: rpcmem_to_fd returned -1 for tensor='{}', ptr={}",
+               QNN_TENSOR_GET_NAME(qnn_tensor) ? QNN_TENSOR_GET_NAME(qnn_tensor) : "<null>", ptr);
+    MLLM_RT_ASSERT(mem_fd != -1);
+  }
 
   // Make qnn memory descriptor. Set ION.
   Qnn_MemDescriptor_t mem_descriptor = QNN_MEM_DESCRIPTOR_INIT;
@@ -106,7 +133,24 @@ void QNNAllocator::registerQnnTensorToSharedBuffer(void* ptr, Qnn_Tensor_t& qnn_
 
   // Register to QNN memory
   Qnn_MemHandle_t mem_handle = QNN_TENSOR_GET_MEM_HANDLE(qnn_tensor);
-  MLLM_RT_ASSERT_EQ(QNN_SUCCESS, qnnInterface_.memRegister(context_, &mem_descriptor, 1u, &mem_handle));
+  Qnn_ErrorHandle_t status = qnnInterface_.memRegister(context_, &mem_descriptor, 1u, &mem_handle);
+  if (QNN_SUCCESS != status) {
+    std::ostringstream dims;
+    dims << "[";
+    const auto rank = QNN_TENSOR_GET_RANK(qnn_tensor);
+    const auto* shape = QNN_TENSOR_GET_DIMENSIONS(qnn_tensor);
+    for (uint32_t i = 0; i < rank; ++i) { dims << (i == 0 ? "" : ",") << shape[i]; }
+    dims << "]";
+    std::fprintf(stderr, "QNN memRegister failed: status=%lu, tensor='%s', ptr=%p, fd=%d, dtype=%d, rank=%u, dims=%s\n",
+                 static_cast<unsigned long>(status),
+                 QNN_TENSOR_GET_NAME(qnn_tensor) ? QNN_TENSOR_GET_NAME(qnn_tensor) : "<null>", ptr, mem_fd,
+                 static_cast<int>(QNN_TENSOR_GET_DATA_TYPE(qnn_tensor)), rank, dims.str().c_str());
+    std::fflush(stderr);
+    MLLM_ERROR("QNN memRegister failed: status={}, tensor='{}', ptr={}, fd={}, dtype={}, rank={}, dims={}", status,
+               QNN_TENSOR_GET_NAME(qnn_tensor) ? QNN_TENSOR_GET_NAME(qnn_tensor) : "<null>", ptr, mem_fd,
+               static_cast<int>(QNN_TENSOR_GET_DATA_TYPE(qnn_tensor)), rank, dims.str());
+    MLLM_RT_ASSERT_EQ(QNN_SUCCESS, status);
+  }
 
   QNN_TENSOR_SET_MEM_HANDLE(qnn_tensor, mem_handle);
 

--- a/mllm/backends/qnn/QNNBackend.cpp
+++ b/mllm/backends/qnn/QNNBackend.cpp
@@ -657,13 +657,17 @@ void QNNBackend::graphExecute(const std::string& graphName, std::vector<Tensor>&
                inputs.size(), graphName);
     return;
   }
+  if (outputs.size() != model->getGraphOutputTensorWrappers().size()) {
+    MLLM_ERROR("Output size mismatch: expected {}, got {} for graph '{}'", model->getGraphOutputTensorWrappers().size(),
+               outputs.size(), graphName);
+    return;
+  }
 
   std::vector<Qnn_Tensor_t> qnn_inputs;
   std::vector<Qnn_Tensor_t> qnn_outputs;
   // Prepare QNN inputs
   for (int i = 0; i < model->getGraphInputTensorWrappers().size(); i++) {
     auto wrapper = model->getGraphInputTensorWrappers()[i];
-    auto& wrapper_tensor = wrapper->getDataContainer();
     const auto& runtime_input = inputs[i];
 
     // Validate input tensors
@@ -672,9 +676,9 @@ void QNNBackend::graphExecute(const std::string& graphName, std::vector<Tensor>&
       return;
     }
 
-    // Case of executing retrieved graph created by AOT
-    // input wrapper is empty, set wrapper's dataContainer(mllm::Tensor)
-    if (!wrapper->isAlloc()) { wrapper->__setDataContainer(runtime_input); }
+    // Retrieved AOT graphs may be executed repeatedly with different runtime buffers
+    // in diagnostic paths. Rebind on every execution so QNN sees the current tensor.
+    wrapper->__setDataContainer(runtime_input);
 
     // Allocate and register the wrapper tensor with QNN allocator
     // QNNAllocator will handle registered memory descriptor when needed
@@ -684,7 +688,6 @@ void QNNBackend::graphExecute(const std::string& graphName, std::vector<Tensor>&
   // Prepare QNN outputs
   for (int j = 0; j < model->getGraphOutputTensorWrappers().size(); j++) {
     auto wrapper = model->getGraphOutputTensorWrappers()[j];
-    auto& wrapper_tensor = wrapper->getDataContainer();
     const auto& runtime_output = outputs[j];
 
     // Validate output tensors
@@ -693,8 +696,9 @@ void QNNBackend::graphExecute(const std::string& graphName, std::vector<Tensor>&
       return;
     }
 
-    // output wrapper is empty, set wrapper's dataContainer(mllm::Tensor)
-    if (!wrapper->isAlloc()) { wrapper->__setDataContainer(runtime_output); }
+    // Retrieved AOT graphs may be executed repeatedly with different runtime buffers
+    // in diagnostic paths. Rebind on every execution so QNN writes to the current tensor.
+    wrapper->__setDataContainer(runtime_output);
 
     // alloc and register qnn tensor
     wrapper->alloc();  // QNNAllocator will handle registered memory descriptor

--- a/mllm/backends/qnn/QNNModel.cpp
+++ b/mllm/backends/qnn/QNNModel.cpp
@@ -3,11 +3,33 @@
 
 #include "mllm/backends/qnn/QNNModel.hpp"
 #include <cassert>
+#include <cstdlib>
+#include <sstream>
 #include "mllm/backends/qnn/QNNTypeMacros.hpp"
 #include "mllm/backends/qnn/QNNUtils.hpp"
 #include "mllm/utils/Log.hpp"
 
 namespace mllm::qnn {
+
+namespace {
+
+bool shouldDumpQnnIO() {
+  const char* flag = std::getenv("MLLM_QNN_DUMP_IO");
+  return flag != nullptr && std::string(flag) != "0";
+}
+
+std::string dimsToString(const std::vector<uint32_t>& dims) {
+  std::ostringstream oss;
+  oss << "[";
+  for (size_t i = 0; i < dims.size(); ++i) {
+    if (i > 0) { oss << ", "; }
+    oss << dims[i];
+  }
+  oss << "]";
+  return oss.str();
+}
+
+}  // namespace
 
 template<typename... Args>
 void freeMultiPtr(Args... args) {
@@ -112,6 +134,11 @@ ModelError_t QNNModel::loadGraphTensorInfo(const Qnn_Tensor_t* inputTensors, uin
 
     inputTensorWrappers_.push_back(wrapper);
     tensorWrapperMap_[tensorName] = wrapper;
+
+    if (shouldDumpQnnIO()) {
+      MLLM_INFO("QNN graph {} input[{}]: name='{}', dtype={}, dims={}", graphName_, i, tensorName,
+                static_cast<int>(QNN_TENSOR_GET_DATA_TYPE(tensor)), dimsToString(dimensions));
+    }
   }
 
   // Create wrappers for output tensors
@@ -134,6 +161,11 @@ ModelError_t QNNModel::loadGraphTensorInfo(const Qnn_Tensor_t* inputTensors, uin
 
     outputTensorWrappers_.push_back(wrapper);
     tensorWrapperMap_[tensorName] = wrapper;
+
+    if (shouldDumpQnnIO()) {
+      MLLM_INFO("QNN graph {} output[{}]: name='{}', dtype={}, dims={}", graphName_, i, tensorName,
+                static_cast<int>(QNN_TENSOR_GET_DATA_TYPE(tensor)), dimsToString(dimensions));
+    }
   }
 
   MLLM_INFO("QNNModel::loadGraphTensorInfo() loaded {} input tensors and {} output tensors for graph: {}", numInputTensors,

--- a/mllm/backends/qnn/QNNUtils.hpp
+++ b/mllm/backends/qnn/QNNUtils.hpp
@@ -209,9 +209,8 @@ class QNNTensorWrapper {
 
   bool isAlloc() { return isAlloc_; }
   void __setDataContainer(const Tensor& tensor) {
-    MLLM_RT_ASSERT(dataContainer_.isNil())
     dataContainer_ = tensor;
-    if (!tensor.isNil()) { isAlloc_ = true; }
+    isAlloc_ = !tensor.isNil();
   }
 
   // Helper to set complex quantization params and manage memory

--- a/mllm/backends/qnn/aot/QnnWrappersAPI.cpp
+++ b/mllm/backends/qnn/aot/QnnWrappersAPI.cpp
@@ -23,9 +23,18 @@
 
 namespace mllm::qnn::aot {
 
+namespace {
+
+std::string qnnTensorNameFromIR(const ir::tensor::TensorValue::ptr_t& v) {
+  if (v && v->hasSymbolAttr()) { return v->getSymbolAttr()->str(); }
+  return v ? v->name() : "";
+}
+
+}  // namespace
+
 QnnAOTNodeTensor::QnnAOTNodeTensor(const ir::tensor::TensorValue::ptr_t& v, bool force_static_weight) {
   auto type = parseQnnTensorTypeFromIR(v);
-  auto name = v->name();
+  auto name = parseQnnTensorNameFromIR(v);
   auto quant = parseQnnQuantizeParamFromIR(v);
 
   if (force_static_weight || type == QNN_TENSOR_TYPE_STATIC) {
@@ -103,7 +112,9 @@ Qnn_DataType_t QnnAOTNodeTensor::parseQnnDataTypeFromIR(const ir::tensor::Tensor
   return mllm::qnn::mllmDataTypeToQnnDataType(v->tensor_.dtype());
 }
 
-std::string QnnAOTNodeTensor::parseQnnTensorNameFromIR(const ir::tensor::TensorValue::ptr_t& v) { return v->name(); }
+std::string QnnAOTNodeTensor::parseQnnTensorNameFromIR(const ir::tensor::TensorValue::ptr_t& v) {
+  return qnnTensorNameFromIR(v);
+}
 
 Qnn_QuantizeParams_t QnnAOTNodeTensor::parseQnnQuantizeParamFromIR(const ir::tensor::TensorValue::ptr_t& v) {
   Qnn_QuantizeParams_t ret = QNN_QUANTIZE_PARAMS_INIT;
@@ -139,10 +150,30 @@ Qnn_QuantizeParams_t QnnAOTNodeTensor::parseQnnQuantizeParamFromIR(const ir::ten
         MLLM_ERROR_EXIT(ExitCode::kCoreError, "SymPerTensor quant recipe has no scale. tensor: {}", v->name());
       }
 
-      MLLM_RT_ASSERT_EQ(cfg->quant_to_type, kUInt8);
+      int32_t offset = 0;
+      switch (cfg->quant_to_type) {
+        case kUInt8: {
+          offset = -128;
+          break;
+        }
+        case kUInt16: {
+          offset = -32768;
+          break;
+        }
+        case kInt8:
+        case kInt16: {
+          offset = 0;
+          break;
+        }
+        default: {
+          MLLM_ERROR_EXIT(ExitCode::kCoreError, "Unsupported SymPerTensor quant target type {} for tensor: {}",
+                          nameOfType(cfg->quant_to_type), v->name());
+        }
+      }
 
-      ret.scaleOffsetEncoding = Qnn_ScaleOffset_t{.scale = cfg->scale.item<float>(), .offset = -128};
-      MLLM_INFO("Configuring SymPerTensor quantization for tensor: {}, scale: {}", v->name(), cfg->scale.item<float>());
+      ret.scaleOffsetEncoding = Qnn_ScaleOffset_t{.scale = cfg->scale.item<float>(), .offset = offset};
+      MLLM_INFO("Configuring SymPerTensor quantization for tensor: {}, scale: {}, offset: {}", v->name(),
+                cfg->scale.item<float>(), offset);
       break;
     }
     default: {
@@ -335,8 +366,13 @@ void QnnAOTGraph::addOperation(const QnnAOTNodeOperation::ptr_t& qnn_op) {
   for (auto& in : qnn_op->inputs) qnn_model_->addTensorWrapper(in->getWrapper());
   for (auto& out : qnn_op->outputs) qnn_model_->addTensorWrapper(out->getWrapper());
 
-  qnn_model_->addNode(QNN_OPCONFIG_VERSION_1, qnn_op->name_, qnn_op->package_name_, qnn_op->op_name_, qnn_op->param_tensor,
-                      qnn_op->param_scalar, inputNames, outputNames);
+  auto add_node_status =
+      qnn_model_->addNode(QNN_OPCONFIG_VERSION_1, qnn_op->name_, qnn_op->package_name_, qnn_op->op_name_,
+                          qnn_op->param_tensor, qnn_op->param_scalar, inputNames, outputNames);
+  if (add_node_status != mllm::qnn::MODEL_NO_ERROR) {
+    MLLM_ERROR_EXIT(ExitCode::kCoreError, "QNN AOT failed to add node {} (op type {}) to graph.", qnn_op->name_,
+                    qnn_op->op_name_);
+  }
 
   op_node_.insert({qnn_op->getName(), qnn_op});
 }
@@ -686,7 +722,7 @@ void QnnAOTEnv::captureAOTNodeOp(const std::string& qnn_context_name, const std:
 
 QnnAOTNodeTensor::ptr_t QnnAOTEnv::captureQnnAOTNodeTensor(const std::string& qnn_context_name, const std::string& graph_name,
                                                            const ir::tensor::TensorValue::ptr_t& v, bool force_static_weight) {
-  auto __qnn_tensor_name = v->name();
+  auto __qnn_tensor_name = qnnTensorNameFromIR(v);
 
   bool __qnn_enable_static_weight = force_static_weight;
 

--- a/mllm/backends/qnn/aot/passes/AOTPipeline.cpp
+++ b/mllm/backends/qnn/aot/passes/AOTPipeline.cpp
@@ -37,4 +37,22 @@ std::vector<std::shared_ptr<ir::Pass>> createQnnAOTLoweringPipeline(QnnAOTEnv* e
 
   return ret;
 }
+
+std::vector<std::shared_ptr<ir::Pass>> createQnnAOTSimpleLoweringPipeline(QnnAOTEnv* env, const std::string& config_path,
+                                                                          const ParameterFile::ptr_t& pf,
+                                                                          const std::string& qnn_graph_name) {
+  std::vector<ir::Pass::ptr_t> ret;
+
+  AOTCompileContext::getInstance().setEnv(env);
+  AOTCompileContext::getInstance().setConfig(config_path);
+  AOTCompileContext::getInstance().setParamFile(pf);
+
+  ret.emplace_back(createMarkQnnGraphPass());
+  ret.emplace_back(createOpNamingPass());
+  ret.emplace_back(createLLMQuantRecipePass());
+  ret.emplace_back(createPTQPass());
+  ret.emplace_back(createLLM2QnnLoweringPass(qnn_graph_name));
+
+  return ret;
+}
 }  // namespace mllm::qnn::aot

--- a/mllm/backends/qnn/aot/passes/AOTPipeline.hpp
+++ b/mllm/backends/qnn/aot/passes/AOTPipeline.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <string>
 #include <vector>
 
 #include "mllm/backends/qnn/aot/QnnWrappersAPI.hpp"
@@ -13,5 +14,9 @@ namespace mllm::qnn::aot {
 
 std::vector<std::shared_ptr<ir::Pass>> createQnnAOTLoweringPipeline(QnnAOTEnv* env, const std::string& config_path,
                                                                     const ParameterFile::ptr_t& pf);
+
+std::vector<std::shared_ptr<ir::Pass>> createQnnAOTSimpleLoweringPipeline(QnnAOTEnv* env, const std::string& config_path,
+                                                                          const ParameterFile::ptr_t& pf,
+                                                                          const std::string& qnn_graph_name = "");
 
 }  // namespace mllm::qnn::aot

--- a/mllm/backends/qnn/aot/passes/LLM2QnnLoweringPass.cpp
+++ b/mllm/backends/qnn/aot/passes/LLM2QnnLoweringPass.cpp
@@ -1,7 +1,9 @@
 // Copyright (c) MLLM Team.
 // Licensed under the MIT License.
 
+#include <functional>
 #include <regex>
+#include <utility>
 
 #include "mllm/backends/qnn/aot/passes/LLM2QnnLoweringPass.hpp"
 #include "mllm/backends/qnn/aot/passes/AOTCompileContext.hpp"
@@ -16,9 +18,11 @@
 #include "mllm/backends/qnn/aot/visitor/Elewise.hpp"
 #include "mllm/backends/qnn/aot/visitor/Embedding.hpp"
 #include "mllm/backends/qnn/aot/visitor/Gather.hpp"
+#include "mllm/backends/qnn/aot/visitor/GELU.hpp"
 #include "mllm/backends/qnn/aot/visitor/CastType.hpp"
 #include "mllm/backends/qnn/aot/visitor/View.hpp"
 #include "mllm/backends/qnn/aot/visitor/Index.hpp"
+#include "mllm/backends/qnn/aot/visitor/LayerNorm.hpp"
 #include "mllm/backends/qnn/aot/visitor/RMSNorm.hpp"
 #include "mllm/backends/qnn/aot/visitor/Linear.hpp"
 #include "mllm/backends/qnn/aot/visitor/Concat.hpp"
@@ -34,12 +38,18 @@
 
 namespace mllm::qnn::aot {
 
-LLM2QnnLoweringPass::LLM2QnnLoweringPass() {
+namespace {
+
+}  // namespace
+
+LLM2QnnLoweringPass::LLM2QnnLoweringPass(std::string simple_qnn_graph_name)
+    : simple_qnn_graph_name_(std::move(simple_qnn_graph_name)) {
   registerPatterns<QnnAOTEmbeddingPattern, QnnAOTCastTypePattern, QnnAOTAddPattern, QnnAOTMulPattern, QnnAOTNegPattern,
                    QnnAOTViewPattern, QnnAOTIndexPattern, QnnAOTGatherPattern, QnnAOTRMSNormPattern, QnnAOTLinearPattern,
                    QnnAOTTransposePattern, QnnAOTSlicePattern, QnnAOTConcatPattern, QnnAOTRepeatPattern, QnnAOTMatMulPattern,
                    QnnAOTReduceMaxPattern, QnnAOTReduceMinPattern, QnnAOTReduceMeanPattern, QnnAOTReduceSumPattern,
-                   QnnAOTEqualPattern, QnnAOTWherePattern, QnnAOTSoftmaxPattern, QnnAOTSigmoidPattern, QnnAOTConv2DPattern>();
+                   QnnAOTEqualPattern, QnnAOTWherePattern, QnnAOTSoftmaxPattern, QnnAOTSigmoidPattern, QnnAOTConv2DPattern,
+                   QnnAOTGELUPattern, QnnAOTLayerNormPattern>();
 }
 
 uint8_t LLM2QnnLoweringPass::run(const ir::node_ptr_t& op) {
@@ -66,8 +76,12 @@ uint8_t LLM2QnnLoweringPass::run(const ir::node_ptr_t& op) {
   // Check call graph op point to a subgraph named "model"
   auto symbol_attr = call_graph_op->getSymbolAttr();
   if (symbol_attr == nullptr || symbol_attr->str() != "model") {
-    MLLM_ERROR("LLM2QnnLoweringPass: CallGraphOp should point to a subgraph named 'model'");
-    return ir::PASS_RET_FAILURE;
+    if (simple_qnn_graph_name_.empty()) {
+      MLLM_ERROR("LLM2QnnLoweringPass: CallGraphOp should point to a subgraph named 'model'");
+      return ir::PASS_RET_FAILURE;
+    }
+    auto root_name = symbol_attr ? symbol_attr->str() : "";
+    return runSimpleGraph(op, root_name, simple_qnn_graph_name_);
   }
 
   // Get the "model" subgraph
@@ -191,6 +205,101 @@ uint8_t LLM2QnnLoweringPass::run(const ir::node_ptr_t& op) {
   return ir::PASS_RET_SUCCESS;
 }
 
-ir::Pass::ptr_t createLLM2QnnLoweringPass() { return std::make_shared<LLM2QnnLoweringPass>(); }
+uint8_t LLM2QnnLoweringPass::runSimpleGraph(const ir::node_ptr_t& op, const std::string& root_graph_name,
+                                            const std::string& qnn_graph_name) {
+  MLLM_RT_ASSERT(op->isa_<ir::ModuleOp>());
+  if (root_graph_name.empty()) {
+    MLLM_ERROR("LLM2QnnLoweringPass: simple graph root name is empty");
+    return ir::PASS_RET_FAILURE;
+  }
+
+  auto root_ir = getCtx()->lookupSymbolTable(root_graph_name);
+  if (!root_ir || !root_ir->isa_<ir::graph::SubGraphOp>()) {
+    MLLM_ERROR("LLM2QnnLoweringPass: Cannot find simple root graph {}", root_graph_name);
+    return ir::PASS_RET_FAILURE;
+  }
+
+  auto root_graph = root_ir->cast_<ir::graph::SubGraphOp>();
+  auto aot_cfg = AOTCompileContext::getInstance().getConfig();
+  auto aot_env = AOTCompileContext::getInstance().getEnv();
+
+  int split_graph = aot_cfg.value("split_graph", 1);
+  MLLM_RT_ASSERT_EQ(split_graph, 1);
+  aot_env->createContext("context.0", true);
+  auto aot_graph = aot_env->captureAOTGraph("context.0", qnn_graph_name);
+
+  for (auto& input : root_graph->getTopRegion()->inputs()) {
+    auto tensor_input = input->cast_<ir::tensor::TensorValue>();
+    if (tensor_input) {
+      tensor_input->setAttr("qnn_graph_inputs", getCtx()->create<ir::BoolAttr>(true));
+      aot_env->captureQnnAOTNodeTensor("context.0", qnn_graph_name, tensor_input);
+    }
+  }
+  for (auto& output : root_graph->getTopRegion()->outputs()) {
+    auto tensor_output = output->cast_<ir::tensor::TensorValue>();
+    if (tensor_output) {
+      tensor_output->setAttr("qnn_graph_outputs", getCtx()->create<ir::BoolAttr>(true));
+      aot_env->captureQnnAOTNodeTensor("context.0", qnn_graph_name, tensor_output);
+    }
+  }
+
+  std::function<void(ir::graph::SubGraphOp::ptr_t)> lower_subgraph_inline;
+  lower_subgraph_inline = [&](ir::graph::SubGraphOp::ptr_t subgraph) {
+    auto region = subgraph->getTopRegion();
+    if (!region) { return; }
+
+    auto subgraph_writer = ir::IRWriter(getCtx(), region);
+    subgraph_writer.walk<ir::Op>(
+        [&](ir::IRWriter& this_tough_writer, const ir::Op::ptr_t& some_op) -> ir::IRWriter::WalkResult {
+          if (some_op->isa_<ir::graph::CallGraphOp>()) {
+            auto call_op = some_op->cast_<ir::graph::CallGraphOp>();
+            auto called = getCtx()->lookupSymbolTable(call_op->getSymbolAttr()->str());
+            if (!called || !called->isa_<ir::graph::SubGraphOp>()) {
+              MLLM_ERROR_EXIT(ExitCode::kCoreError, "Cannot find called subgraph {}", call_op->getSymbolAttr()->str());
+            }
+            lower_subgraph_inline(called->cast_<ir::graph::SubGraphOp>());
+            return ir::IRWriter::WalkResult::WALK_CONTINUE;
+          }
+
+          if (!some_op->isa_<ir::linalg::LinalgIROp>()) { return ir::IRWriter::WalkResult::WALK_CONTINUE; }
+
+          auto linalg_op = some_op->cast_<ir::linalg::LinalgIROp>();
+          if (!linalg_op->getAttr("using_qnn")) {
+            MLLM_WARN("Found non-qnn op: {} in graph: {}", linalg_op->getAOp()->getName(), qnn_graph_name);
+            return ir::IRWriter::WalkResult::WALK_BREAK;
+          }
+
+          linalg_op->setAttr("qnn_context_name", getCtx()->create<ir::StrAttr>("context.0"));
+          linalg_op->setAttr("qnn_graph_name", getCtx()->create<ir::StrAttr>(qnn_graph_name));
+
+          bool processed = false;
+          for (auto& [op_type, pass] : named_pattern_) {
+            if (pass->isMatch(linalg_op)) {
+              if (!pass->rewrite(this_tough_writer, linalg_op)) {
+                MLLM_ERROR_EXIT(ExitCode::kCoreError, "Failed when processing op {} with pass {}",
+                                linalg_op->getAOp()->getName(), optype2Str(op_type));
+              }
+              processed = true;
+              break;
+            }
+          }
+
+          if (!processed) {
+            MLLM_ERROR_EXIT(ExitCode::kCoreError, "Failed processing op {} on all passes", linalg_op->getAOp()->getName());
+          }
+
+          return ir::IRWriter::WALK_CONTINUE;
+        });
+  };
+
+  lower_subgraph_inline(root_graph);
+
+  MLLM_RT_ASSERT(aot_graph->compile());
+  return ir::PASS_RET_SUCCESS;
+}
+
+ir::Pass::ptr_t createLLM2QnnLoweringPass(std::string simple_qnn_graph_name) {
+  return std::make_shared<LLM2QnnLoweringPass>(std::move(simple_qnn_graph_name));
+}
 
 }  // namespace mllm::qnn::aot

--- a/mllm/backends/qnn/aot/passes/LLM2QnnLoweringPass.hpp
+++ b/mllm/backends/qnn/aot/passes/LLM2QnnLoweringPass.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <string>
 #include <unordered_map>
 
 #include "mllm/core/OpTypes.hpp"
@@ -15,11 +16,13 @@ namespace mllm::qnn::aot {
 
 class LLM2QnnLoweringPass final : public ir::Pass {
  public:
-  LLM2QnnLoweringPass();
+  explicit LLM2QnnLoweringPass(std::string simple_qnn_graph_name = "");
 
   ~LLM2QnnLoweringPass() override = default;
 
   uint8_t run(const ir::node_ptr_t& op) override;
+
+  uint8_t runSimpleGraph(const ir::node_ptr_t& op, const std::string& root_graph_name, const std::string& qnn_graph_name);
 
  private:
   template<typename... Patterns>
@@ -29,8 +32,9 @@ class LLM2QnnLoweringPass final : public ir::Pass {
 
   std::unordered_map<OpTypes, std::shared_ptr<QnnAOTBasePattern>> named_pattern_;
   std::unordered_map<std::string, ir::graph::SubGraphOp::ptr_t> subgraph_map_;
+  std::string simple_qnn_graph_name_;
 };
 
-ir::Pass::ptr_t createLLM2QnnLoweringPass();
+ir::Pass::ptr_t createLLM2QnnLoweringPass(std::string simple_qnn_graph_name = "");
 
 }  // namespace mllm::qnn::aot

--- a/mllm/backends/qnn/aot/passes/LLMQuantRecipePass.cpp
+++ b/mllm/backends/qnn/aot/passes/LLMQuantRecipePass.cpp
@@ -14,6 +14,8 @@
 #include "mllm/compile/ir/linalg/Attribute.hpp"
 #include "mllm/backends/qnn/aot/passes/AOTCompileContext.hpp"
 #include "mllm/backends/qnn/aot/passes/LLMQuantRecipePass.hpp"
+#include "mllm/core/aops/LayerNormOp.hpp"
+#include "mllm/core/aops/LinearOp.hpp"
 
 namespace mllm::qnn::aot {
 
@@ -500,6 +502,58 @@ bool LLMQuantRecipeRMSNormPattern::rewrite(ir::IRWriter& writer, const ir::op_pt
 }
 
 //===----------------------------------------------------------------------===//
+// LayerNorm Pattern
+//===----------------------------------------------------------------------===//
+bool LLMQuantRecipeLayerNormPattern::isMatch(const mllm::ir::op_ptr_t& op) {
+  if (op->isa_<ir::linalg::LayerNormOp>()) { return true; }
+  return false;
+}
+
+bool LLMQuantRecipeLayerNormPattern::rewrite(ir::IRWriter& writer, const ir::op_ptr_t& node) {
+  auto ret = noSharingSingleInAndSingleOutQuantAnnoAttr(writer.getContext(), node->cast_<ir::linalg::LinalgIROp>());
+  if (!ret) return false;
+
+  auto layer_norm_ir = node->cast_<ir::linalg::LayerNormOp>();
+  auto layer_norm_aop = dynamic_cast<mllm::aops::LayerNormOp*>(layer_norm_ir->getAOp());
+  MLLM_RETURN_FALSE_IF_NOT(layer_norm_aop);
+
+  auto annotation_attr =
+      node->getAttr("quant_recipe")->cast_<ir::linalg::LinalgIRQuantizatonAnnotationAttr>();
+
+  auto add_raw_weight_recipe = [&](const std::string& suffix) -> bool {
+    auto reg_tensor_ir = writer.getContext()->lookupSymbolTable(layer_norm_ir->getAOp()->getName() + suffix);
+    MLLM_RETURN_FALSE_IF_NOT(reg_tensor_ir);
+    MLLM_RETURN_FALSE_IF_NOT(reg_tensor_ir->isa_<ir::tensor::RegisterOp>());
+    MLLM_RETURN_FALSE_IF_NOT(reg_tensor_ir->outputs().front()->isa_<ir::tensor::TensorValue>());
+
+    auto t = reg_tensor_ir->outputs().front()->cast_<ir::tensor::TensorValue>();
+    auto weight_spec_attr = writer.create<ir::linalg::LinalgIRQuantizatonSpecAttr>(
+        ir::linalg::QuantizationSpecRaw::create(t->tensor_.dtype()));
+    t->setAttr("quant_recipe", weight_spec_attr);
+    annotation_attr->annotation_.weights.insert({suffix.substr(1), weight_spec_attr->spec_});
+
+    return true;
+  };
+
+  if (layer_norm_aop->options().elementwise_affine && !add_raw_weight_recipe(".weight")) { return false; }
+  if (layer_norm_aop->options().bias && !add_raw_weight_recipe(".bias")) { return false; }
+
+  return true;
+}
+
+//===----------------------------------------------------------------------===//
+// GELU Pattern
+//===----------------------------------------------------------------------===//
+bool LLMQuantRecipeGELUPattern::isMatch(const mllm::ir::op_ptr_t& op) {
+  if (op->isa_<ir::linalg::GELUOp>()) { return true; }
+  return false;
+}
+
+bool LLMQuantRecipeGELUPattern::rewrite(ir::IRWriter& writer, const ir::op_ptr_t& node) {
+  return noSharingSingleInAndSingleOutQuantAnnoAttr(writer.getContext(), node->cast_<ir::linalg::LinalgIROp>());
+}
+
+//===----------------------------------------------------------------------===//
 // SiLU Pattern
 //===----------------------------------------------------------------------===//
 bool LLMQuantRecipeSiLUPattern::isMatch(const mllm::ir::op_ptr_t& op) {
@@ -609,9 +663,7 @@ bool LLMQuantRecipeElementwisePattern::rewrite(ir::IRWriter& writer, const ir::o
                                              i_0->getAttr("quant_recipe")->cast_<ir::linalg::LinalgIRQuantizatonSpecAttr>()));
 
     } else {
-      MLLM_WARN("LLMQuantRecipeEqualPattern Only support constant Value as second inputs right now. Pls send us a issue or PR "
-                "if you want to compare two normal tensor(rather than static-tensor).");
-      return false;
+      i_1->setAttr("quant_recipe", genSimpleQuantizationSpecAttr(writer.getContext(), i_1->cast_<ir::tensor::TensorValue>()));
     }
   }
 
@@ -899,7 +951,26 @@ bool LLMQuantRecipeLinearPattern::rewrite(ir::IRWriter& writer, const ir::op_ptr
     auto input_spec = linear_ir->inputs().front()->getAttr("quant_recipe")->cast_<ir::linalg::LinalgIRQuantizatonSpecAttr>();
     annotation_attr->annotation_.inputs.emplace_back(input_spec->spec_);
 
-    if (use_config["method"] == "LPBQ") {
+    auto weight_name = linear_ir->getAOp()->getName() + ".weight";
+    auto weight_reg_tensor_ir = writer.getContext()->lookupSymbolTable(weight_name);
+    MLLM_RETURN_FALSE_IF_NOT(weight_reg_tensor_ir);
+    MLLM_RETURN_FALSE_IF_NOT(weight_reg_tensor_ir->isa_<ir::tensor::RegisterOp>());
+    MLLM_RETURN_FALSE_IF_NOT(weight_reg_tensor_ir->outputs().front()->isa_<ir::tensor::TensorValue>());
+    auto weight_tensor = weight_reg_tensor_ir->outputs().front()->cast_<ir::tensor::TensorValue>();
+
+    const bool allow_raw_float_linear = use_config.value("allow_raw_float_linear", false);
+    const bool float_weight = weight_tensor->tensor_.dtype() == kFloat32 || weight_tensor->tensor_.dtype() == kFloat16
+                              || weight_tensor->tensor_.dtype() == kBFloat16;
+
+    if (allow_raw_float_linear && float_weight) {
+      auto weight_quant_spec = ir::linalg::QuantizationSpecRaw::create(weight_tensor->tensor_.dtype());
+      weight_tensor->setAttr("quant_recipe", writer.create<ir::linalg::LinalgIRQuantizatonSpecAttr>(weight_quant_spec));
+      annotation_attr->annotation_.weights.insert({"weight", weight_quant_spec});
+
+      auto out_quant_spec = ir::linalg::QuantizationSpecRaw::create(linear_ir->outputs().front()->cast_<ir::tensor::TensorValue>()->tensor_.dtype());
+      linear_ir->outputs().front()->setAttr("quant_recipe", writer.create<ir::linalg::LinalgIRQuantizatonSpecAttr>(out_quant_spec));
+      annotation_attr->annotation_.outputs.emplace_back(out_quant_spec);
+    } else if (use_config["method"] == "LPBQ") {
       // Unpack
       std::string precision = use_config["precision"];
       bool sym = use_config["sym"];
@@ -922,16 +993,24 @@ bool LLMQuantRecipeLinearPattern::rewrite(ir::IRWriter& writer, const ir::op_ptr
         annotation_attr->annotation_.weights.insert({"weight", weight_quant_spec});
       }
 
-      auto weight_name = linear_ir->getAOp()->getName() + ".weight";
-      auto weight_reg_tensor_ir = writer.getContext()->lookupSymbolTable(weight_name);
-      MLLM_RETURN_FALSE_IF_NOT(weight_reg_tensor_ir);
-      MLLM_RETURN_FALSE_IF_NOT(weight_reg_tensor_ir->isa_<ir::tensor::RegisterOp>());
-      MLLM_RETURN_FALSE_IF_NOT(weight_reg_tensor_ir->outputs().front()->isa_<ir::tensor::TensorValue>());
-      auto t = weight_reg_tensor_ir->outputs().front()->cast_<ir::tensor::TensorValue>();
-      t->setAttr("quant_recipe", writer.create<ir::linalg::LinalgIRQuantizatonSpecAttr>(weight_quant_spec));
+      weight_tensor->setAttr("quant_recipe", writer.create<ir::linalg::LinalgIRQuantizatonSpecAttr>(weight_quant_spec));
     } else {
       std::string s = use_config["method"];
       MLLM_WARN("Currently not support method: {}", s);
+    }
+
+    auto real_linear_op = dynamic_cast<mllm::aops::LinearOp*>(linear_ir->getAOp());
+    if (real_linear_op && real_linear_op->options().bias) {
+      auto bias_name = linear_ir->getAOp()->getName() + ".bias";
+      auto bias_reg_tensor_ir = writer.getContext()->lookupSymbolTable(bias_name);
+      if (bias_reg_tensor_ir) {
+        MLLM_RETURN_FALSE_IF_NOT(bias_reg_tensor_ir->isa_<ir::tensor::RegisterOp>());
+        MLLM_RETURN_FALSE_IF_NOT(bias_reg_tensor_ir->outputs().front()->isa_<ir::tensor::TensorValue>());
+        auto bias_tensor = bias_reg_tensor_ir->outputs().front()->cast_<ir::tensor::TensorValue>();
+        auto bias_quant_spec = ir::linalg::QuantizationSpecRaw::create(bias_tensor->tensor_.dtype());
+        bias_tensor->setAttr("quant_recipe", writer.create<ir::linalg::LinalgIRQuantizatonSpecAttr>(bias_quant_spec));
+        annotation_attr->annotation_.weights.insert({"bias", bias_quant_spec});
+      }
     }
 
     linear_ir->setAttr("quant_recipe", annotation_attr);
@@ -1116,6 +1195,8 @@ LLMQuantRecipePass::LLMQuantRecipePass() {
   addPattern(LLMQuantRecipeRoPEPattern::create(), "rope", 0);
   addPattern(LLMQuantRecipeCastTypePattern::create(), "cast_type", 0);
   addPattern(LLMQuantRecipeRMSNormPattern::create(), "rms_norm", 0);
+  addPattern(LLMQuantRecipeLayerNormPattern::create(), "layer_norm", 0);
+  addPattern(LLMQuantRecipeGELUPattern::create(), "gelu", 0);
   addPattern(LLMQuantRecipeSiLUPattern::create(), "silu", 0);
   addPattern(LLMQuantRecipeIndexPattern::create(), "index", 0);
   addPattern(LLMQuantRecipeElementwisePattern::create(), "elementwise", 0);

--- a/mllm/backends/qnn/aot/passes/LLMQuantRecipePass.hpp
+++ b/mllm/backends/qnn/aot/passes/LLMQuantRecipePass.hpp
@@ -127,6 +127,34 @@ class LLMQuantRecipeRMSNormPattern : public ir::Pattern {
 };
 
 //===----------------------------------------------------------------------===//
+// LayerNorm Pattern
+//===----------------------------------------------------------------------===//
+class LLMQuantRecipeLayerNormPattern : public ir::Pattern {
+ public:
+  bool isMatch(const mllm::ir::op_ptr_t& op) override;
+
+  bool rewrite(ir::IRWriter& writer, const ir::op_ptr_t& node) override;
+
+  static inline std::shared_ptr<LLMQuantRecipeLayerNormPattern> create() {
+    return std::make_shared<LLMQuantRecipeLayerNormPattern>();
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// GELU Pattern
+//===----------------------------------------------------------------------===//
+class LLMQuantRecipeGELUPattern : public ir::Pattern {
+ public:
+  bool isMatch(const mllm::ir::op_ptr_t& op) override;
+
+  bool rewrite(ir::IRWriter& writer, const ir::op_ptr_t& node) override;
+
+  static inline std::shared_ptr<LLMQuantRecipeGELUPattern> create() {
+    return std::make_shared<LLMQuantRecipeGELUPattern>();
+  }
+};
+
+//===----------------------------------------------------------------------===//
 // SiLU Pattern
 //===----------------------------------------------------------------------===//
 class LLMQuantRecipeSiLUPattern : public ir::Pattern {

--- a/mllm/backends/qnn/aot/passes/PTQPass.cpp
+++ b/mllm/backends/qnn/aot/passes/PTQPass.cpp
@@ -33,31 +33,38 @@ void checkTypeLimits(Tensor in, int quant_min, int quant_max) {  // NOLINT
 void solveLinearWeight(const ir::IRContext::ptr_t& ctx, const ParameterFile::ptr_t& pf,
                        const ir::linalg::LinalgIROp::ptr_t& op) {
   auto mllm_op = op->getAOp();
-  MLLM_INFO("PTQPass working on Op: {}'s weight", mllm_op->getName());
-  auto weight_spec =
-      op->getAttr("quant_recipe")->cast_<ir::linalg::LinalgIRQuantizatonAnnotationAttr>()->annotation_.weights.at("weight");
+  MLLM_INFO("PTQPass working on Op: {}'s linear weights", mllm_op->getName());
+  auto annotation =
+      op->getAttr("quant_recipe")->cast_<ir::linalg::LinalgIRQuantizatonAnnotationAttr>()->annotation_;
 
-  if (weight_spec->solved) return;
+  for (const auto& [name, weight_spec] : annotation.weights) {
+    if (weight_spec->solved) continue;
 
-  switch (weight_spec->type) {
-    case ir::linalg::QuantizationSpecType::kLPBQ: {
-      auto this_spec = std::static_pointer_cast<ir::linalg::QuantizationSpecLPBQ>(weight_spec);
-      auto scale1 = pf->pull(mllm_op->getName() + ".scale1");  // using uint8 to store uint4
-      auto scale2 = pf->pull(mllm_op->getName() + ".scale2");
-      auto weight = pf->pull(mllm_op->getName() + ".weight");
+    switch (weight_spec->type) {
+      case ir::linalg::QuantizationSpecType::kRaw: {
+        weight_spec->solved = true;
+        break;
+      }
+      case ir::linalg::QuantizationSpecType::kLPBQ: {
+        if (name != "weight") { NYI("LPBQ quant recipe only supports Linear weight, got '{}'.", name); }
+        auto this_spec = std::static_pointer_cast<ir::linalg::QuantizationSpecLPBQ>(weight_spec);
+        auto scale1 = pf->pull(mllm_op->getName() + ".scale1");  // using uint8 to store uint4
+        auto scale2 = pf->pull(mllm_op->getName() + ".scale2");
+        auto weight = pf->pull(mllm_op->getName() + ".weight");
 
-      // FIXME weight maybe error, Check qnn eats int8 or uint8. Here weight using int8 to store int4.
-      checkTypeLimits<int8_t>(weight, 0, 15);   // Int4
-      checkTypeLimits<uint8_t>(scale1, 0, 16);  // UInt4
+        // FIXME weight maybe error, Check qnn eats int8 or uint8. Here weight using int8 to store int4.
+        checkTypeLimits<int8_t>(weight, 0, 15);   // Int4
+        checkTypeLimits<uint8_t>(scale1, 0, 16);  // UInt4
 
-      this_spec->scale_level_0_int = scale1;
-      this_spec->scale_level_1_fp = scale2;
+        this_spec->scale_level_0_int = scale1;
+        this_spec->scale_level_1_fp = scale2;
 
-      weight_spec->solved = true;
-      break;
-    }
-    default: {
-      NYI("quant recipe type not support");
+        weight_spec->solved = true;
+        break;
+      }
+      default: {
+        NYI("quant recipe type not support");
+      }
     }
   }
 }
@@ -94,6 +101,28 @@ void solveRMSNormWeight(const ir::IRContext::ptr_t& ctx, const ParameterFile::pt
     }
     default: {
       NYI("quant recipe type not support");
+    }
+  }
+}
+
+void solveLayerNormWeights(const ir::IRContext::ptr_t& ctx, const ParameterFile::ptr_t& pf,
+                           const ir::linalg::LinalgIROp::ptr_t& op) {
+  auto mllm_op = op->getAOp();
+  MLLM_INFO("PTQPass working on Op: {}'s layernorm weights", mllm_op->getName());
+  auto annotation =
+      op->getAttr("quant_recipe")->cast_<ir::linalg::LinalgIRQuantizatonAnnotationAttr>()->annotation_;
+
+  for (const auto& [name, weight_spec] : annotation.weights) {
+    if (weight_spec->solved) continue;
+
+    switch (weight_spec->type) {
+      case ir::linalg::QuantizationSpecType::kRaw: {
+        weight_spec->solved = true;
+        break;
+      }
+      default: {
+        NYI("LayerNorm weight '{}' only supports raw quant recipe for now.", name);
+      }
     }
   }
 }
@@ -144,6 +173,9 @@ void recursiveSolveWeights(const std::shared_ptr<ir::IRContext>& ir_ctx, const i
       solveLinearWeight(w.getContext(), pf, op->cast_<ir::linalg::LinalgIROp>());
     }
     if (op->isa_<ir::linalg::RMSNormOp>()) { solveRMSNormWeight(w.getContext(), pf, op->cast_<ir::linalg::LinalgIROp>()); }
+    if (op->isa_<ir::linalg::LayerNormOp>()) {
+      solveLayerNormWeights(w.getContext(), pf, op->cast_<ir::linalg::LinalgIROp>());
+    }
     if (op->isa_<ir::linalg::EmbeddingOp>()) { solveEmbeddingWeight(w.getContext(), pf, op->cast_<ir::linalg::LinalgIROp>()); }
     if (op->isa_<ir::graph::CallGraphOp>()) {
       auto ns = op->cast_<ir::graph::CallGraphOp>()->getSymbolAttr()->str();

--- a/mllm/backends/qnn/aot/visitor/Conv2D.cpp
+++ b/mllm/backends/qnn/aot/visitor/Conv2D.cpp
@@ -9,6 +9,7 @@
 #include "mllm/backends/qnn/aot/visitor/Conv2D.hpp"
 #include "mllm/backends/qnn/aot/passes/AOTCompileContext.hpp"
 #include "mllm/core/aops/Conv2DOp.hpp"
+#include "mllm/compile/ir/linalg/Attribute.hpp"
 
 namespace mllm::qnn::aot {
 
@@ -61,6 +62,11 @@ bool QnnAOTConv2DPattern::rewrite(ir::IRWriter& writer, const ir::op_ptr_t& op) 
                         ->outputs()
                         .front()
                         ->cast_<ir::tensor::TensorValue>();
+    if (!bias_val->getAttr("quant_recipe")) {
+      bias_val->setAttr("quant_recipe",
+                        writer.create<ir::linalg::LinalgIRQuantizatonSpecAttr>(
+                            ir::linalg::QuantizationSpecRaw::create(bias_val->tensor_.dtype())));
+    }
     qnn_op_node->emplaceInput(env->captureQnnAOTNodeTensor(qnn_context_name, qnn_graph_name, bias_val, true));
   }
 

--- a/mllm/backends/qnn/aot/visitor/GELU.cpp
+++ b/mllm/backends/qnn/aot/visitor/GELU.cpp
@@ -1,0 +1,47 @@
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
+
+#include "mllm/backends/qnn/aot/visitor/GELU.hpp"
+
+#include "mllm/backends/qnn/aot/QnnWrappersAPI.hpp"
+#include "mllm/backends/qnn/aot/passes/AOTCompileContext.hpp"
+#include "mllm/compile/ir/builtin/Attribute.hpp"
+#include "mllm/compile/ir/linalg/Op.hpp"
+#include "mllm/utils/Common.hpp"
+
+namespace mllm::qnn::aot {
+
+bool QnnAOTGELUPattern::isMatch(const mllm::ir::op_ptr_t& op) {
+  return op->isa_<mllm::ir::linalg::GELUOp>() && (op->getAttr("using_qnn") != nullptr);
+}
+
+bool QnnAOTGELUPattern::rewrite(ir::IRWriter& writer, const ir::op_ptr_t& op) {
+  auto env = AOTCompileContext::getInstance().getEnv();
+
+  MLLM_RETURN_FALSE_IF_NOT(op->getAttr("quant_recipe"));
+  auto gelu_op = op->cast_<mllm::ir::linalg::GELUOp>();
+  if (!gelu_op) {
+    MLLM_ERROR("Failed to cast to linalg::GELUOp");
+    return false;
+  }
+
+  MLLM_RETURN_FALSE_IF_NOT(op->getAttr("qnn_graph_name"));
+  auto qnn_graph_name = op->getAttr("qnn_graph_name")->cast_<ir::StrAttr>()->data();
+  MLLM_RETURN_FALSE_IF_NOT(op->getAttr("qnn_context_name"));
+  auto qnn_context_name = op->getAttr("qnn_context_name")->cast_<ir::StrAttr>()->data();
+
+  auto input = op->inputs().front()->cast_<ir::tensor::TensorValue>();
+  auto output = op->outputs().front()->cast_<ir::tensor::TensorValue>();
+
+  auto qnn_op_node = QnnAOTNodeOperation::create("Gelu");
+  qnn_op_node->setPackageName("qti.aisw");
+  qnn_op_node->emplaceInput(env->captureQnnAOTNodeTensor(qnn_context_name, qnn_graph_name, input))
+      ->emplaceOutput(env->captureQnnAOTNodeTensor(qnn_context_name, qnn_graph_name, output))
+      ->setName(gelu_op->getAOp()->getName());
+
+  env->captureAOTNodeOp(qnn_context_name, qnn_graph_name, qnn_op_node);
+
+  return true;
+}
+
+}  // namespace mllm::qnn::aot

--- a/mllm/backends/qnn/aot/visitor/GELU.hpp
+++ b/mllm/backends/qnn/aot/visitor/GELU.hpp
@@ -1,0 +1,23 @@
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "mllm/core/OpTypes.hpp"
+#include "mllm/compile/ir/Node.hpp"
+#include "mllm/backends/qnn/aot/visitor/Base.hpp"
+
+namespace mllm::qnn::aot {
+
+class QnnAOTGELUPattern : public QnnAOTBasePattern {
+ public:
+  bool isMatch(const mllm::ir::op_ptr_t& op) override;
+
+  bool rewrite(ir::IRWriter& writer, const ir::op_ptr_t& op) override;
+
+  static inline std::pair<OpTypes, std::shared_ptr<QnnAOTGELUPattern>> create() {
+    return {OpTypes::kGELU, std::make_shared<QnnAOTGELUPattern>()};
+  }
+};
+
+}  // namespace mllm::qnn::aot

--- a/mllm/backends/qnn/aot/visitor/LayerNorm.cpp
+++ b/mllm/backends/qnn/aot/visitor/LayerNorm.cpp
@@ -1,0 +1,82 @@
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
+
+#include "mllm/backends/qnn/aot/visitor/LayerNorm.hpp"
+
+#include "mllm/backends/qnn/aot/QnnWrappersAPI.hpp"
+#include "mllm/backends/qnn/aot/passes/AOTCompileContext.hpp"
+#include "mllm/compile/ir/builtin/Attribute.hpp"
+#include "mllm/compile/ir/linalg/Op.hpp"
+#include "mllm/core/aops/LayerNormOp.hpp"
+#include "mllm/utils/Common.hpp"
+
+namespace mllm::qnn::aot {
+
+bool QnnAOTLayerNormPattern::isMatch(const mllm::ir::op_ptr_t& op) {
+  return op->isa_<mllm::ir::linalg::LayerNormOp>() && (op->getAttr("using_qnn") != nullptr);
+}
+
+bool QnnAOTLayerNormPattern::rewrite(ir::IRWriter& writer, const ir::op_ptr_t& op) {
+  auto env = AOTCompileContext::getInstance().getEnv();
+
+  MLLM_RETURN_FALSE_IF_NOT(op->getAttr("quant_recipe"));
+  auto layer_norm_op = op->cast_<mllm::ir::linalg::LayerNormOp>();
+  if (!layer_norm_op) {
+    MLLM_ERROR("Failed to cast to linalg::LayerNormOp");
+    return false;
+  }
+
+  MLLM_RETURN_FALSE_IF_NOT(op->getAttr("qnn_graph_name"));
+  auto qnn_graph_name = op->getAttr("qnn_graph_name")->cast_<ir::StrAttr>()->data();
+  MLLM_RETURN_FALSE_IF_NOT(op->getAttr("qnn_context_name"));
+  auto qnn_context_name = op->getAttr("qnn_context_name")->cast_<ir::StrAttr>()->data();
+
+  auto base_op = layer_norm_op->getAOp();
+  auto real_layer_norm_op = dynamic_cast<mllm::aops::LayerNormOp*>(base_op);
+  if (!real_layer_norm_op) {
+    MLLM_ERROR("Failed to cast BaseOp to mllm::aops::LayerNormOp");
+    return false;
+  }
+
+  auto input = op->inputs().front()->cast_<ir::tensor::TensorValue>();
+  auto output = op->outputs().front()->cast_<ir::tensor::TensorValue>();
+
+  auto qnn_op_node = QnnAOTNodeOperation::create("LayerNorm");
+  qnn_op_node->setPackageName("qti.aisw");
+  qnn_op_node->emplaceInput(env->captureQnnAOTNodeTensor(qnn_context_name, qnn_graph_name, input));
+
+  if (real_layer_norm_op->options().elementwise_affine) {
+    auto weight = writer.getContext()
+                      ->lookupSymbolTable(base_op->getName() + ".weight")
+                      ->outputs()
+                      .front()
+                      ->cast_<ir::tensor::TensorValue>();
+    qnn_op_node->emplaceInput(env->captureQnnAOTNodeTensor(qnn_context_name, qnn_graph_name, weight, true));
+  }
+
+  if (real_layer_norm_op->options().bias) {
+    auto bias = writer.getContext()
+                    ->lookupSymbolTable(base_op->getName() + ".bias")
+                    ->outputs()
+                    .front()
+                    ->cast_<ir::tensor::TensorValue>();
+    qnn_op_node->emplaceInput(env->captureQnnAOTNodeTensor(qnn_context_name, qnn_graph_name, bias, true));
+  }
+
+  qnn_op_node->emplaceParamScalar(QNNParamScalarWrapper::create("epsilon", real_layer_norm_op->options().eps));
+
+  std::vector<uint32_t> axes_dims = {1};
+  auto axes_param = QNNParamTensorWrapper::create("axes", base_op->getName() + "_axes", QNN_DATATYPE_UINT_32, axes_dims);
+  auto* axes_data = reinterpret_cast<uint32_t*>(axes_param->alloc());
+  axes_data[0] = input->tensor_.shape().size() - 1;
+  qnn_op_node->emplaceParamTensor(axes_param);
+
+  qnn_op_node->emplaceOutput(env->captureQnnAOTNodeTensor(qnn_context_name, qnn_graph_name, output))
+      ->setName(base_op->getName());
+
+  env->captureAOTNodeOp(qnn_context_name, qnn_graph_name, qnn_op_node);
+
+  return true;
+}
+
+}  // namespace mllm::qnn::aot

--- a/mllm/backends/qnn/aot/visitor/LayerNorm.hpp
+++ b/mllm/backends/qnn/aot/visitor/LayerNorm.hpp
@@ -1,0 +1,23 @@
+// Copyright (c) MLLM Team.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "mllm/core/OpTypes.hpp"
+#include "mllm/compile/ir/Node.hpp"
+#include "mllm/backends/qnn/aot/visitor/Base.hpp"
+
+namespace mllm::qnn::aot {
+
+class QnnAOTLayerNormPattern : public QnnAOTBasePattern {
+ public:
+  bool isMatch(const mllm::ir::op_ptr_t& op) override;
+
+  bool rewrite(ir::IRWriter& writer, const ir::op_ptr_t& op) override;
+
+  static inline std::pair<OpTypes, std::shared_ptr<QnnAOTLayerNormPattern>> create() {
+    return {OpTypes::kLayerNorm, std::make_shared<QnnAOTLayerNormPattern>()};
+  }
+};
+
+}  // namespace mllm::qnn::aot

--- a/mllm/backends/qnn/aot/visitor/Matmul.cpp
+++ b/mllm/backends/qnn/aot/visitor/Matmul.cpp
@@ -4,6 +4,7 @@
 #include "mllm/utils/Common.hpp"
 #include "mllm/compile/ir/linalg/Op.hpp"
 #include "mllm/compile/ir/builtin/Attribute.hpp"
+#include "mllm/core/aops/MatMulOp.hpp"
 #include "mllm/backends/qnn/aot/QnnWrappersAPI.hpp"
 #include "mllm/backends/qnn/aot/visitor/Matmul.hpp"
 #include "mllm/backends/qnn/aot/passes/AOTCompileContext.hpp"
@@ -20,6 +21,11 @@ bool QnnAOTMatMulPattern::rewrite(ir::IRWriter& writer, const ir::op_ptr_t& op) 
   auto matmul_op = op->cast_<mllm::ir::linalg::MatMulOp>();
   if (!matmul_op) {
     MLLM_ERROR("Failed to cast to linalg::MatMulOp");
+    return false;
+  }
+  auto aop = dynamic_cast<mllm::aops::MatMulOp*>(matmul_op->getAOp());
+  if (!aop) {
+    MLLM_ERROR("Failed to cast AOp to aops::MatMulOp");
     return false;
   }
 
@@ -43,6 +49,10 @@ bool QnnAOTMatMulPattern::rewrite(ir::IRWriter& writer, const ir::op_ptr_t& op) 
       ->emplaceInput(env->captureQnnAOTNodeTensor(qnn_context_name, qnn_graph_name, input1))
       ->emplaceOutput(env->captureQnnAOTNodeTensor(qnn_context_name, qnn_graph_name, output))
       ->setName(matmul_op->getAOp()->getName());
+
+  const auto& options = aop->options();
+  qnn_op_node->emplaceParamScalar(QNNParamScalarWrapper::create("transpose_in0", options.transpose_a));
+  qnn_op_node->emplaceParamScalar(QNNParamScalarWrapper::create("transpose_in1", options.transpose_b));
 
   // Register this op node into one graph.
   env->captureAOTNodeOp(qnn_context_name, qnn_graph_name, qnn_op_node);

--- a/mllm/backends/qnn/aot/visitor/Repeat.cpp
+++ b/mllm/backends/qnn/aot/visitor/Repeat.cpp
@@ -8,6 +8,7 @@
 #include "mllm/backends/qnn/aot/visitor/Repeat.hpp"
 #include "mllm/backends/qnn/aot/passes/AOTCompileContext.hpp"
 #include "mllm/core/aops/RepeatOp.hpp"
+#include "mllm/core/Tensor.hpp"
 #include <cstring>
 
 namespace mllm::qnn::aot {
@@ -49,36 +50,55 @@ bool QnnAOTRepeatPattern::rewrite(ir::IRWriter& writer, const ir::op_ptr_t& op) 
 
   if (dim < 0) { dim += rank; }
 
-  std::vector<uint32_t> multiples(rank, 1);
+  std::vector<uint32_t> multiples(rank + 1, 1);
   if (dim >= 0 && dim < rank) {
-    multiples[dim] = (uint32_t)repeat_times;
+    multiples[dim + 1] = (uint32_t)repeat_times;
   } else {
     MLLM_ERROR("Invalid dimension for RepeatOp: {}", dim);
     return false;
   }
 
-  // Create QNN Op Node
-  // QNN uses "Tile" for repeat
-  auto qnn_op_node = QnnAOTNodeOperation::create("Tile");
-  qnn_op_node->setPackageName("qti.aisw");
+  // mllm Repeat semantics are repeat_interleave along one dimension. QNN Tile
+  // repeats whole dimensions, so use reshape + tile + reshape:
+  // [.., D, ..] -> [.., D, 1, ..] -> tile inserted dim -> [.., D * repeat, ..].
+  auto expanded_shape = input_shape;
+  expanded_shape.insert(expanded_shape.begin() + dim + 1, 1);
+  auto tiled_shape = expanded_shape;
+  tiled_shape[dim + 1] = repeat_times;
 
-  // Add Input
-  qnn_op_node->emplaceInput(env->captureQnnAOTNodeTensor(qnn_context_name, qnn_graph_name, input));
+  auto expanded = writer.getContext()->create<ir::tensor::TensorValue>(
+      Tensor::empty(expanded_shape, input->tensor_.dtype(), input->tensor_.device()));
+  expanded->setAttr("quant_recipe", input->getAttr("quant_recipe"));
+  auto tiled = writer.getContext()->create<ir::tensor::TensorValue>(
+      Tensor::empty(tiled_shape, input->tensor_.dtype(), input->tensor_.device()));
+  tiled->setAttr("quant_recipe", input->getAttr("quant_recipe"));
 
-  // Add multiples Param
+  auto reshape_in = QnnAOTNodeOperation::create("Reshape");
+  reshape_in->setPackageName("qti.aisw");
+  reshape_in->emplaceInput(env->captureQnnAOTNodeTensor(qnn_context_name, qnn_graph_name, input))
+      ->emplaceOutput(env->captureQnnAOTNodeTensor(qnn_context_name, qnn_graph_name, expanded))
+      ->setName(base_op->getName() + ".repeat_interleave_reshape_in");
+  env->captureAOTNodeOp(qnn_context_name, qnn_graph_name, reshape_in);
+
+  auto tile = QnnAOTNodeOperation::create("Tile");
+  tile->setPackageName("qti.aisw");
+  tile->emplaceInput(env->captureQnnAOTNodeTensor(qnn_context_name, qnn_graph_name, expanded));
   auto multiplesName = base_op->getName() + ".multiples";
-  auto multiplesParam =
-      QNNParamTensorWrapper::create("multiples", multiplesName, QNN_DATATYPE_UINT_32, std::vector<uint32_t>{(uint32_t)rank});
+  auto multiplesParam = QNNParamTensorWrapper::create("multiples", multiplesName, QNN_DATATYPE_UINT_32,
+                                                     std::vector<uint32_t>{(uint32_t)multiples.size()});
   uint32_t* multiplesData = static_cast<uint32_t*>(multiplesParam->alloc());
-  std::memcpy(multiplesData, multiples.data(), rank * sizeof(uint32_t));
-  qnn_op_node->emplaceParamTensor(multiplesParam);
+  std::memcpy(multiplesData, multiples.data(), multiples.size() * sizeof(uint32_t));
+  tile->emplaceParamTensor(multiplesParam);
+  tile->emplaceOutput(env->captureQnnAOTNodeTensor(qnn_context_name, qnn_graph_name, tiled))
+      ->setName(base_op->getName() + ".repeat_interleave_tile");
+  env->captureAOTNodeOp(qnn_context_name, qnn_graph_name, tile);
 
-  // Add Output
-  qnn_op_node->emplaceOutput(env->captureQnnAOTNodeTensor(qnn_context_name, qnn_graph_name, output))
+  auto reshape_out = QnnAOTNodeOperation::create("Reshape");
+  reshape_out->setPackageName("qti.aisw");
+  reshape_out->emplaceInput(env->captureQnnAOTNodeTensor(qnn_context_name, qnn_graph_name, tiled))
+      ->emplaceOutput(env->captureQnnAOTNodeTensor(qnn_context_name, qnn_graph_name, output))
       ->setName(base_op->getName());
-
-  // Register
-  env->captureAOTNodeOp(qnn_context_name, qnn_graph_name, qnn_op_node);
+  env->captureAOTNodeOp(qnn_context_name, qnn_graph_name, reshape_out);
 
   return true;
 }

--- a/mllm/backends/qnn/aot/visitor/View.cpp
+++ b/mllm/backends/qnn/aot/visitor/View.cpp
@@ -35,6 +35,22 @@ bool QnnAOTViewPattern::rewrite(ir::IRWriter& writer, const ir::op_ptr_t& op) {
   // Output
   auto output = op->outputs().front()->cast_<ir::tensor::TensorValue>();
 
+  // mllm ViewOp can be a metadata-only no-op and reuse the same TensorValue name
+  // for input/output. QNN Reshape cannot write back to the exact same graph
+  // tensor, so keep true no-op views as aliases. Shape-changing views should be
+  // traced with enable_ssa=true by model code so that QNN receives a distinct
+  // output tensor with the new shape.
+  if (input->name() == output->name()) {
+    if (input->tensor_.shape() == output->tensor_.shape()) {
+      env->captureQnnAOTNodeTensor(qnn_context_name, qnn_graph_name, input);
+      return true;
+    }
+    MLLM_ERROR("QNN AOT ViewOp {} changes shape from [{}] to [{}] but input/output share tensor name {}. "
+               "Use Tensor::view(..., true) for this path.",
+               view_op->getAOp()->getName(), input->tensor_.shape(), output->tensor_.shape(), input->name());
+    return false;
+  }
+
   // Create Shape Tensor
   auto output_shape = output->tensor_.shape();
   std::vector<int32_t> shape_data;

--- a/mllm/core/aops/VisionRoPEOp.cpp
+++ b/mllm/core/aops/VisionRoPEOp.cpp
@@ -9,7 +9,7 @@
 
 namespace mllm::aops {
 
-VisionRoPEOp::VisionRoPEOp(const VisionRoPEOpOptions& options) : BaseOp(OpTypes::kSiLU), options_(options) {}
+VisionRoPEOp::VisionRoPEOp(const VisionRoPEOpOptions& options) : BaseOp(OpTypes::kVisionRoPE), options_(options) {}
 
 void VisionRoPEOp::load(const ParameterFile::ptr_t& ploader) { MLLM_EMPTY_SCOPE; }
 

--- a/mllm/mllm.hpp
+++ b/mllm/mllm.hpp
@@ -330,12 +330,12 @@ inline void print_stack_trace() {
       const char* name = demangled ? demangled : info.dli_sname;
       char line[256];
       int len = snprintf(line, sizeof(line), "#%d %p %s\n", i, buffer[i], name);
-      safe_write(line, len);
+      safe_write(line, std::min(static_cast<size_t>(std::max(len, 0)), sizeof(line) - 1));
       free(demangled);
     } else {
       char line[256];
       int len = snprintf(line, sizeof(line), "#%d %p\n", i, buffer[i]);
-      safe_write(line, len);
+      safe_write(line, std::min(static_cast<size_t>(std::max(len, 0)), sizeof(line) - 1));
     }
   }
 #endif


### PR DESCRIPTION
<!--
Thank you for your contribution to the MLLM framework!

To help us review your Pull Request efficiently, please check out this template.
A clear and complete description will significantly speed up the review process.
-->

Please check [Guidelines for Contributing](../docs/contribute/guidelines.md).

## Summary

Depends on #674.

This PR adds generic QNN AOT support needed for lowering visual encoder graphs:

- Add an explicit simple graph lowering pipeline for non-LLM graph roots.
- Add QNN AOT visitors for `GELU` and `LayerNorm`.
- Add quant recipe support for `GELU` and `LayerNorm`.
- Add PTQ handling for raw LayerNorm weights.
- Support raw Linear weights only when `allow_raw_float_linear=true` is explicitly set in the quant recipe config.
- Add Conv2D bias raw quant recipe handling.

This is model-agnostic infrastructure. A follow-up PR will add the Qwen2-VL 2B full-QNN example and runtime scripts.

## Validation

- `git diff --cached --check`
- `cmake --build build-qnn-aot --target mllm-qwen2vl-aot-c -j2`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added QNN AOT visitor support for LayerNorm and GELU operations with quantization.
  * Introduced simplified QNN graph lowering pipeline factory.

* **Bug Fixes**
  * Fixed VisionRoPE operation type initialization.
  * Fixed Android stack trace output buffer handling.
  * Added output tensor count validation in graph execution.

* **Improvements**
  * Enhanced diagnostic logging for tensor operations and quantization metadata.
  * Extended quantization recipe support for LayerNorm and GELU patterns.
  * Improved tensor naming and quantization handling in QNN AOT compilation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/UbiquitousLearning/mllm/pull/675?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->