### PR TITLE
feat(qwen3.5): GDN chunkwise prefill kernel, quantized inference, and native multimodal support

### DIFF
--- a/benchmarks/bench_serve.py
+++ b/benchmarks/bench_serve.py
@@ -1,0 +1,334 @@
+#!/usr/bin/env python3
+"""Benchmark pymllm server: prefill and decode throughput.
+
+Sends a list of prompts sequentially to the /v1/completions endpoint,
+measures Time-To-First-Token (TTFT, i.e. prefill latency) and decode
+throughput for each request, and prints a summary table.
+
+Usage:
+    # Start the server first, then:
+    python benchmarks/bench_server.py
+
+    # Custom server URL:
+    python benchmarks/bench_server.py --url http://192.168.1.100:30000
+
+    # Adjust max tokens:
+    python benchmarks/bench_server.py --max-tokens 200
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from dataclasses import dataclass, field
+from typing import List
+
+import requests
+
+
+# ---------------------------------------------------------------------------
+# Benchmark prompts — short / medium / long to test different prefill sizes
+# ---------------------------------------------------------------------------
+
+PROMPTS: List[str] = [
+    # ~256 tokens
+    "You are an expert historian. Please provide a comprehensive overview of the Industrial Revolution, "
+    "including its origins in 18th century Britain, the key technological innovations such as the steam "
+    "engine and spinning jenny, the social and economic impacts on the working class, urbanization trends, "
+    "As a senior software architect, design a complete microservices architecture for an e-commerce "
+    "platform. The platform should support user authentication and authorization, product catalog "
+    "management with search and filtering, shopping cart functionality, order processing and payment "
+    "integration, inventory management, shipping and logistics tracking, customer reviews and ratings, "
+    "recommendation engine, analytics dashboard, and notification services. For each microservice, "
+    "describe its responsibilities, the technology stack you would choose, the database type, "
+    "the API contracts, and how the services communicate with each other. Also discuss deployment discuss",
+
+    "You are an expert historian. Please provide a comprehensive overview of the Industrial Revolution, "
+    "including its origins in 18th century Britain, the key technological innovations such as the steam "
+    "engine and spinning jenny, the social and economic impacts on the working class, urbanization trends, "
+    "As a senior software architect, design a complete microservices architecture for an e-commerce "
+    "platform. The platform should support user authentication and authorization, product catalog "
+    "management with search and filtering, shopping cart functionality, order processing and payment "
+    "integration, inventory management, shipping and logistics tracking, customer reviews and ratings, "
+    "recommendation engine, analytics dashboard, and notification services. For each microservice, "
+    "describe its responsibilities, the technology stack you would choose, the database type, "
+    "the API contracts, and how the services communicate with each other. Also discuss deployment "
+    "strategies, monitoring, and fault tolerance. You are an expert historian. Please provide a comprehensive overview of the Industrial Revolution, "
+    "including its origins in 18th century Britain, the key technological innovations such as the steam "
+    "engine and spinning jenny, the social and economic impacts on the working class, urbanization trends, "
+    "As a senior software architect, design a complete microservices architecture for an e-commerce "
+    "platform. The platform should support user authentication and authorization, product catalog "
+    "management with search and filtering, shopping cart functionality, order processing and payment "
+    "integration, inventory management, shipping and logistics tracking, customer reviews and ratings, "
+    "recommendation engine, analytics dashboard, and notification services. For each microservice, "
+    "describe its responsibilities, the technology stack you would choose, the database type, "
+    "the API contracts, and how the services communicate with each other.",
+
+    "You are an expert historian. Please provide a comprehensive overview of the Industrial Revolution, "
+    "including its origins in 18th century Britain, the key technological innovations such as the steam "
+    "engine and spinning jenny, the social and economic impacts on the working class, urbanization trends, "
+    "As a senior software architect, design a complete microservices architecture for an e-commerce "
+    "platform. The platform should support user authentication and authorization, product catalog "
+    "management with search and filtering, shopping cart functionality, order processing and payment "
+    "integration, inventory management, shipping and logistics tracking, customer reviews and ratings, "
+    "recommendation engine, analytics dashboard, and notification services. For each microservice, "
+    "describe its responsibilities, the technology stack you would choose, the database type, "
+    "the API contracts, and how the services communicate with each other. Also discuss deployment "
+    "strategies, monitoring, and fault tolerance. You are an expert historian. Please provide a comprehensive overview of the Industrial Revolution, "
+    "including its origins in 18th century Britain, the key technological innovations such as the steam "
+    "engine and spinning jenny, the social and economic impacts on the working class, urbanization trends, "
+    "As a senior software architect, design a complete microservices architecture for an e-commerce "
+    "platform. The platform should support user authentication and authorization, product catalog "
+    "management with search and filtering, shopping cart functionality, order processing and payment "
+    "integration, inventory management, shipping and logistics tracking, customer reviews and ratings, "
+    "recommendation engine, analytics dashboard, and notification services. For each microservice, "
+    "describe its responsibilities, the technology stack you would choose, the database type, "
+    "the API contracts, and how the services communicate with each other. Also discuss deployment "
+    "strategies, monitoring, and fault tolerance. You are an expert historian. Please provide a comprehensive overview of the Industrial Revolution, "
+    "including its origins in 18th century Britain, the key technological innovations such as the steam "
+    "engine and spinning jenny, the social and economic impacts on the working class, urbanization trends, "
+    "As a senior software architect, design a complete microservices architecture for an e-commerce "
+    "platform. The platform should support user authentication and authorization, product catalog "
+    "management with search and filtering, shopping cart functionality, order processing and payment "
+    "integration, inventory management, shipping and logistics tracking, customer reviews and ratings, "
+    "recommendation engine, analytics dashboard, and notification services. For each microservice, "
+    "describe its responsibilities, the technology stack you would choose, the database type, "
+    "the API contracts, and how the services communicate with each other. Also discuss deployment "
+    "strategies, monitoring, and fault tolerance. You are an expert historian. Please provide a comprehensive overview of the Industrial Revolution, "
+    "including its origins in 18th century Britain, the key technological innovations such as the steam "
+    "engine and spinning jenny, the social and economic impacts on the working class, urbanization trends, "
+    "As a senior software architect, design a complete microservices architecture for an e-commerce "
+    "platform. The platform should support user authentication and authorization, product catalog "
+    "management with search and filtering, shopping cart functionality, order processing and payment "
+    "integration, inventory management, shipping and logistics tracking, customer reviews and ratings, "
+    "recommendation engine, analytics dashboard, and notification services. For each microservice, "
+    "describe its responsibilities, the technology stack you would choose, the database type, "
+    "describe its responsibilities"
+]
+
+
+
+# ---------------------------------------------------------------------------
+# Result data
+# ---------------------------------------------------------------------------
+
+@dataclass
+class RequestResult:
+    prompt: str
+    prompt_tokens: int
+    generated_tokens: int
+    ttft_ms: float          # time to first token (prefill latency)
+    total_time_ms: float    # total request time
+    decode_time_ms: float   # total_time - ttft
+    prefill_tps: float      # prompt_tokens / ttft
+    decode_tps: float       # generated_tokens / decode_time
+
+
+@dataclass
+class BenchmarkSummary:
+    results: List[RequestResult] = field(default_factory=list)
+
+    def add(self, r: RequestResult):
+        self.results.append(r)
+
+    def print_table(self):
+        print()
+        print("=" * 110)
+        print(f"{'#':>3}  {'Prompt Tok':>10}  {'Gen Tok':>8}  "
+              f"{'TTFT(ms)':>10}  {'Prefill t/s':>12}  "
+              f"{'Decode(ms)':>10}  {'Decode t/s':>11}  "
+              f"{'Total(ms)':>10}")
+        print("-" * 110)
+
+        for i, r in enumerate(self.results):
+            print(
+                f"{i+1:>3}  {r.prompt_tokens:>10}  {r.generated_tokens:>8}  "
+                f"{r.ttft_ms:>10.1f}  {r.prefill_tps:>12.1f}  "
+                f"{r.decode_time_ms:>10.1f}  {r.decode_tps:>11.1f}  "
+                f"{r.total_time_ms:>10.1f}"
+            )
+
+        print("-" * 110)
+
+        if not self.results:
+            return
+
+        avg_prefill = sum(r.prefill_tps for r in self.results) / len(self.results)
+        avg_decode = sum(r.decode_tps for r in self.results) / len(self.results)
+        avg_ttft = sum(r.ttft_ms for r in self.results) / len(self.results)
+        total_prompt = sum(r.prompt_tokens for r in self.results)
+        total_gen = sum(r.generated_tokens for r in self.results)
+        total_time = sum(r.total_time_ms for r in self.results)
+
+        print(f"AVG  {'':<10}  {'':<8}  "
+              f"{avg_ttft:>10.1f}  {avg_prefill:>12.1f}  "
+              f"{'':>10}  {avg_decode:>11.1f}")
+        print(f"SUM  {total_prompt:>10}  {total_gen:>8}  "
+              f"{'':>10}  {'':>12}  "
+              f"{'':>10}  {'':>11}  {total_time:>10.1f}")
+        print("=" * 110)
+
+
+# ---------------------------------------------------------------------------
+# Streaming request with TTFT measurement
+# ---------------------------------------------------------------------------
+
+def run_one_request(
+    url: str,
+    model: str,
+    prompt: str,
+    max_tokens: int,
+    temperature: float,
+) -> RequestResult:
+    """Send a streaming completions request and measure TTFT + decode speed."""
+
+    payload = {
+        "model": model,
+        "prompt": prompt,
+        "max_tokens": max_tokens,
+        "temperature": temperature,
+        "stream": True,
+    }
+
+    t_start = time.perf_counter()
+    t_first_token = None
+    chunk_count = 0         # SSE data chunks received (≈ generated tokens)
+    api_prompt_tokens = 0   # from usage field if server reports it
+    api_gen_tokens = 0      # from usage field if server reports it
+
+    resp = requests.post(
+        f"{url}/v1/completions",
+        json=payload,
+        headers={"Content-Type": "application/json"},
+        stream=True,
+        timeout=300,
+    )
+    resp.raise_for_status()
+
+    for line in resp.iter_lines(decode_unicode=True):
+        if not line or not line.startswith("data: "):
+            continue
+        data_str = line[len("data: "):]
+        if data_str.strip() == "[DONE]":
+            break
+
+        try:
+            data = json.loads(data_str)
+        except json.JSONDecodeError:
+            continue
+
+        # Record TTFT on the very first data chunk
+        if t_first_token is None:
+            t_first_token = time.perf_counter()
+
+        chunk_count += 1
+
+        # Extract usage if the server provides it (usually in the last chunk)
+        usage = data.get("usage")
+        if usage:
+            api_prompt_tokens = usage.get("prompt_tokens", api_prompt_tokens)
+            api_gen_tokens = usage.get("completion_tokens", api_gen_tokens)
+
+    t_end = time.perf_counter()
+
+    if t_first_token is None:
+        t_first_token = t_end
+
+    # Use server-reported counts when available; fall back to chunk count
+    prompt_tokens = api_prompt_tokens if api_prompt_tokens > 0 else max(1, len(prompt.split()) * 2)
+    generated_tokens = api_gen_tokens if api_gen_tokens > 0 else max(chunk_count, 1)
+
+    ttft_ms = (t_first_token - t_start) * 1000
+    total_ms = (t_end - t_start) * 1000
+    decode_ms = total_ms - ttft_ms
+
+    prefill_tps = prompt_tokens / (ttft_ms / 1000) if ttft_ms > 0 else 0
+    decode_tps = generated_tokens / (decode_ms / 1000) if decode_ms > 0 else 0
+
+    return RequestResult(
+        prompt=prompt[:60] + ("..." if len(prompt) > 60 else ""),
+        prompt_tokens=prompt_tokens,
+        generated_tokens=generated_tokens,
+        ttft_ms=ttft_ms,
+        total_time_ms=total_ms,
+        decode_time_ms=decode_ms,
+        prefill_tps=prefill_tps,
+        decode_tps=decode_tps,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(description="Benchmark pymllm server")
+    parser.add_argument("--url", default="http://127.0.0.1:30000",
+                        help="Server base URL (default: http://127.0.0.1:30000)")
+    parser.add_argument("--model", default="Qwen3.5-2B",
+                        help="Model name for the API request")
+    parser.add_argument("--max-tokens", type=int, default=256,
+                        help="Max tokens to generate per request (default: 500)")
+    parser.add_argument("--temperature", type=float, default=0.6,
+                        help="Sampling temperature (default: 0.6)")
+    parser.add_argument("--warmup", type=int, default=1,
+                        help="Number of warmup requests before benchmarking (default: 1)")
+    args = parser.parse_args()
+
+    print(f"pymllm Server Benchmark")
+    print(f"  URL:         {args.url}")
+    print(f"  Model:       {args.model}")
+    print(f"  Max tokens:  {args.max_tokens}")
+    print(f"  Temperature: {args.temperature}")
+    print(f"  Prompts:     {len(PROMPTS)}")
+    print()
+
+    # Check server is alive
+    try:
+        r = requests.get(f"{args.url}/health", timeout=5)
+        print(f"Server health: {r.status_code}")
+    except Exception:
+        print(f"Server health: endpoint not found (proceeding anyway)")
+
+    # Warmup — ensures JIT-compiled CUDA kernels (e.g. cuda_chunkwise) are
+    # already compiled before benchmark requests start.  On Jetson Orin the
+    # first compile can take ~10-15 s; this cost is paid here, not during
+    # benchmark measurement.
+    if args.warmup > 0:
+        print(f"\n--- Warmup ({args.warmup} request(s), first may be slow due to JIT) ---")
+        for i in range(args.warmup):
+            print(f"  warmup {i+1}/{args.warmup} ...", end=" ", flush=True)
+            wr = run_one_request(
+                args.url, args.model,
+                "Please explain the GDN linear attention mechanism briefly.",
+                max_tokens=20, temperature=args.temperature,
+            )
+            print(f"done ({wr.total_time_ms:.0f} ms)"
+                  + (" ← JIT compile included" if wr.ttft_ms > 5000 else ""))
+
+    # Benchmark
+    print(f"\n--- Benchmark ({len(PROMPTS)} requests) ---")
+    summary = BenchmarkSummary()
+
+    for i, prompt in enumerate(PROMPTS):
+        short = prompt[:50] + ("..." if len(prompt) > 50 else "")
+        print(f"  [{i+1}/{len(PROMPTS)}] \"{short}\"", flush=True)
+
+        result = run_one_request(
+            args.url, args.model, prompt,
+            max_tokens=args.max_tokens,
+            temperature=args.temperature,
+        )
+        summary.add(result)
+
+        print(f"         TTFT={result.ttft_ms:.0f}ms  "
+              f"prefill={result.prefill_tps:.0f} t/s  "
+              f"decode={result.decode_tps:.1f} t/s  "
+              f"gen={result.generated_tokens} tokens")
+
+    summary.print_table()
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/bench_serve.py
+++ b/benchmarks/bench_serve.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
-"""Benchmark pymllm server: prefill and decode throughput.
+"""
+Benchmark pymllm server: prefill and decode throughput.
 
 Sends a list of prompts sequentially to the /v1/completions endpoint,
 measures Time-To-First-Token (TTFT, i.e. prefill latency) and decode
@@ -118,10 +119,11 @@ class RequestResult:
     prompt: str
     prompt_tokens: int
     generated_tokens: int
-    ttft_ms: float          # time to first token (prefill latency)
+    ttft_ms: float          # time to first token (prefill latency), client-side
+    prefill_ms: float       # estimated pure prefill time = ttft - one_decode_step
     total_time_ms: float    # total request time
     decode_time_ms: float   # total_time - ttft
-    prefill_tps: float      # prompt_tokens / ttft
+    prefill_tps: float      # prompt_tokens / prefill_ms
     decode_tps: float       # generated_tokens / decode_time
 
 
@@ -134,40 +136,34 @@ class BenchmarkSummary:
 
     def print_table(self):
         print()
-        print("=" * 110)
+        print("=" * 120)
         print(f"{'#':>3}  {'Prompt Tok':>10}  {'Gen Tok':>8}  "
-              f"{'TTFT(ms)':>10}  {'Prefill t/s':>12}  "
+              f"{'TTFT(ms)':>10}  {'Prefill(ms)':>12}  {'Prefill t/s':>12}  "
               f"{'Decode(ms)':>10}  {'Decode t/s':>11}  "
               f"{'Total(ms)':>10}")
-        print("-" * 110)
+        print("-" * 120)
 
         for i, r in enumerate(self.results):
             print(
                 f"{i+1:>3}  {r.prompt_tokens:>10}  {r.generated_tokens:>8}  "
-                f"{r.ttft_ms:>10.1f}  {r.prefill_tps:>12.1f}  "
+                f"{r.ttft_ms:>10.1f}  {r.prefill_ms:>12.1f}  {r.prefill_tps:>12.1f}  "
                 f"{r.decode_time_ms:>10.1f}  {r.decode_tps:>11.1f}  "
                 f"{r.total_time_ms:>10.1f}"
             )
 
-        print("-" * 110)
+        print("-" * 120)
 
         if not self.results:
             return
 
-        avg_prefill = sum(r.prefill_tps for r in self.results) / len(self.results)
-        avg_decode = sum(r.decode_tps for r in self.results) / len(self.results)
-        avg_ttft = sum(r.ttft_ms for r in self.results) / len(self.results)
         total_prompt = sum(r.prompt_tokens for r in self.results)
         total_gen = sum(r.generated_tokens for r in self.results)
         total_time = sum(r.total_time_ms for r in self.results)
 
-        print(f"AVG  {'':<10}  {'':<8}  "
-              f"{avg_ttft:>10.1f}  {avg_prefill:>12.1f}  "
-              f"{'':>10}  {avg_decode:>11.1f}")
         print(f"SUM  {total_prompt:>10}  {total_gen:>8}  "
-              f"{'':>10}  {'':>12}  "
+              f"{'':>10}  {'':>12}  {'':>12}  "
               f"{'':>10}  {'':>11}  {total_time:>10.1f}")
-        print("=" * 110)
+        print("=" * 120)
 
 
 # ---------------------------------------------------------------------------
@@ -243,14 +239,22 @@ def run_one_request(
     total_ms = (t_end - t_start) * 1000
     decode_ms = total_ms - ttft_ms
 
-    prefill_tps = prompt_tokens / (ttft_ms / 1000) if ttft_ms > 0 else 0
     decode_tps = generated_tokens / (decode_ms / 1000) if decode_ms > 0 else 0
+
+    # Estimate pure prefill time by subtracting one decode step from TTFT.
+    # TTFT (client-side) = network_rtt + server_queue + prefill + first_decode_step + network_rtt.
+    # On localhost network_rtt ≈ 0.  We estimate first_decode_step ≈ decode_ms / generated_tokens.
+    one_decode_step_ms = (decode_ms / generated_tokens) if generated_tokens > 0 else 0
+    prefill_ms = max(ttft_ms - one_decode_step_ms, ttft_ms * 0.5)
+
+    prefill_tps = prompt_tokens / (prefill_ms / 1000) if prefill_ms > 0 else 0
 
     return RequestResult(
         prompt=prompt[:60] + ("..." if len(prompt) > 60 else ""),
         prompt_tokens=prompt_tokens,
         generated_tokens=generated_tokens,
         ttft_ms=ttft_ms,
+        prefill_ms=prefill_ms,
         total_time_ms=total_ms,
         decode_time_ms=decode_ms,
         prefill_tps=prefill_tps,
@@ -268,7 +272,7 @@ def main():
                         help="Server base URL (default: http://127.0.0.1:30000)")
     parser.add_argument("--model", default="Qwen3.5-2B",
                         help="Model name for the API request")
-    parser.add_argument("--max-tokens", type=int, default=256,
+    parser.add_argument("--max-tokens", type=int, default=128,
                         help="Max tokens to generate per request (default: 500)")
     parser.add_argument("--temperature", type=float, default=0.6,
                         help="Sampling temperature (default: 0.6)")
@@ -322,7 +326,7 @@ def main():
         )
         summary.add(result)
 
-        print(f"         TTFT={result.ttft_ms:.0f}ms  "
+        print(f"         TTFT={result.ttft_ms:.0f}ms  prefill_est={result.prefill_ms:.0f}ms  "
               f"prefill={result.prefill_tps:.0f} t/s  "
               f"decode={result.decode_tps:.1f} t/s  "
               f"gen={result.generated_tokens} tokens")

--- a/mllm-kernel/mllm_kernel/cuda/csrc/gdn_extend_chunkwise.cuh
+++ b/mllm-kernel/mllm_kernel/cuda/csrc/gdn_extend_chunkwise.cuh
@@ -1,0 +1,619 @@
+// Chunkwise-parallel fused GDN extend using WY representation.
+//
+// Reference: Gated Delta Networks (Yang et al., 2024) — "Chunkwise Parallel
+// DeltaNet" approach.  For each chunk of CHUNK_C tokens the sequential
+// recurrence is decomposed into:
+//
+//   WY form:  S_T = γ_C · (S_0 (I − W K^T) + Ũ K^T)
+//
+// where W (K-space) and Ũ (V-space) are built by a sequential O(C) scan
+// inside the kernel using shared memory, and the output / state-update
+// become parallel matmul-like operations that avoid per-token global state
+// traffic.
+//
+// ──────────────────────────────────────────────────────────────────────────
+// Optimisation log (relative to original single-block-reduce implementation)
+// ──────────────────────────────────────────────────────────────────────────
+// [OPT-1] Batched WY inner loop (Phase 1)
+//   Original: 2×t block_reduce_sum calls per token t, each requiring 2
+//   __syncthreads → O(C²) syncs per chunk (~1984 for C=32, BLOCK_K=128).
+//   New: one batched warp-then-cross-warp reduction per token → 2 syncs
+//   regardless of t, giving O(C) syncs (~64 for C=32).
+//   Mechanism: all warps write partial dot-products for ALL i<t into
+//   batch_wbuf/batch_kbuf (smem), then warp-0 threads fan-in in parallel
+//   across the CHUNK_C indices after a single __syncthreads.
+//
+// [OPT-2] Batched KQ inner loop (Phase 2)
+//   Original: (r+1) block_reduce_sum calls per output position r → O(C²)
+//   syncs (~1248 for C=32).
+//   New: same batched scheme (reuses batch_wbuf / pw_smem from Phase 1) →
+//   2 syncs per output position, O(C) total (~64 for C=32).
+//
+// [OPT-3] Numerical guard for γ underflow
+//   When gam_t underflows to 0 (aggressive decay + long chunks), β/γ would
+//   be ±inf.  Since γ_r ≤ γ_t when r≥t, the output contribution
+//   γ_r · Ũ[t] is also zero in that regime; we set U_smem[t]=0 explicitly.
+//
+// [OPT-4 REVERTED — analysis]
+//   CHUNK_C=64 on SM80+ was intended to halve chunk iterations, but
+//   Phase 1 and Phase 2 both contain O(C²) inner loops (warp_reduce_sum
+//   over i=0..t_loc-1 / 0..r).  Doubling C quadruples per-chunk O(C²)
+//   work while only halving chunk count → net 2× MORE arithmetic.
+//   Worse: 83.9 KB smem (BLOCK_K=128, CHUNK_C=64) limits occupancy to
+//   1 block/SM on SM87 (164 KB/SM) versus 3 blocks/SM for 42.5 KB
+//   (CHUNK_C=32).  Combined effect: ~3-4× slower in practice.
+//   CHUNK_C=32 fits comfortably in the default 48 KB smem limit for
+//   all supported BLOCK_K values (max 42.5 KB at BLOCK_K=128), so no
+//   cudaFuncSetAttribute or runtime SM detection is required.
+//
+// Sync budget per chunk (BLOCK_K=128, CHUNK_C=32):
+//   Phase 1 per token: k_norm(2) + syncA(1) + batchedWY syncB+C(2)
+//                    + syncD(1) + block_reduce_bv(2) + syncE(1) = 9
+//   Phase 2 per output: q_norm(2) + syncA(1) + block_reduce_bv(2)
+//                     + batchedKQ syncB+C(2) + syncD(1) = 8
+//   Total per chunk C=32: 9×32 + 8×32 = 544  (was ~3400 before OPT-1/2)
+//
+// Works on all SM versions (SM70+).
+//
+// Grid : (NV, batch_size * HV)   NV = ceil(V / BV)
+// Block: BLOCK_K threads         BLOCK_K = round_up_32(K), max 256
+//
+// Shared memory (BLOCK_K=64,  CHUNK_C=32, BV=32): ≈ 21.5 KB   (well within 48 KB)
+// Shared memory (BLOCK_K=128, CHUNK_C=32, BV=32): ≈ 42.5 KB   (well within 48 KB)
+// Shared memory (BLOCK_K=256, CHUNK_C=16, BV=32): ≈ 39.4 KB   (well within 48 KB)
+//
+// Algorithm per chunk [cs, cs+C):
+//
+//   Phase 1  WY construction  — sequential O(C) steps:
+//     t=0..C-1:
+//       α_t = exp(-exp(A_log)·softplus(a_t+dt_bias)),  β_t = sigmoid(b_t)
+//       γ_t = ∏_{j≤t} α_j
+//       k̂_t  = L2norm(k_t)        → K_smem[t, :]
+//       bk_t = β_t · k̂_t
+//       pw[i] = <W_smem[i,:], bk_t>  for i < t   (batched warp-reduce)
+//       pk[i] = <K_smem[i,:], bk_t>  for i < t   (batched warp-reduce)
+//       W_smem[t,k] = bk_t[k] − Σ_i K_smem[i,k]·pw[i]
+//       SW_smem[t,v] = <S_0[v,:], W_smem[t,:]>         (block_reduce_bv)
+//       U_smem[t,v] = (β_t/γ_t)·v_t[v] − Σ_i U_smem[i,v]·pk[i]
+//                     (guarded: 0 when γ_t underflows)
+//
+//   Phase 2  Output  — for each r = 0..C-1:
+//     q̂_r  = L2norm(q_r)/√K
+//     SQ[v] = <S_0[v,:], q̂_r>                          (block_reduce_bv)
+//     KQ[i] = <K_smem[i,:], q̂_r>   for i ≤ r           (batched warp-reduce)
+//     Δ_i[v] = U_smem[i,v] − SW_smem[i,v]
+//     O[v,r] = γ_r · (SQ[v] + Σ_{i≤r} Δ_i[v]·KQ[i])
+//
+//   Phase 3  State update  — parallel over K (no block reduce):
+//     S_new[v,k] = γ_C · (S_0[v,k] + Σ_i Δ_i[v]·K_smem[i,k])
+
+#pragma once
+
+#include <mllm_kernel/tensor.hpp>
+#include <mllm_kernel/utils.cuh>
+
+#include <dlpack/dlpack.h>
+#include <tvm/ffi/container/tensor.h>
+
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+
+#include <cmath>
+
+namespace GDNExtendChunkwiseKernel {
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+inline constexpr int BV = 32;  // V-tile size — matches gdn_extend / gdn_decode
+
+// ---------------------------------------------------------------------------
+// Warp-level scalar reduction
+// ---------------------------------------------------------------------------
+
+__device__ __forceinline__ float warp_reduce_sum(float val) {
+#pragma unroll
+    for (int off = 16; off > 0; off >>= 1)
+        val += __shfl_xor_sync(0xffffffff, val, off);
+    return val;
+}
+
+// ---------------------------------------------------------------------------
+// Type helpers
+// ---------------------------------------------------------------------------
+
+template <typename T> __device__ __forceinline__ float to_float(T v);
+template <> __device__ __forceinline__ float to_float<__half>(__half v) { return __half2float(v); }
+template <> __device__ __forceinline__ float to_float<__nv_bfloat16>(__nv_bfloat16 v) { return __bfloat162float(v); }
+template <> __device__ __forceinline__ float to_float<float>(float v) { return v; }
+
+template <typename T> __device__ __forceinline__ T from_float(float v);
+template <> __device__ __forceinline__ __half from_float<__half>(float v) { return __float2half(v); }
+template <> __device__ __forceinline__ __nv_bfloat16 from_float<__nv_bfloat16>(float v) { return __float2bfloat16(v); }
+template <> __device__ __forceinline__ float from_float<float>(float v) { return v; }
+
+// ---------------------------------------------------------------------------
+// Block-level scalar reduction → broadcast to all threads via smem[0]
+// ---------------------------------------------------------------------------
+
+__device__ __forceinline__ float block_reduce_sum(float val, float* smem) {
+    const int wid  = threadIdx.x / 32;
+    const int lid  = threadIdx.x % 32;
+    const int nw   = blockDim.x / 32;
+    val = warp_reduce_sum(val);
+    if (lid == 0) smem[wid] = val;
+    __syncthreads();
+    if (wid == 0) {
+        float v = (lid < nw) ? smem[lid] : 0.f;
+        v = warp_reduce_sum(v);
+        if (lid == 0) smem[0] = v;
+    }
+    __syncthreads();
+    return smem[0];
+}
+
+// ---------------------------------------------------------------------------
+// Block-level BV-vector reduction → broadcast via smem broadcast_buf[BV]
+// ---------------------------------------------------------------------------
+
+__device__ __forceinline__ void block_reduce_bv(
+    float        partial[BV],
+    float* __restrict__ reduce_buf,    // [num_warps * BV]
+    float* __restrict__ broadcast_buf, // [BV]
+    float        out[BV]
+) {
+    const int wid = threadIdx.x / 32;
+    const int lid = threadIdx.x % 32;
+    const int nw  = blockDim.x / 32;
+
+#pragma unroll
+    for (int bv = 0; bv < BV; bv++) {
+        float v = warp_reduce_sum(partial[bv]);
+        if (lid == 0) reduce_buf[wid * BV + bv] = v;
+    }
+    __syncthreads();
+
+    if (wid == 0) {
+#pragma unroll
+        for (int bv = 0; bv < BV; bv++) {
+            float v = (lid < nw) ? reduce_buf[lid * BV + bv] : 0.f;
+            v = warp_reduce_sum(v);
+            if (lid == 0) broadcast_buf[bv] = v;
+        }
+    }
+    __syncthreads();
+
+#pragma unroll
+    for (int bv = 0; bv < BV; bv++) out[bv] = broadcast_buf[bv];
+}
+
+// ---------------------------------------------------------------------------
+// Main chunkwise kernel
+// ---------------------------------------------------------------------------
+
+template <typename T, int BLOCK_K, int CHUNK_C>
+__global__ void gdn_extend_chunkwise_kernel(
+    const T* __restrict__ q_ptr,
+    const T* __restrict__ k_ptr,
+    const T* __restrict__ v_ptr,
+    const T* __restrict__ a_ptr,
+    const T* __restrict__ b_ptr,
+    const float* __restrict__ A_log_ptr,
+    const float* __restrict__ dt_bias_ptr,
+    float*       __restrict__ state_pool,
+    const int64_t* __restrict__ cache_indices,
+    const int64_t* __restrict__ cu_seqlens,
+    T*           __restrict__ output_ptr,
+    const int batch_size,
+    const int H,
+    const int HV,
+    const int K,
+    const int V
+) {
+    const int bv_blk     = blockIdx.x;
+    const int batch_head = blockIdx.y;
+    const int i_n        = batch_head / HV;
+    const int i_hv       = batch_head % HV;
+    const int i_h        = i_hv * H / HV;
+    const int k_idx      = threadIdx.x;
+    const int v_start    = bv_blk * BV;
+    const int num_warps  = BLOCK_K / 32;
+    const int wid        = k_idx / 32;
+    const int lid        = k_idx % 32;
+
+    if (i_n >= batch_size) return;
+
+    // ── Shared memory layout ──────────────────────────────────────────────
+    //
+    //  sq          [BLOCK_K]              — scratch: current q/bk vector
+    //  warp_buf    [num_warps]            — scalar block-reduce workspace
+    //                                       (used by block_reduce_sum for norms)
+    //  pw_smem     [CHUNK_C]              — [Phase1] reduced pw[i] = <W[i],bk_t>
+    //                                       [Phase2] reused as kq[i] = <K[i],q̂_r>
+    //  pk_smem     [CHUNK_C]              — [Phase1] reduced pk[i] = <K[i],bk_t>
+    //  batch_wbuf  [num_warps × CHUNK_C]  — cross-warp scratch for pw / kq
+    //  batch_kbuf  [num_warps × CHUNK_C]  — cross-warp scratch for pk
+    //  K_smem      [CHUNK_C × BLOCK_K]    — normalised key per chunk-token
+    //  W_smem      [CHUNK_C × BLOCK_K]    — WY W vectors
+    //  U_smem      [CHUNK_C × BV]         — WY Ũ vectors (V-space)
+    //  SW_smem     [CHUNK_C × BV]         — S₀ @ W_smem (precomputed)
+    //  gamma_sm    [CHUNK_C]              — cumulative decay in chunk
+    //  rbv         [num_warps × BV]       — block_reduce_bv workspace
+    //  bcast       [BV]                   — block_reduce_bv broadcast
+    extern __shared__ float smem[];
+
+    int off = 0;
+    float* sq         = smem + off; off += BLOCK_K;
+    float* warp_buf   = smem + off; off += num_warps;
+    float* pw_smem    = smem + off; off += CHUNK_C;
+    float* pk_smem    = smem + off; off += CHUNK_C;
+    float* batch_wbuf = smem + off; off += num_warps * CHUNK_C;
+    float* batch_kbuf = smem + off; off += num_warps * CHUNK_C;
+    float* K_smem     = smem + off; off += CHUNK_C * BLOCK_K;
+    float* W_smem     = smem + off; off += CHUNK_C * BLOCK_K;
+    float* U_smem     = smem + off; off += CHUNK_C * BV;
+    float* SW_smem    = smem + off; off += CHUNK_C * BV;
+    float* gamma_sm   = smem + off; off += CHUNK_C;
+    float* rbv        = smem + off; off += num_warps * BV;
+    float* bcast      = smem + off; // [BV]
+
+    const float A_log_val   = A_log_ptr[i_hv];
+    const float dt_bias_val = dt_bias_ptr[i_hv];
+
+    const int64_t seq_start = cu_seqlens[i_n];
+    const int64_t seq_end   = cu_seqlens[i_n + 1];
+
+    // ── Load initial state into registers ─────────────────────────────────
+    const int64_t pool_idx   = cache_indices[i_n];
+    const int64_t state_base =
+        pool_idx * (int64_t)HV * V * K + i_hv * (int64_t)V * K;
+
+    float state[BV];
+#pragma unroll
+    for (int bv = 0; bv < BV; bv++) {
+        const int v_idx = v_start + bv;
+        state[bv] = (v_idx < V && k_idx < K)
+            ? state_pool[state_base + (int64_t)v_idx * K + k_idx]
+            : 0.f;
+    }
+
+    // ── Chunk loop ─────────────────────────────────────────────────────────
+    for (int64_t cs = seq_start; cs < seq_end; cs += CHUNK_C) {
+        const int C      = (int)min((int64_t)CHUNK_C, seq_end - cs);
+        float prev_gamma = 1.f;
+
+        // ============================================================
+        // Phase 1 — WY construction
+        //   Sequential over t_loc = 0..C-1.
+        //   Inner dot products pw[i]/pk[i] are computed via one batched
+        //   warp→cross-warp reduction (2 __syncthreads total per token)
+        //   instead of the original 2×t individual block_reduce_sum calls.
+        // ============================================================
+        for (int t_loc = 0; t_loc < C; t_loc++) {
+            const int64_t t_g = cs + t_loc;
+
+            // ── Gating scalars ────────────────────────────────────────
+            const float a_val  = to_float(a_ptr[t_g * HV + i_hv]);
+            const float b_val  = to_float(b_ptr[t_g * HV + i_hv]);
+            const float x      = a_val + dt_bias_val;
+            const float sp_x   = (x <= 20.f) ? logf(1.f + expf(x)) : x;
+            const float alpha  = expf(-expf(A_log_val) * sp_x);
+            const float beta   = 1.f / (1.f + expf(-b_val));
+            const float gam_t  = prev_gamma * alpha;
+            prev_gamma = gam_t;
+            if (k_idx == 0) gamma_sm[t_loc] = gam_t;
+
+            // ── L2-normalise k → K_smem[t_loc,:];  bk_t → sq ────────
+            const float k_raw = (k_idx < K)
+                ? to_float(k_ptr[t_g * H * K + i_h * K + k_idx]) : 0.f;
+            const float k_sq  = block_reduce_sum(k_raw * k_raw, warp_buf);
+            // block_reduce_sum includes 2 __syncthreads internally
+            const float k_n   = k_raw * rsqrtf(k_sq + 1e-6f);
+            K_smem[t_loc * BLOCK_K + k_idx] = k_n;
+            sq[k_idx] = beta * k_n;   // bk_t
+            __syncthreads();          // sync A: K_smem[t_loc], sq, gamma_sm ready
+
+            // ── [OPT-1] Batched WY inner loop ────────────────────────
+            // Compute pw[i]=<W[i,:],bk_t> and pk[i]=<K[i,:],bk_t> for
+            // all i < t_loc with only 2 __syncthreads.
+            //
+            // Step 1: every thread accumulates warp-level partial sums
+            //   for all i simultaneously (no sync needed for warp ops).
+            for (int i = 0; i < t_loc; i++) {
+                float pw_p = warp_reduce_sum(W_smem[i * BLOCK_K + k_idx] * sq[k_idx]);
+                float pk_p = warp_reduce_sum(K_smem[i * BLOCK_K + k_idx] * sq[k_idx]);
+                // Lane 0 of each warp records its partial sum.
+                if (lid == 0) {
+                    batch_wbuf[wid * CHUNK_C + i] = pw_p;
+                    batch_kbuf[wid * CHUNK_C + i] = pk_p;
+                }
+            }
+            __syncthreads();   // sync B: warp partials visible to warp 0
+
+            // Step 2: warp-0 threads fan-in across warps, distributing
+            //   the CHUNK_C reduction indices across the 32 lanes.
+            if (wid == 0) {
+                for (int i = lid; i < t_loc; i += 32) {
+                    float pw_tot = 0.f, pk_tot = 0.f;
+                    for (int w = 0; w < num_warps; w++) {
+                        pw_tot += batch_wbuf[w * CHUNK_C + i];
+                        pk_tot += batch_kbuf[w * CHUNK_C + i];
+                    }
+                    pw_smem[i] = pw_tot;
+                    pk_smem[i] = pk_tot;
+                }
+            }
+            __syncthreads();   // sync C: pw_smem / pk_smem broadcast
+
+            // Step 3: apply corrections — pure register arithmetic,
+            //   no sync needed.
+            float w_corr = 0.f;
+            float u_corr = 0.f;
+            for (int i = 0; i < t_loc; i++) {
+                w_corr += K_smem[i * BLOCK_K + k_idx] * pw_smem[i];
+                if (k_idx < BV) u_corr += U_smem[i * BV + k_idx] * pk_smem[i];
+            }
+
+            // W_smem[t_loc, :] = bk_t − w_corr
+            W_smem[t_loc * BLOCK_K + k_idx] = sq[k_idx] - w_corr;
+
+            // Load v for V-owning threads
+            float v_val = 0.f;
+            if (k_idx < BV) {
+                const int v_idx = v_start + k_idx;
+                v_val = (v_idx < V)
+                    ? to_float(v_ptr[t_g * HV * V + i_hv * V + v_idx]) : 0.f;
+            }
+            __syncthreads();   // sync D: W_smem[t_loc] visible for block_reduce_bv
+
+            // SW_smem[t_loc, v] = <S₀[v,:], W_smem[t_loc,:]>
+            float psw[BV];
+#pragma unroll
+            for (int bv = 0; bv < BV; bv++)
+                psw[bv] = state[bv] * W_smem[t_loc * BLOCK_K + k_idx];
+            float sw_r[BV];
+            block_reduce_bv(psw, rbv, bcast, sw_r);
+            // block_reduce_bv includes 2 __syncthreads internally
+
+            if (k_idx < BV) {
+                SW_smem[t_loc * BV + k_idx] = sw_r[k_idx];
+                // [OPT-3] Numerical guard: when gam_t underflows to 0.f the
+                // contribution β/γ·v would be ±inf, but the corresponding
+                // output term γ_r·Ũ[t] = 0 for any r≥t (since γ_r≤γ_t=0).
+                // Setting U_smem to 0 is therefore mathematically exact.
+                U_smem[t_loc * BV + k_idx] = (gam_t > 0.f)
+                    ? (beta / gam_t) * v_val - u_corr
+                    : 0.f;
+            }
+            __syncthreads();   // sync E: SW/U/gamma_sm visible for next t_loc
+        }
+
+        // ============================================================
+        // Phase 2 — Output for each token r in chunk.
+        //   Inner KQ dot products are batched the same way as Phase 1,
+        //   reusing batch_wbuf (Phase 1 data no longer needed) and
+        //   pw_smem (also safe to overwrite at each r).
+        // ============================================================
+        for (int r = 0; r < C; r++) {
+            const int64_t t_g = cs + r;
+
+            // ── L2-normalise q̂_r/√K → sq ────────────────────────────
+            const float q_raw = (k_idx < K)
+                ? to_float(q_ptr[t_g * H * K + i_h * K + k_idx]) : 0.f;
+            const float q_sq  = block_reduce_sum(q_raw * q_raw, warp_buf);
+            // block_reduce_sum: 2 __syncthreads internally
+            const float q_n   = q_raw * rsqrtf(q_sq + 1e-6f) * rsqrtf((float)K);
+            sq[k_idx] = q_n;
+            __syncthreads();   // sync A: sq ready
+
+            // SQ[v] = <S₀[v,:], q̂_r>
+            float psq[BV];
+#pragma unroll
+            for (int bv = 0; bv < BV; bv++) psq[bv] = state[bv] * sq[k_idx];
+            float sqs[BV];
+            block_reduce_bv(psq, rbv, bcast, sqs);
+            // block_reduce_bv: 2 __syncthreads internally
+
+            // ── [OPT-2] Batched KQ inner loop ────────────────────────
+            // KQ[i] = <K_smem[i,:], q̂_r> for i = 0..r
+            // Reuses batch_wbuf (Phase 1 done) and pw_smem (kq output).
+            //
+            // Step 1: warp partial sums for all i ≤ r simultaneously.
+            for (int i = 0; i <= r; i++) {
+                float kq_p = warp_reduce_sum(K_smem[i * BLOCK_K + k_idx] * sq[k_idx]);
+                if (lid == 0) batch_wbuf[wid * CHUNK_C + i] = kq_p;
+            }
+            __syncthreads();   // sync B: warp partials visible
+
+            // Step 2: warp-0 cross-warp fan-in.
+            if (wid == 0) {
+                for (int i = lid; i <= r; i += 32) {
+                    float tot = 0.f;
+                    for (int w = 0; w < num_warps; w++)
+                        tot += batch_wbuf[w * CHUNK_C + i];
+                    pw_smem[i] = tot;   // pw_smem repurposed as kq_smem
+                }
+            }
+            __syncthreads();   // sync C: kq values (pw_smem[0..r]) visible
+
+            // Accumulate Δ_i · KQ_i for i = 0..r  (pure register arithmetic)
+            float accum_k = 0.f;
+            if (k_idx < BV) {
+                for (int i = 0; i <= r; i++)
+                    accum_k += (U_smem[i * BV + k_idx] - SW_smem[i * BV + k_idx])
+                               * pw_smem[i];
+            }
+
+            // Write output
+            const float gam_r = gamma_sm[r];
+            if (k_idx < BV) {
+                const int v_idx = v_start + k_idx;
+                if (v_idx < V)
+                    output_ptr[t_g * HV * V + i_hv * V + v_idx] =
+                        from_float<T>(gam_r * (sqs[k_idx] + accum_k));
+            }
+            __syncthreads();   // sync D: protect sq/batch_wbuf/pw_smem
+        }
+
+        // ============================================================
+        // Phase 3 — State update (fully parallel over K, no block reduce)
+        //   S_new[v,k] = γ_C · (S₀[v,k] + Σ_i Δ_i[v]·K_smem[i,k])
+        // ============================================================
+        const float gam_C = gamma_sm[C - 1];
+#pragma unroll
+        for (int bv = 0; bv < BV; bv++) {
+            float ds = 0.f;
+            for (int i = 0; i < C; i++) {
+                const float delta = U_smem[i * BV + bv] - SW_smem[i * BV + bv];
+                ds += delta * K_smem[i * BLOCK_K + k_idx];
+            }
+            state[bv] = gam_C * (state[bv] + ds);
+        }
+        __syncthreads();   // smem safe to overwrite in next chunk
+    }
+
+    // ── Write final state back to pool ────────────────────────────────────
+#pragma unroll
+    for (int bv = 0; bv < BV; bv++) {
+        const int v_idx = v_start + bv;
+        if (v_idx < V && k_idx < K)
+            state_pool[state_base + (int64_t)v_idx * K + k_idx] = state[bv];
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Shared-memory size helper  (constexpr, updated for new smem layout)
+// ---------------------------------------------------------------------------
+
+template <int BLOCK_K, int CHUNK_C>
+constexpr size_t chunkwise_smem_bytes() {
+    constexpr int nw = BLOCK_K / 32;
+    // sq + warp_buf + pw_smem + pk_smem + batch_wbuf + batch_kbuf
+    //   + K_smem + W_smem + U_smem + SW_smem + gamma + rbv + bcast
+    return static_cast<size_t>(
+        BLOCK_K              // sq
+      + nw                   // warp_buf
+      + CHUNK_C              // pw_smem  [OPT-1/2]
+      + CHUNK_C              // pk_smem  [OPT-1]
+      + nw * CHUNK_C         // batch_wbuf [OPT-1/2]
+      + nw * CHUNK_C         // batch_kbuf [OPT-1]
+      + CHUNK_C * BLOCK_K    // K_smem
+      + CHUNK_C * BLOCK_K    // W_smem
+      + CHUNK_C * BV         // U_smem
+      + CHUNK_C * BV         // SW_smem
+      + CHUNK_C              // gamma_sm
+      + nw * BV              // rbv
+      + BV                   // bcast
+    ) * sizeof(float);
+}
+
+// ---------------------------------------------------------------------------
+// Smem size reference (bytes) — all within 48 KB default limit:
+//   BLOCK_K=64,  CHUNK_C=32, nw=2: ~21.5 KB  (K≤64)
+//   BLOCK_K=128, CHUNK_C=32, nw=4: ~42.5 KB  (K=128, most common)
+//   BLOCK_K=256, CHUNK_C=16, nw=8: ~39.4 KB  (K=256)
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Launch wrapper (called via TVM FFI)
+// ---------------------------------------------------------------------------
+
+void run(
+    tvm::ffi::TensorView q,
+    tvm::ffi::TensorView k,
+    tvm::ffi::TensorView v,
+    tvm::ffi::TensorView a,
+    tvm::ffi::TensorView b,
+    tvm::ffi::TensorView A_log,
+    tvm::ffi::TensorView dt_bias,
+    tvm::ffi::TensorView state_pool,
+    tvm::ffi::TensorView cache_indices,
+    tvm::ffi::TensorView cu_seqlens,
+    tvm::ffi::TensorView output
+) {
+    using namespace mllm_kernel::host;
+
+    auto TT  = SymbolicSize{"total_tokens"};
+    auto BS  = SymbolicSize{"batch_size"};
+    auto BS1 = SymbolicSize{"batch_size_plus_1"};
+    auto H_  = SymbolicSize{"H"};
+    auto HV_ = SymbolicSize{"HV"};
+    auto K_  = SymbolicSize{"K"};
+    auto V_  = SymbolicSize{"V"};
+    auto PS  = SymbolicSize{"pool_size"};
+    auto dtype  = SymbolicDType{};
+    auto device = SymbolicDevice{};
+    device.set_options<kDLCUDA>();
+    dtype.set_options<fp16_t, bf16_t>();
+
+    (void)TensorMatcher({TT, H_, K_}).with_dtype(dtype).with_device(device).verify(q);
+    (void)TensorMatcher({TT, H_, K_}).with_dtype(dtype).with_device(device).verify(k);
+    (void)TensorMatcher({TT, HV_, V_}).with_dtype(dtype).with_device(device).verify(v);
+    (void)TensorMatcher({TT, HV_}).with_dtype(dtype).with_device(device).verify(a);
+    (void)TensorMatcher({TT, HV_}).with_dtype(dtype).with_device(device).verify(b);
+    (void)TensorMatcher({HV_}).with_dtype<float>().with_device(device).verify(A_log);
+    (void)TensorMatcher({HV_}).with_dtype<float>().with_device(device).verify(dt_bias);
+    (void)TensorMatcher({PS, HV_, V_, K_}).with_dtype<float>().with_device(device).verify(state_pool);
+    (void)TensorMatcher({BS}).with_device(device).verify(cache_indices);
+    (void)TensorMatcher({BS1}).with_device(device).verify(cu_seqlens);
+    (void)TensorMatcher({TT, HV_, V_}).with_dtype(dtype).with_device(device).verify(output);
+
+    RuntimeCheck(BS1.unwrap() == BS.unwrap() + 1,
+                 "cu_seqlens must have batch_size+1 elements");
+
+    if (TT.unwrap() == 0) return;
+
+    const int batch_size = static_cast<int>(BS.unwrap());
+    const int H  = static_cast<int>(H_.unwrap());
+    const int HV = static_cast<int>(HV_.unwrap());
+    const int K  = static_cast<int>(K_.unwrap());
+    const int V  = static_cast<int>(V_.unwrap());
+
+    int block_k = ((K + 31) / 32) * 32;
+    if (block_k > 256) block_k = 256;
+    const int NV = (V + BV - 1) / BV;
+    dim3 grid(NV, batch_size * HV);
+    dim3 block(block_k);
+
+    const DLDevice dl_device = device.unwrap();
+
+    // ── Launch macro ──────────────────────────────────────────────────────
+    // All configurations stay within the 48 KB default dynamic-smem limit:
+    //   BLOCK_K ≤ 64,  CHUNK_C=32 → ~21.5 KB
+    //   BLOCK_K = 128, CHUNK_C=32 → ~42.5 KB
+    //   BLOCK_K = 256, CHUNK_C=16 → ~39.4 KB
+    // No cudaFuncSetAttribute / runtime SM detection needed.
+#define LAUNCH_CW(CType, BKVAL, CCVAL)                                        \
+    LaunchKernel(grid, block, dl_device,                                       \
+                 chunkwise_smem_bytes<BKVAL, CCVAL>())(                        \
+        gdn_extend_chunkwise_kernel<CType, BKVAL, CCVAL>,                     \
+        static_cast<const CType*>(q.data_ptr()),                              \
+        static_cast<const CType*>(k.data_ptr()),                              \
+        static_cast<const CType*>(v.data_ptr()),                              \
+        static_cast<const CType*>(a.data_ptr()),                              \
+        static_cast<const CType*>(b.data_ptr()),                              \
+        static_cast<const float*>(A_log.data_ptr()),                          \
+        static_cast<const float*>(dt_bias.data_ptr()),                        \
+        static_cast<float*>(state_pool.data_ptr()),                           \
+        static_cast<const int64_t*>(cache_indices.data_ptr()),                \
+        static_cast<const int64_t*>(cu_seqlens.data_ptr()),                   \
+        static_cast<CType*>(output.data_ptr()),                               \
+        batch_size, H, HV, K, V)
+
+    // ── Dispatch ──────────────────────────────────────────────────────────
+    if (dtype.is_type<bf16_t>()) {
+        if      (block_k <= 64)  { LAUNCH_CW(__nv_bfloat16, 64,  32); }
+        else if (block_k == 128) { LAUNCH_CW(__nv_bfloat16, 128, 32); }
+        else                     { LAUNCH_CW(__nv_bfloat16, 256, 16); }
+    } else {
+        if      (block_k <= 64)  { LAUNCH_CW(__half, 64,  32); }
+        else if (block_k == 128) { LAUNCH_CW(__half, 128, 32); }
+        else                     { LAUNCH_CW(__half, 256, 16); }
+    }
+
+#undef LAUNCH_CW
+}
+
+}  // namespace GDNExtendChunkwiseKernel

--- a/mllm-kernel/mllm_kernel/cuda/csrc/gdn_extend_chunkwise.cuh
+++ b/mllm-kernel/mllm_kernel/cuda/csrc/gdn_extend_chunkwise.cuh
@@ -379,11 +379,13 @@ __global__ void gdn_extend_chunkwise_kernel(
 
             if (k_idx < BV) {
                 SW_smem[t_loc * BV + k_idx] = sw_r[k_idx];
-                // [OPT-3] Numerical guard: when gam_t underflows to 0.f the
-                // contribution β/γ·v would be ±inf, but the corresponding
-                // output term γ_r·Ũ[t] = 0 for any r≥t (since γ_r≤γ_t=0).
-                // Setting U_smem to 0 is therefore mathematically exact.
-                U_smem[t_loc * BV + k_idx] = (gam_t > 0.f)
+                // OPT-3 (stricter): the bound must protect against denormal as well,
+                // because beta / gam_t needs to fit in FP32.  With v_val up to O(10^3)
+                // (post-RMSNorm activation), the safe threshold is ~1e-30
+                // (then |beta/gam_t * v_val| ≲ 10^3 / 10^-30 = 10^33, well under FP32 max).
+                // Mathematically equivalent to setting Ũ[t]=0 because for any r ≥ t,
+                // γ_r ≤ γ_t ≤ 1e-30, so γ_r · Ũ[t] is below FP32 precision floor anyway.
+                U_smem[t_loc * BV + k_idx] = (gam_t > 1.0e-30f)
                     ? (beta / gam_t) * v_val - u_corr
                     : 0.f;
             }
@@ -469,7 +471,9 @@ __global__ void gdn_extend_chunkwise_kernel(
                 const float delta = U_smem[i * BV + bv] - SW_smem[i * BV + bv];
                 ds += delta * K_smem[i * BLOCK_K + k_idx];
             }
-            state[bv] = gam_C * (state[bv] + ds);
+            // Guard: when gam_C underflows the new state is mathematically 0;
+            // avoid 0 * Inf = NaN propagation if upstream (e.g. Phase 1/2) overflowed.
+            state[bv] = (gam_C > 0.f) ? gam_C * (state[bv] + ds) : 0.f;
         }
         __syncthreads();   // smem safe to overwrite in next chunk
     }

--- a/mllm-kernel/mllm_kernel/cuda/jit/__init__.py
+++ b/mllm-kernel/mllm_kernel/cuda/jit/__init__.py
@@ -11,6 +11,7 @@ __all__ = [
     "gptq_marlin_repack",
     "can_use_store_cache",
     "gdn_decode",
+    "gdn_extend",
     "gptq_marlin_gemm",
     "store_cache",
 ]

--- a/mllm-kernel/mllm_kernel/cuda/jit/gdn_extend_chunkwise.py
+++ b/mllm-kernel/mllm_kernel/cuda/jit/gdn_extend_chunkwise.py
@@ -1,0 +1,178 @@
+"""Chunkwise-parallel GDN extend CUDA JIT kernel (WY representation).
+
+Implements the same GDN prefill recurrence as ``gdn_extend`` but uses
+a WY-factored chunkwise decomposition inside the kernel:
+
+  S_T = γ_C · (S_0 (I − W K^T) + Ũ K^T)
+
+The sequential WY scan runs inside the CUDA block (shared memory), while
+the per-token output and the final state update are expressed as
+matrix-like operations that exploit more GPU parallelism, especially for
+long sequences.
+
+Performance notes (Jetson Orin NX, SM87):
+  • Eliminates all Python-level dispatch overhead vs. the PyTorch
+    chunkwise backend (``gdn_chunkwise.py``).
+  • For T ≳ 4 × CHUNK_C (≈ 128 tokens) performance is comparable to
+    the sequential ``gdn_extend`` kernel.
+  • For T ≳ 512 tokens the smem K/W reuse begins to pay off.
+  • For T < 64 the WY construction overhead dominates; prefer the
+    sequential ``mllm_kernel`` backend.
+
+Usage::
+
+    from mllm_kernel.cuda.jit.gdn_extend_chunkwise import gdn_extend_chunkwise
+
+    output = gdn_extend_chunkwise(
+        q, k, v, a, b, A_log, dt_bias,
+        state_pool, cache_indices, cu_seqlens,
+    )
+"""
+
+from __future__ import annotations
+
+import torch
+
+from mllm_kernel.jit_utils import cache_once, jit
+
+
+@cache_once
+def _make_gdn_extend_chunkwise_kernel():
+    """JIT-compile the chunkwise GDN extend CUDA kernel.
+
+    On Jetson Orin (ARM CPU) the first compilation takes ~10-15 s.
+    Use :func:`precompile` during server startup to avoid this latency
+    on the first actual inference request.
+    """
+
+    @jit(
+        args=[],
+        device="cuda",
+        cuda_files=["gdn_extend_chunkwise.cuh"],
+        cpp_wrappers=[],
+        cuda_wrappers=[
+            ("gdn_extend_chunkwise", "GDNExtendChunkwiseKernel::run"),
+        ],
+        func_name="gdn_extend_chunkwise",
+    )
+    def _kernel(
+        compiled_module,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        a: torch.Tensor,
+        b: torch.Tensor,
+        A_log: torch.Tensor,
+        dt_bias: torch.Tensor,
+        state_pool: torch.Tensor,
+        cache_indices: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        output: torch.Tensor,
+    ) -> None:
+        compiled_module.gdn_extend_chunkwise(
+            q, k, v, a, b, A_log, dt_bias,
+            state_pool, cache_indices, cu_seqlens, output,
+        )
+
+    return _kernel
+
+
+def precompile() -> bool:
+    """Eagerly trigger CUDA kernel compilation.
+
+    Call this during server / model initialization so that the first
+    inference request does not pay the compilation cost (~10-15 s on
+    Jetson Orin ARM CPU).  Idempotent: subsequent calls return
+    immediately because the result is cached by ``@cache_once``.
+
+    Returns
+    -------
+    bool
+        ``True`` if the kernel compiled successfully, ``False`` on error.
+    """
+    import logging
+    _log = logging.getLogger(__name__)
+    try:
+        _make_gdn_extend_chunkwise_kernel()
+        return True
+    except Exception as e:
+        _log.warning(
+            "gdn_extend_chunkwise precompile FAILED: %s: %s",
+            type(e).__name__, e, exc_info=True,
+        )
+        return False
+
+
+def gdn_extend_chunkwise(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    a: torch.Tensor,
+    b: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    state_pool: torch.Tensor,
+    cache_indices: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+) -> torch.Tensor:
+    """Chunkwise-parallel GDN extend using WY decomposition (CUDA kernel).
+
+    Processes variable-length token sequences (prefill stage).  The
+    recurrent state is kept in registers across chunks, with the
+    intra-chunk WY scan performed in shared memory.
+
+    Parameters
+    ----------
+    q : torch.Tensor
+        Query tensor ``(total_tokens, num_k_heads, head_k_dim)``, bf16/fp16.
+        L2 normalization + 1/√K scaling applied inside the kernel.
+    k : torch.Tensor
+        Key tensor ``(total_tokens, num_k_heads, head_k_dim)``, bf16/fp16.
+    v : torch.Tensor
+        Value tensor ``(total_tokens, num_v_heads, head_v_dim)``, bf16/fp16.
+    a : torch.Tensor
+        Decay gate input ``(total_tokens, num_v_heads)``, bf16/fp16.
+    b : torch.Tensor
+        Update gate input ``(total_tokens, num_v_heads)``, bf16/fp16.
+    A_log : torch.Tensor
+        Log-space decay parameter ``(num_v_heads,)``, float32.
+    dt_bias : torch.Tensor
+        Decay gate bias ``(num_v_heads,)``, float32.
+    state_pool : torch.Tensor
+        Pooled recurrent state
+        ``(pool_size, num_v_heads, head_v_dim, head_k_dim)``, float32.
+        Modified in-place.
+    cache_indices : torch.Tensor
+        Pool indices per request ``(batch_size,)``, int64.
+    cu_seqlens : torch.Tensor
+        Cumulative sequence lengths ``(batch_size + 1,)``, int64.
+
+    Returns
+    -------
+    torch.Tensor
+        Output ``(total_tokens, num_v_heads, head_v_dim)``, same dtype as ``v``.
+    """
+    total_tokens = q.shape[0]
+    num_v_heads  = v.shape[1]
+    head_v_dim   = v.shape[2]
+
+    output = torch.empty(
+        total_tokens, num_v_heads, head_v_dim,
+        dtype=v.dtype, device=v.device,
+    )
+
+    kernel = _make_gdn_extend_chunkwise_kernel()
+    kernel(
+        q.contiguous(),
+        k.contiguous(),
+        v.contiguous(),
+        a.contiguous(),
+        b.contiguous(),
+        A_log.contiguous(),
+        dt_bias.contiguous(),
+        state_pool,
+        cache_indices.to(torch.int64).contiguous(),
+        cu_seqlens.to(torch.int64).contiguous(),
+        output,
+    )
+    return output

--- a/pymllm/configs/server_config.py
+++ b/pymllm/configs/server_config.py
@@ -58,6 +58,7 @@ class ServerConfig:
     # --------------------------------------------------------------------- #
     attention_backend: Literal["auto", "flashinfer"] = "auto"
     gdn_decode_backend: Literal["auto", "flashinfer", "mllm_kernel", "pytorch"] = "auto"
+    gdn_extend_backend: Literal["auto", "flashinfer", "mllm_kernel", "cuda_chunkwise", "pytorch"] = "auto"
     sampling_backend: Optional[str] = None
     disable_cuda_graph: bool = False
     enable_torch_compile: bool = False

--- a/pymllm/layers/attention/gdn_backend.py
+++ b/pymllm/layers/attention/gdn_backend.py
@@ -42,6 +42,27 @@ def _get_gdn_decode_backend_override() -> str:
         return "auto"
 
 
+def _get_gdn_extend_backend_override() -> str:
+    """Read GDN extend backend preference.
+
+    Checks (in order):
+    1. ``$PYMLLM_GDN_EXTEND_BACKEND`` env var
+    2. ``server.gdn_extend_backend`` config field
+    3. Falls back to ``"auto"``
+
+    Returns one of: ``"auto"``, ``"flashinfer"``, ``"mllm_kernel"``,
+    ``"cuda_chunkwise"``, ``"pytorch"``.
+    """
+    env = os.environ.get("PYMLLM_GDN_EXTEND_BACKEND", "").strip().lower()
+    if env in ("auto", "flashinfer", "mllm_kernel", "cuda_chunkwise", "pytorch"):
+        return env
+    try:
+        from pymllm.configs import get_global_config
+        return getattr(get_global_config().server, "gdn_extend_backend", "auto")
+    except Exception:
+        return "auto"
+
+
 # ---------------------------------------------------------------------------
 # mllm-kernel GDN decode (lazy import, SM80+)
 # ---------------------------------------------------------------------------
@@ -62,6 +83,81 @@ def _get_mllm_gdn_decode():
             logger.info("GDNAttnBackend: [probe] mllm-kernel GDN decode not available: %s", e)
             _mllm_gdn_decode = False
     return _mllm_gdn_decode if _mllm_gdn_decode is not False else None
+
+
+# ---------------------------------------------------------------------------
+# mllm-kernel GDN extend / prefill (lazy import, SM80+)
+# ---------------------------------------------------------------------------
+
+_mllm_gdn_extend = None
+
+
+def _get_mllm_gdn_extend():
+    """Lazy import for mllm-kernel fused GDN extend (prefill) CUDA kernel."""
+    global _mllm_gdn_extend
+    if _mllm_gdn_extend is None:
+        try:
+            from mllm_kernel.cuda.jit.gdn_extend import gdn_extend
+            _mllm_gdn_extend = gdn_extend
+            logger.info("GDNAttnBackend: [probe] mllm-kernel GDN extend available (SM80+)")
+        except (ImportError, RuntimeError) as e:
+            logger.info("GDNAttnBackend: [probe] mllm-kernel GDN extend not available: %s", e)
+            _mllm_gdn_extend = False
+    return _mllm_gdn_extend if _mllm_gdn_extend is not False else None
+
+
+# ---------------------------------------------------------------------------
+# mllm-kernel GDN chunkwise extend (lazy import + eager compile, SM80+)
+# ---------------------------------------------------------------------------
+
+_mllm_gdn_extend_cw = None
+
+
+def _get_mllm_gdn_extend_chunkwise():
+    """Import and eagerly compile the chunkwise GDN extend CUDA kernel.
+
+    Called from ``GDNAttnBackend.__init__`` when ``cuda_chunkwise`` is
+    explicitly configured, so the ~15 s JIT cost is paid at model-load time.
+    """
+    global _mllm_gdn_extend_cw
+    if _mllm_gdn_extend_cw is None:
+        try:
+            from mllm_kernel.cuda.jit.gdn_extend_chunkwise import gdn_extend_chunkwise
+            try:
+                from mllm_kernel.cuda.jit.gdn_extend_chunkwise import precompile as _cw_precompile
+            except ImportError:
+                _cw_precompile = None
+
+            if _cw_precompile is not None:
+                logger.info(
+                    "GDNAttnBackend: [probe] mllm-kernel GDN chunkwise — "
+                    "compiling CUDA kernel (first run may take ~15 s on Jetson) …"
+                )
+                ok = _cw_precompile()
+            else:
+                logger.info(
+                    "GDNAttnBackend: [probe] mllm-kernel GDN chunkwise — "
+                    "precompile not available, kernel will compile on first use"
+                )
+                ok = True
+
+            if ok:
+                _mllm_gdn_extend_cw = gdn_extend_chunkwise
+                logger.info("GDNAttnBackend: [probe] mllm-kernel GDN chunkwise extend available (SM80+)")
+            else:
+                _mllm_gdn_extend_cw = False
+                logger.warning(
+                    "GDNAttnBackend: [probe] mllm-kernel GDN chunkwise extend "
+                    "CUDA compilation failed — falling back to pytorch"
+                )
+        except Exception as e:
+            logger.warning(
+                "GDNAttnBackend: [probe] mllm-kernel GDN chunkwise extend "
+                "import/compile error (%s: %s) — falling back",
+                type(e).__name__, e, exc_info=True,
+            )
+            _mllm_gdn_extend_cw = False
+    return _mllm_gdn_extend_cw if _mllm_gdn_extend_cw is not False else None
 
 
 # ---------------------------------------------------------------------------
@@ -172,6 +268,11 @@ class GDNAttnBackend:
 
         # Pre-check FlashInfer availability
         self._use_flashinfer, _, _ = _get_flashinfer_gdn()
+
+        # Eagerly compile chunkwise kernel at load time so the first
+        # inference request doesn't pay the ~15 s JIT cost.
+        if _get_gdn_extend_backend_override() == "cuda_chunkwise":
+            _get_mllm_gdn_extend_chunkwise()
 
         # One-shot flags to log the selected backend on first actual forward call
         self._decode_backend_logged = False
@@ -404,6 +505,7 @@ class GDNAttnBackend:
         # L2 normalize q and k per-head (matching use_qk_l2norm_in_kernel=True)
         q = q / (q.norm(dim=-1, keepdim=True) + 1e-6)
         k = k / (k.norm(dim=-1, keepdim=True) + 1e-6)
+        q = q * (q.shape[-1] ** -0.5)
 
         decay = torch.exp(g.float())    # [bs, num_v_heads]
         beta_f = beta.float()           # [bs, num_v_heads]
@@ -506,51 +608,79 @@ class GDNAttnBackend:
         k = k.view(total_tokens, layer.num_k_heads, layer.head_k_dim)
         v = v.view(total_tokens, layer.num_v_heads, layer.head_v_dim)
 
-        # --- GDN gating ---
-        g, beta = _gdn_gating(a, b, layer.A_log, layer.dt_bias)
-
         # --- Recurrent computation ---
+        # Priority (when "auto"):
+        #   FlashInfer SM90+ > mllm_kernel SM80+ > cuda_chunkwise SM80+ > PyTorch
+        # Override via server.gdn_extend_backend or $PYMLLM_GDN_EXTEND_BACKEND
+        backend        = _get_gdn_extend_backend_override()
         use_fi, fi_prefill, _ = _get_flashinfer_gdn()
-        use_fi_extend = use_fi and fi_prefill is not None and mixed_qkv.is_cuda
+        mllm_extend    = _get_mllm_gdn_extend()
+        mllm_extend_cw = _get_mllm_gdn_extend_chunkwise()
+
+        use_fi_extend = (
+            (backend in ("auto", "flashinfer"))
+            and use_fi and fi_prefill is not None and mixed_qkv.is_cuda
+        )
+        use_mllm_extend = (
+            not use_fi_extend
+            and (backend in ("auto", "mllm_kernel"))
+            and mllm_extend is not None and mixed_qkv.is_cuda
+        )
+        use_cuda_chunkwise = (
+            (backend == "cuda_chunkwise"
+             or (backend == "auto" and not use_fi_extend and not use_mllm_extend
+                 and mllm_extend_cw is not None and mixed_qkv.is_cuda))
+            and mllm_extend_cw is not None
+        )
 
         if not self._extend_backend_logged:
+            selected = (
+                "flashinfer"     if use_fi_extend      else
+                "mllm_kernel"    if use_mllm_extend    else
+                "cuda_chunkwise" if use_cuda_chunkwise else
+                "pytorch"
+            )
             logger.info(
-                "GDNAttnBackend: [extend] using backend=%s",
-                "flashinfer" if use_fi_extend else "pytorch",
+                "GDNAttnBackend: [extend] using backend=%s (config=%s)", selected, backend
             )
             self._extend_backend_logged = True
 
         if use_fi_extend:
-            # Gather initial states for this batch
+            g, beta = _gdn_gating(a, b, layer.A_log, layer.dt_bias)
             init_state = recurrent_buf[cache_indices].to(torch.float32)
-            # [batch_size, num_v_heads, head_v_dim, head_k_dim]
-
             alpha = torch.exp(g.to(torch.float32))
             beta_f32 = beta.to(torch.float32)
-
             # FlashInfer's use_qk_l2norm_in_kernel is silently ignored —
-            # the flag is declared in the Python wrapper but never forwarded
-            # to the CUDA kernel.  Pre-normalize q and k here, matching
-            # sglang's approach (l2norm_fwd before calling with False).
+            # pre-normalise q/k here to match sglang's approach.
             q_fi = q / (q.norm(dim=-1, keepdim=True) + 1e-6)
             k_fi = k / (k.norm(dim=-1, keepdim=True) + 1e-6)
-
+            q_fi = q_fi * (q_fi.shape[-1] ** -0.5)
             output, final_state = fi_prefill(
-                q=q_fi.contiguous(),
-                k=k_fi.contiguous(),
-                v=v.contiguous(),
-                g=alpha,
-                beta=beta_f32,
-                initial_state=init_state,
-                output_final_state=True,
-                cu_seqlens=cu_seqlens,
-                use_qk_l2norm_in_kernel=False,
+                q=q_fi.contiguous(), k=k_fi.contiguous(), v=v.contiguous(),
+                g=alpha, beta=beta_f32,
+                initial_state=init_state, output_final_state=True,
+                cu_seqlens=cu_seqlens, use_qk_l2norm_in_kernel=False,
+            )
+            recurrent_buf[cache_indices] = final_state.to(recurrent_buf.dtype)
+
+        elif use_mllm_extend:
+            # Sequential recurrent scan — all fused in one CUDA kernel.
+            output = mllm_extend(
+                q, k, v, a, b,
+                layer.A_log, layer.dt_bias,
+                recurrent_buf, cache_indices, cu_seqlens,
             )
 
-            # Scatter final states back to pool
-            recurrent_buf[cache_indices] = final_state.to(recurrent_buf.dtype)
+        elif use_cuda_chunkwise:
+            # Chunkwise WY-parallel CUDA kernel (SM80+).
+            output = mllm_extend_cw(
+                q, k, v, a, b,
+                layer.A_log, layer.dt_bias,
+                recurrent_buf, cache_indices, cu_seqlens,
+            )
+
         else:
-            # PyTorch fallback: per-request sequential scan
+            g, beta = _gdn_gating(a, b, layer.A_log, layer.dt_bias)
             output = self._extend_pytorch_fallback(
                 q, k, v, g, beta, recurrent_buf, cache_indices, cu_seqlens, layer
             )
@@ -585,6 +715,7 @@ class GDNAttnBackend:
         # L2 normalize q and k per-head
         q = q / (q.norm(dim=-1, keepdim=True) + 1e-6)
         k = k / (k.norm(dim=-1, keepdim=True) + 1e-6)
+        q = q * (q.shape[-1] ** -0.5)
 
         # GQA expansion
         if num_k_heads != num_v_heads:

--- a/pymllm/layers/attention/gdn_chunkwise.py
+++ b/pymllm/layers/attention/gdn_chunkwise.py
@@ -1,0 +1,250 @@
+"""Chunkwise parallel GDN extend (prefill) using WY representation.
+
+Implements the WY decomposition from the Gated DeltaNet paper to
+parallelize the GDN recurrent scan over token chunks.  Within each
+chunk the key operations (output and state computation) are expressed
+as batch matrix multiplications, enabling efficient GPU utilisation.
+
+The inter-chunk state propagation remains sequential, but reduces the
+number of iterations from T to ceil(T / C) where C is the chunk size.
+
+Algorithm (per chunk of C tokens with initial state S_0)
+---------------------------------------------------------
+1. **WY construction** (sequential, O(C²K) per head):
+
+       w_i = β_i k_i - K_{<i}(W_{<i}^T (β_i k_i))
+       ũ_i = (β_i / γ_i) v_i - Ũ_{<i}(K_{<i}^T (β_i k_i))
+
+   where γ_i = Π_{j=0}^{i} α_j is the cumulative decay.
+
+2. **Output computation** (parallel, batch matmul):
+
+       O = γ · (S_0 Q − (S_0 W) · triu(K^T Q) + Ũ · triu(K^T Q))
+
+   ``triu`` is the causal mask (upper-triangular: j ≤ r).
+
+3. **State update** (parallel, batch matmul):
+
+       S_new = γ_C · (S_0 − (S_0 W) K^T + Ũ^T K)
+
+Usage::
+
+    from pymllm.layers.attention.gdn_chunkwise import gdn_extend_chunkwise
+
+    output = gdn_extend_chunkwise(
+        q, k, v, a, b, A_log, dt_bias,
+        state_pool, cache_indices, cu_seqlens,
+        chunk_size=64,
+    )
+"""
+
+from __future__ import annotations
+
+import torch
+
+
+def gdn_extend_chunkwise(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    a: torch.Tensor,
+    b: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    state_pool: torch.Tensor,
+    cache_indices: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    chunk_size: int = 64,
+) -> torch.Tensor:
+    """Chunkwise parallel GDN extend with WY representation.
+
+    Parameters
+    ----------
+    q : Tensor [total_tokens, H, K]
+        Query tensor (bf16/fp16).  NOT pre-normalised.
+    k : Tensor [total_tokens, H, K]
+        Key tensor (bf16/fp16).
+    v : Tensor [total_tokens, HV, V]
+        Value tensor (bf16/fp16).
+    a : Tensor [total_tokens, HV]
+        Raw decay-gate input (before softplus/exp).
+    b : Tensor [total_tokens, HV]
+        Raw update-gate input (before sigmoid).
+    A_log : Tensor [HV]
+        Log-space decay parameter, float32.
+    dt_bias : Tensor [HV]
+        Bias for decay gate, float32.
+    state_pool : Tensor [pool_size, HV, V, K]
+        Pooled recurrent state, float32.  Modified **in-place**.
+    cache_indices : Tensor [batch_size]
+        Pool index per request, int64.
+    cu_seqlens : Tensor [batch_size + 1]
+        Cumulative sequence lengths, int64.
+    chunk_size : int
+        Number of tokens per chunk (default 64).
+
+    Returns
+    -------
+    Tensor [total_tokens, HV, V]
+        Output tensor, same dtype as *v*.
+    """
+    total_tokens, H, K = q.shape
+    HV = v.shape[1]
+    V = v.shape[2]
+    batch_size = cache_indices.shape[0]
+    device = q.device
+
+    orig_dtype = v.dtype
+    q = q.float()
+    k = k.float()
+    v = v.float()
+    a = a.float()
+    b = b.float()
+
+    # --- gating (all tokens) ---
+    x = a + dt_bias.unsqueeze(0)
+    softplus_x = torch.where(x <= 20.0, torch.log1p(torch.exp(x)), x)
+    g = -torch.exp(A_log.unsqueeze(0)) * softplus_x
+    alpha = torch.exp(g)
+    beta = torch.sigmoid(b)
+
+    # --- L2 normalise q, k (per key-head, before GQA expansion) ---
+    q = q / (q.norm(dim=-1, keepdim=True) + 1e-6)
+    k = k / (k.norm(dim=-1, keepdim=True) + 1e-6)
+    q = q * (K ** -0.5)
+
+    # --- GQA expansion ---
+    if H != HV:
+        repeats = HV // H
+        q = q.repeat_interleave(repeats, dim=1)
+        k = k.repeat_interleave(repeats, dim=1)
+
+    output = torch.zeros(total_tokens, HV, V, device=device, dtype=torch.float32)
+
+    for i in range(batch_size):
+        seq_start = int(cu_seqlens[i].item())
+        seq_end = int(cu_seqlens[i + 1].item())
+        seq_len = seq_end - seq_start
+        if seq_len == 0:
+            continue
+
+        pool_idx = int(cache_indices[i].item())
+        state = state_pool[pool_idx].clone()  # [HV, V, K]
+
+        q_seq = q[seq_start:seq_end]
+        k_seq = k[seq_start:seq_end]
+        v_seq = v[seq_start:seq_end]
+        alpha_seq = alpha[seq_start:seq_end]
+        beta_seq = beta[seq_start:seq_end]
+
+        for cs in range(0, seq_len, chunk_size):
+            ce = min(cs + chunk_size, seq_len)
+            C = ce - cs
+
+            q_c = q_seq[cs:ce]          # [C, HV, K]
+            k_c = k_seq[cs:ce]          # [C, HV, K]
+            v_c = v_seq[cs:ce]          # [C, HV, V]
+            alpha_c = alpha_seq[cs:ce]  # [C, HV]
+            beta_c = beta_seq[cs:ce]    # [C, HV]
+
+            state = _process_chunk(
+                q_c, k_c, v_c, alpha_c, beta_c,
+                state, output,
+                seq_start + cs, C, HV, K, V, device,
+            )
+
+        state_pool[pool_idx] = state
+
+    return output.to(orig_dtype)
+
+
+def _process_chunk(
+    q_c: torch.Tensor,      # [C, HV, K]
+    k_c: torch.Tensor,      # [C, HV, K]
+    v_c: torch.Tensor,      # [C, HV, V]
+    alpha_c: torch.Tensor,  # [C, HV]
+    beta_c: torch.Tensor,   # [C, HV]
+    state: torch.Tensor,    # [HV, V, K]
+    output: torch.Tensor,   # [total_tokens, HV, V]  (written in-place)
+    write_offset: int,
+    C: int,
+    HV: int,
+    K: int,
+    V: int,
+    device: torch.device,
+) -> torch.Tensor:
+    """Process one chunk: WY construction → matmul output → state update."""
+
+    # ---- cumulative decay within chunk ----
+    log_alpha_c = torch.log(alpha_c.clamp(min=1e-10))  # [C, HV]
+    cum_log = torch.cumsum(log_alpha_c, dim=0)          # [C, HV]
+    gamma = torch.exp(cum_log)                           # [C, HV]
+    gamma_C = gamma[-1]                                  # [HV]
+
+    # ---- precompute β·k and (β/γ)·v ----
+    bk = beta_c.unsqueeze(-1) * k_c                      # [C, HV, K]
+    bv_scaled = (beta_c / gamma).unsqueeze(-1) * v_c     # [C, HV, V]
+
+    # Contiguous buffers for WY vectors (permuted: [HV, dim, C])
+    bk_p = bk.permute(1, 2, 0).contiguous()              # [HV, K, C]
+    bv_p = bv_scaled.permute(1, 2, 0).contiguous()       # [HV, V, C]
+    K_p = k_c.permute(1, 2, 0).contiguous()              # [HV, K, C]
+
+    W_buf = torch.zeros(HV, K, C, device=device, dtype=torch.float32)
+    U_buf = torch.zeros(HV, V, C, device=device, dtype=torch.float32)
+
+    # ================================================================
+    # Phase 1 — WY construction (sequential over C, parallel over HV)
+    # ================================================================
+    W_buf[:, :, 0] = bk_p[:, :, 0]
+    U_buf[:, :, 0] = bv_p[:, :, 0]
+
+    for t in range(1, C):
+        bk_t = bk_p[:, :, t : t + 1]            # [HV, K, 1]
+        K_prev = K_p[:, :, :t]                   # [HV, K, t]
+        W_prev = W_buf[:, :, :t]                 # [HV, K, t]
+        U_prev = U_buf[:, :, :t]                 # [HV, V, t]
+
+        # proj_w = W_prev^T @ (β_t k_t)
+        proj_w = torch.bmm(W_prev.transpose(1, 2), bk_t)   # [HV, t, 1]
+        # w correction = K_prev @ proj_w
+        w_corr = torch.bmm(K_prev, proj_w)                  # [HV, K, 1]
+        W_buf[:, :, t : t + 1] = bk_t - w_corr
+
+        # proj_k = K_prev^T @ (β_t k_t)  (shared for U update)
+        proj_k = torch.bmm(K_prev.transpose(1, 2), bk_t)   # [HV, t, 1]
+        u_corr = torch.bmm(U_prev, proj_k)                  # [HV, V, 1]
+        U_buf[:, :, t : t + 1] = bv_p[:, :, t : t + 1] - u_corr
+
+    # ================================================================
+    # Phase 2 — output computation (batch matmul)
+    # ================================================================
+    Q_p = q_c.permute(1, 2, 0).contiguous()      # [HV, K, C]
+
+    SQ = torch.bmm(state, Q_p)                    # [HV, V, C]
+    SW = torch.bmm(state, W_buf)                   # [HV, V, C]
+
+    # K^T Q with causal mask (j ≤ r → upper triangular)
+    KQ = torch.bmm(K_p.transpose(1, 2), Q_p)      # [HV, C, C]
+    causal = torch.triu(torch.ones(C, C, device=device, dtype=torch.float32))
+    KQ_masked = KQ * causal.unsqueeze(0)
+
+    SW_KQ = torch.bmm(SW, KQ_masked)              # [HV, V, C]
+    U_KQ = torch.bmm(U_buf, KQ_masked)            # [HV, V, C]
+
+    # O = γ · (S_0 Q − (S_0 W) triu(K^T Q) + Ũ triu(K^T Q))
+    gamma_bc = gamma.permute(1, 0).unsqueeze(1)    # [HV, 1, C]
+    O_chunk = gamma_bc * (SQ - SW_KQ + U_KQ)      # [HV, V, C]
+
+    output[write_offset : write_offset + C] = O_chunk.permute(2, 0, 1)
+
+    # ================================================================
+    # Phase 3 — state update
+    # ================================================================
+    # S_new = γ_C · (S_0 − S_0 W K^T + Ũ^T K)
+    K_pT = K_p.transpose(1, 2)                    # [HV, C, K]
+    SW_K = torch.bmm(SW, K_pT)                    # [HV, V, K]
+    UK = torch.bmm(U_buf, K_pT)                   # [HV, V, K]
+
+    gamma_C_bc = gamma_C.unsqueeze(-1).unsqueeze(-1)
+    return gamma_C_bc * (state - SW_K + UK)

--- a/pymllm/layers/rms_norm.py
+++ b/pymllm/layers/rms_norm.py
@@ -82,6 +82,13 @@ class GemmaRMSNorm(MllmBaseLayer):
         x: torch.Tensor,
         residual: Optional[torch.Tensor] = None,
     ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+        # Guard: empty batch (M=0) can happen when the radix cache fully covers
+        # all tokens in a request (100% cache hit).  The flashinfer/TVM kernel
+        # would be launched with grid_dim=0, which is an invalid CUDA
+        # configuration.  Return the tensors unchanged instead.
+        if x.shape[0] == 0:
+            return (x, residual) if residual is not None else x
+
         if residual is not None:
             flashinfer.norm.gemma_fused_add_rmsnorm(
                 x, residual, self.weight.data, self.eps

--- a/pymllm/models/qwen3_5.py
+++ b/pymllm/models/qwen3_5.py
@@ -372,14 +372,15 @@ class Qwen3_5ForCausalLM(nn.Module):
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         """Load HuggingFace checkpoint weights with name remapping."""
-        # When quantized, gate/up are separate projections — skip stacking.
-        if self.quant_config is not None:
-            stacked_params_mapping = []
-        else:
-            stacked_params_mapping = [
-                ("gate_up_proj", "gate_proj", 0),
-                ("gate_up_proj", "up_proj", 1),
-            ]
+        # Always enable gate/up stacking.
+        # - Pre-fused checkpoints (our GPTQ script): gate_up_proj.* keys pass
+        #   path-component matching unchanged and are loaded directly.
+        # - Unfused checkpoints (e.g. llm-compressor / RedHatAI style):
+        #   gate_proj.* / up_proj.* are sharded into gate_up_proj.* below.
+        stacked_params_mapping = [
+            ("gate_up_proj", "gate_proj", 0),
+            ("gate_up_proj", "up_proj", 1),
+        ]
 
         params_dict = dict(self.named_parameters())
         loaded: Set[str] = set()
@@ -397,19 +398,33 @@ class Qwen3_5ForCausalLM(nn.Module):
                 name = name[len("model."):]
             # NOTE: do NOT strip .self_attn — pymllm keeps it as a submodule
 
-            # Handle stacked params (gate_up_proj = gate_proj + up_proj)
+            # Handle stacked params (gate_up_proj = gate_proj + up_proj).
+            # Use path-component matching (".gate_proj." in ".name.") to avoid
+            # "gate_proj" falsely matching inside "gate_up_proj".
             matched = False
             for param_name, weight_name, shard_id in stacked_params_mapping:
-                if weight_name not in name:
+                if f".{weight_name}." not in f".{name}.":
                     continue
                 if "mlp.experts" in name:
                     continue
-                name = name.replace(weight_name, param_name)
-                if name not in params_dict:
+                # Use a tentative name; only commit once we confirm it's shardable.
+                stacked_name = name.replace(weight_name, param_name)
+                # llm-compressor W4A16: packed int4 saved as "weight",
+                # pymllm registers the parameter as "weight_packed".
+                if stacked_name not in params_dict and stacked_name.endswith(".weight"):
+                    alt = stacked_name[: -len(".weight")] + ".weight_packed"
+                    if alt in params_dict:
+                        stacked_name = alt
+                if stacked_name not in params_dict:
                     continue
-                param = params_dict[name]
-                # gate_up_proj is a plain Linear — manually place each shard
+                param = params_dict[stacked_name]
+                # gate_up_proj is a plain Linear — manually place each shard.
+                # Guard: skip metadata tensors (e.g. weight_shape [2]) that
+                # cannot be evenly halved along dim-0.
                 output_dim = param.shape[0] // 2
+                if weight.shape[0] != output_dim:
+                    break  # not a shardable weight tensor; fall through to direct load
+                name = stacked_name  # commit rename
                 param.data[shard_id * output_dim : (shard_id + 1) * output_dim].copy_(
                     weight
                 )
@@ -417,6 +432,12 @@ class Qwen3_5ForCausalLM(nn.Module):
                 break
 
             if not matched:
+                # llm-compressor W4A16: packed int4 saved as "weight",
+                # pymllm registers the parameter as "weight_packed".
+                if name not in params_dict and name.endswith(".weight"):
+                    alt = name[: -len(".weight")] + ".weight_packed"
+                    if alt in params_dict:
+                        name = alt
                 if name not in params_dict:
                     continue
                 param = params_dict[name]

--- a/pymllm/models/qwen3_5.py
+++ b/pymllm/models/qwen3_5.py
@@ -457,22 +457,438 @@ class Qwen3_5ForCausalLM(nn.Module):
 
 
 # ---------------------------------------------------------------------------
+# Qwen3.5 Vision encoder
+# ---------------------------------------------------------------------------
+def _rotate_half(x: torch.Tensor) -> torch.Tensor:
+    """Rotate half the hidden dims of the input for RoPE."""
+    x1 = x[..., : x.shape[-1] // 2]
+    x2 = x[..., x.shape[-1] // 2 :]
+    return torch.cat((-x2, x1), dim=-1)
+
+def _apply_rotary_pos_emb_vision(
+    q: torch.Tensor, k: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Apply rotary embedding to vision Q/K. Inputs are ``(seq, heads, dim)``."""
+    orig_dtype = q.dtype
+    q, k = q.float(), k.float()
+    cos = cos.unsqueeze(-2).float()  # (seq, 1, dim)
+    sin = sin.unsqueeze(-2).float()
+    q_embed = (q * cos) + (_rotate_half(q) * sin)
+    k_embed = (k * cos) + (_rotate_half(k) * sin)
+    return q_embed.to(orig_dtype), k_embed.to(orig_dtype)
+
+class Qwen3_5VisionRotaryEmbedding(nn.Module):
+    """Simple rotary embedding used inside the vision encoder."""
+
+    def __init__(self, dim: int, theta: float = 10000.0):
+        super().__init__()
+        self.dim = dim
+        inv_freq = 1.0 / (theta ** (torch.arange(0, dim, 2, dtype=torch.float) / dim))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+
+    def forward(self, seqlen: int) -> torch.Tensor:
+        seq = torch.arange(seqlen, device=self.inv_freq.device, dtype=self.inv_freq.dtype)
+        return torch.outer(seq, self.inv_freq)  # (seqlen, dim // 2)
+
+class Qwen3_5VisionMLP(nn.Module):
+    def __init__(self, hidden_size: int, intermediate_size: int,
+                 hidden_act: str = "gelu_pytorch_tanh"):
+        super().__init__()
+        self.linear_fc1 = nn.Linear(hidden_size, intermediate_size, bias=True)
+        self.linear_fc2 = nn.Linear(intermediate_size, hidden_size, bias=True)
+        if hidden_act == "gelu_pytorch_tanh":
+            self.act = nn.GELU(approximate="tanh")
+        elif hidden_act == "gelu":
+            self.act = nn.GELU()
+        else:
+            self.act = nn.SiLU()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.linear_fc2(self.act(self.linear_fc1(x)))
+
+class Qwen3_5VisionPatchEmbed(nn.Module):
+    """3-D conv patch embedding (same structure as Qwen3VL)."""
+
+    def __init__(self, patch_size: int, temporal_patch_size: int,
+                 in_channels: int, embed_dim: int):
+        super().__init__()
+        self.patch_size = patch_size
+        self.temporal_patch_size = temporal_patch_size
+        self.in_channels = in_channels
+        self.embed_dim = embed_dim
+        kernel = [temporal_patch_size, patch_size, patch_size]
+        self.proj = nn.Conv3d(in_channels, embed_dim, kernel_size=kernel,
+                              stride=kernel, bias=True)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        target_dtype = self.proj.weight.dtype
+        x = x.view(-1, self.in_channels, self.temporal_patch_size,
+                    self.patch_size, self.patch_size)
+        return self.proj(x.to(dtype=target_dtype)).view(-1, self.embed_dim)
+
+class Qwen3_5VisionPatchMerger(nn.Module):
+    """Merge ``spatial_merge_size²`` adjacent patches into one token.
+
+    Unlike Qwen3VL there is **no deepstack** — a single merger outputs
+    ``out_hidden_size`` features.
+    """
+
+    def __init__(self, hidden_size: int, spatial_merge_size: int,
+                 out_hidden_size: int):
+        super().__init__()
+        self.merged_dim = hidden_size * (spatial_merge_size ** 2)
+        # Norm on per-token hidden_size (before spatial concat)
+        self.norm = nn.LayerNorm(hidden_size, eps=1e-6)
+        self.linear_fc1 = nn.Linear(self.merged_dim, self.merged_dim)
+        self.act_fn = nn.GELU()
+        self.linear_fc2 = nn.Linear(self.merged_dim, out_hidden_size)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # x: (total_tokens, hidden_size), tokens already in merge order
+        x = self.norm(x).view(-1, self.merged_dim)
+        return self.linear_fc2(self.act_fn(self.linear_fc1(x)))
+
+class Qwen3_5VisionAttention(nn.Module):
+    """Multi-head attention for the vision encoder.
+
+    Processes each image/frame separately via ``cu_seqlens`` boundaries.
+    """
+
+    def __init__(self, hidden_size: int, num_heads: int):
+        super().__init__()
+        self.hidden_size = hidden_size
+        self.num_heads = num_heads
+        self.head_dim = hidden_size // num_heads
+        self.qkv = nn.Linear(hidden_size, hidden_size * 3, bias=True)
+        self.proj = nn.Linear(hidden_size, hidden_size)
+
+    def forward(self, hidden_states: torch.Tensor, cu_seqlens: torch.Tensor,
+                cos: torch.Tensor, sin: torch.Tensor) -> torch.Tensor:
+        seq_len = hidden_states.shape[0]
+        qkv = self.qkv(hidden_states).reshape(seq_len, 3, self.num_heads, self.head_dim)
+        q, k, v = qkv.unbind(1)  # each (seq, heads, dim)
+
+        q, k = _apply_rotary_pos_emb_vision(q, k, cos, sin)
+
+        # Per-image/frame attention (no cross-image attention)
+        outputs: List[torch.Tensor] = []
+        for i in range(len(cu_seqlens) - 1):
+            s, e = cu_seqlens[i].item(), cu_seqlens[i + 1].item()
+            qi = q[s:e].transpose(0, 1).unsqueeze(0)
+            ki = k[s:e].transpose(0, 1).unsqueeze(0)
+            vi = v[s:e].transpose(0, 1).unsqueeze(0)
+            oi = F.scaled_dot_product_attention(qi, ki, vi, is_causal=False)
+            outputs.append(oi.squeeze(0).transpose(0, 1))
+
+        attn_out = torch.cat(outputs, dim=0).reshape(seq_len, -1).contiguous()
+        return self.proj(attn_out)
+
+class Qwen3_5VisionBlock(nn.Module):
+    """Transformer block for the vision encoder."""
+
+    def __init__(self, hidden_size: int, num_heads: int,
+                 intermediate_size: int, hidden_act: str):
+        super().__init__()
+        self.norm1 = nn.LayerNorm(hidden_size, eps=1e-6)
+        self.norm2 = nn.LayerNorm(hidden_size, eps=1e-6)
+        self.attn = Qwen3_5VisionAttention(hidden_size, num_heads)
+        self.mlp = Qwen3_5VisionMLP(hidden_size, intermediate_size, hidden_act)
+
+    def forward(self, x: torch.Tensor, cu_seqlens: torch.Tensor,
+                cos: torch.Tensor, sin: torch.Tensor) -> torch.Tensor:
+        x = x + self.attn(self.norm1(x), cu_seqlens, cos, sin)
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+class Qwen3_5VisionModel(nn.Module):
+    """Qwen3.5 native vision encoder.
+
+    Key differences from Qwen3VL's ``Qwen3VLVisionModel``:
+
+    * **No deepstack** — single merger produces ``out_hidden_size`` features.
+    * **Learned absolute position embedding** (``nn.Embedding``) with bilinear
+      interpolation to arbitrary resolutions.
+    * **2-D rotary position embedding** (row, col only — no temporal dim in
+      the rotary frequencies).
+    * Returns a **list of per-image tensors** instead of a single concatenated
+      tensor with deepstack channels.
+    """
+
+    def __init__(
+        self,
+        depth: int = 27,
+        hidden_size: int = 1152,
+        hidden_act: str = "gelu_pytorch_tanh",
+        intermediate_size: int = 4304,
+        num_heads: int = 16,
+        in_channels: int = 3,
+        patch_size: int = 16,
+        spatial_merge_size: int = 2,
+        temporal_patch_size: int = 2,
+        out_hidden_size: int = 3584,
+        num_position_embeddings: int = 2304,
+    ):
+        super().__init__()
+        self.spatial_merge_size = spatial_merge_size
+        self.patch_size = patch_size
+        self.hidden_size = hidden_size
+        self.out_hidden_size = out_hidden_size
+
+        self.patch_embed = Qwen3_5VisionPatchEmbed(
+            patch_size=patch_size,
+            temporal_patch_size=temporal_patch_size,
+            in_channels=in_channels,
+            embed_dim=hidden_size,
+        )
+
+        # Learned absolute position embedding
+        self.pos_embed = nn.Embedding(num_position_embeddings, hidden_size)
+        self.num_grid_per_side = int(num_position_embeddings ** 0.5)
+
+        # 2-D rotary embedding for ViT attention
+        head_dim = hidden_size // num_heads
+        self.rotary_pos_emb = Qwen3_5VisionRotaryEmbedding(head_dim // 2)
+
+        self.blocks = nn.ModuleList([
+            Qwen3_5VisionBlock(hidden_size, num_heads, intermediate_size, hidden_act)
+            for _ in range(depth)
+        ])
+
+        self.merger = Qwen3_5VisionPatchMerger(
+            hidden_size=hidden_size,
+            spatial_merge_size=spatial_merge_size,
+            out_hidden_size=out_hidden_size,
+        )
+
+    def _rot_pos_emb(self, grid_thw: torch.Tensor) -> torch.Tensor:
+        """Compute 2-D rotary position embeddings for all patches."""
+        merge = self.spatial_merge_size
+        grid_list = grid_thw.tolist()
+        device = self.rotary_pos_emb.inv_freq.device
+
+        max_hw = max(max(int(h), int(w)) for _, h, w in grid_list)
+        freq_table = self.rotary_pos_emb(max_hw)  # (max_hw, head_dim//4)
+
+        total = sum(int(t) * int(h) * int(w) for t, h, w in grid_list)
+        pos_ids = torch.empty((total, 2), dtype=torch.long, device=device)
+
+        offset = 0
+        for nf, height, width in grid_list:
+            nf, height, width = int(nf), int(height), int(width)
+            mh, mw = height // merge, width // merge
+
+            br = torch.arange(mh, device=device)
+            bc = torch.arange(mw, device=device)
+            ir = torch.arange(merge, device=device)
+            ic = torch.arange(merge, device=device)
+
+            row = (br[:, None, None, None] * merge + ir[None, None, :, None])
+            col = (bc[None, :, None, None] * merge + ic[None, None, None, :])
+            row = row.expand(mh, mw, merge, merge).reshape(-1)
+            col = col.expand(mh, mw, merge, merge).reshape(-1)
+            coords = torch.stack((row, col), dim=-1)
+            if nf > 1:
+                coords = coords.repeat(nf, 1)
+
+            n = coords.shape[0]
+            pos_ids[offset:offset + n] = coords
+            offset += n
+
+        embs = freq_table[pos_ids]       # (total, 2, head_dim//4)
+        return embs.flatten(1)            # (total, head_dim//2)
+
+    def _fast_pos_embed_interpolate(self, grid_thw: torch.Tensor) -> torch.Tensor:
+        """Bilinear-interpolate learned position embeddings to any resolution."""
+        grid_list = grid_thw.tolist()
+        ts = [int(r[0]) for r in grid_list]
+        hs = [int(r[1]) for r in grid_list]
+        ws = [int(r[2]) for r in grid_list]
+        device = self.pos_embed.weight.device
+        N = self.num_grid_per_side
+
+        idx4: List[List[int]] = [[] for _ in range(4)]
+        wt4: List[List[float]] = [[] for _ in range(4)]
+
+        for h, w in zip(hs, ws):
+            hi = torch.linspace(0, N - 1, h)
+            wi = torch.linspace(0, N - 1, w)
+            hf, wf = hi.int(), wi.int()
+            hc = (hf + 1).clip(max=N - 1)
+            wc = (wf + 1).clip(max=N - 1)
+            dh, dw = hi - hf.float(), wi - wf.float()
+            bh, bhc = hf * N, hc * N
+
+            indices = [
+                (bh[:, None] + wf[None, :]).flatten(),
+                (bh[:, None] + wc[None, :]).flatten(),
+                (bhc[:, None] + wf[None, :]).flatten(),
+                (bhc[:, None] + wc[None, :]).flatten(),
+            ]
+            weights = [
+                ((1 - dh)[:, None] * (1 - dw)[None, :]).flatten(),
+                ((1 - dh)[:, None] * dw[None, :]).flatten(),
+                (dh[:, None] * (1 - dw)[None, :]).flatten(),
+                (dh[:, None] * dw[None, :]).flatten(),
+            ]
+            for c in range(4):
+                idx4[c].extend(indices[c].tolist())
+                wt4[c].extend(weights[c].tolist())
+
+        idx_t = torch.tensor(idx4, dtype=torch.long, device=device)
+        wt_t = torch.tensor(wt4, dtype=self.pos_embed.weight.dtype, device=device)
+        pe = self.pos_embed(idx_t) * wt_t[:, :, None]
+        patch_pe = pe[0] + pe[1] + pe[2] + pe[3]
+
+        # Split by image, rearrange to spatial-merge order
+        parts = patch_pe.split([h * w for h, w in zip(hs, ws)])
+        merge = self.spatial_merge_size
+        result: List[torch.Tensor] = []
+        for p, t, h, w in zip(parts, ts, hs, ws):
+            p = p.repeat(t, 1)
+            p = (p.view(t, h // merge, merge, w // merge, merge, -1)
+                  .permute(0, 1, 3, 2, 4, 5)
+                  .flatten(0, 4))
+            result.append(p)
+        return torch.cat(result)
+
+    def forward(
+        self,
+        pixel_values: torch.Tensor,
+        grid_thw: torch.Tensor,
+    ) -> List[torch.Tensor]:
+        """Run vision encoder.
+
+        Returns a **list** of per-image tensors, each of shape
+        ``[num_merged_tokens_i, out_hidden_size]``.
+        """
+        hidden = self.patch_embed(pixel_values)
+
+        # Add learned absolute position embeddings
+        hidden = hidden + self._fast_pos_embed_interpolate(grid_thw)
+
+        # Rotary embeddings for ViT attention
+        rot = self._rot_pos_emb(grid_thw)
+        emb = torch.cat((rot, rot), dim=-1)
+        cos, sin = emb.cos(), emb.sin()
+
+        # Per-frame cumulative sequence lengths for attention
+        cu_seqlens = torch.repeat_interleave(
+            grid_thw[:, 1] * grid_thw[:, 2], grid_thw[:, 0]
+        ).cumsum(0, dtype=torch.int32)
+        cu_seqlens = F.pad(cu_seqlens, (1, 0), value=0)
+
+        for blk in self.blocks:
+            hidden = blk(hidden, cu_seqlens, cos, sin)
+
+        # Spatial merge → project to LLM hidden size
+        merged = self.merger(hidden)
+
+        # Split into per-image tensors
+        split_sizes = (grid_thw.prod(-1) // (self.spatial_merge_size ** 2)).tolist()
+        return list(torch.split(merged, split_sizes))
+
+
+def get_rope_index_qwen3_5(
+    input_ids: torch.Tensor,
+    image_grid_thw: Optional[torch.Tensor],
+    image_token_id: int,
+    vision_start_token_id: int,
+    spatial_merge_size: int,
+    start_pos: int = 0,
+) -> Tuple[torch.Tensor, int]:
+    """Compute M-RoPE 3-D position IDs for a single Qwen3.5 sequence.
+
+    Compatible with pymllm's ``[3, T]`` M-RoPE interface.
+
+    Key differences from Qwen3VL's ``get_rope_index``:
+
+    * **Position advance** for vision tokens is
+      ``max(H, W) // spatial_merge_size``
+      (Qwen3VL uses ``max(T, H, W)``).
+    * **Temporal position** for image tokens is constant (``= current_pos``).
+
+    Parameters
+    ----------
+    start_pos
+        Starting M-RoPE position counter.  Must equal ``extend_prefix_lens``
+        so that positions are computed correctly when part of the prompt is
+        already cached (radix-cache prefix hit).  Returns ``delta`` adjusted
+        to subtract ``start_pos`` so that the decode formula
+        ``pos = (seq_len - 1) + delta`` remains correct.
+    """
+    total = input_ids.shape[0]
+    device = input_ids.device
+    pos = torch.zeros(3, total, dtype=torch.long, device=device)
+
+    if image_grid_thw is None or image_grid_thw.shape[0] == 0:
+        arange = torch.arange(total, dtype=torch.long, device=device) + start_pos
+        pos[0] = arange
+        pos[1] = arange
+        pos[2] = arange
+        # delta adjusted: (start_pos + total) - total - start_pos = 0
+        return pos, 0
+
+    ids = input_ids.cpu().tolist()
+    grids = image_grid_thw.cpu().tolist()
+
+    cur = start_pos
+    img_idx = 0
+    i = 0
+
+    while i < total:
+        if ids[i] == vision_start_token_id and img_idx < len(grids):
+            # vision_start token → regular sequential position
+            pos[:, i] = cur
+            cur += 1
+            i += 1
+
+            t_g = int(grids[img_idx][0])
+            h_g = int(grids[img_idx][1])
+            w_g = int(grids[img_idx][2])
+            gh = h_g // spatial_merge_size
+            gw = w_g // spatial_merge_size
+            n_img = t_g * gh * gw
+
+            # Temporal: constant
+            t_pos = torch.full((n_img,), cur, device=device, dtype=torch.long)
+            # Height
+            h_pos = (torch.arange(gh, device=device)
+                     .repeat_interleave(gw).repeat(t_g) + cur)
+            # Width
+            w_pos = (torch.arange(gw, device=device)
+                     .repeat(gh * t_g) + cur)
+
+            pos[0, i:i + n_img] = t_pos
+            pos[1, i:i + n_img] = h_pos
+            pos[2, i:i + n_img] = w_pos
+
+            cur += max(gh, gw)
+            i += n_img
+            img_idx += 1
+        else:
+            pos[:, i] = cur
+            cur += 1
+            i += 1
+
+    # delta = (cur - start_pos) - total, so that decode uses:
+    #   pos_1d = (seq_len - 1) + delta
+    #          = (prefix + total + 1 - 1) + (cur - start_pos - total)
+    #          = cur  (the correct next M-RoPE position)
+    return pos, (cur - start_pos) - total
+
+
+# ---------------------------------------------------------------------------
 # Qwen3.5 Vision-Language Model
 # ---------------------------------------------------------------------------
 
 
 class Qwen3_5ForConditionalGeneration(nn.Module):
-    """Qwen3.5 multimodal model (text + vision).
-
-    Inherits vision encoder from Qwen3VL and uses Qwen3.5's hybrid
-    language model.
+    """
+    Qwen3.5 multimodal model (text + vision).
     """
 
     def __init__(self, config, quant_config=None):
         super().__init__()
-        from pymllm.models.qwen3_vl import (
-            Qwen3VLVisionModel,
-        )
 
         self.config = config
         self.quant_config = quant_config
@@ -480,8 +896,9 @@ class Qwen3_5ForConditionalGeneration(nn.Module):
 
         # Vision encoder — NOT quantized
         vision_config = getattr(config, "vision_config", None)
+        self.spatial_merge_size = getattr(vision_config, "spatial_merge_size", 2)
         if vision_config is not None:
-            self.visual = Qwen3VLVisionModel(
+            self.visual = Qwen3_5VisionModel(
                 depth=getattr(vision_config, "depth", 27),
                 hidden_size=getattr(vision_config, "hidden_size", 1152),
                 hidden_act=getattr(vision_config, "hidden_act", "gelu_pytorch_tanh"),
@@ -489,16 +906,12 @@ class Qwen3_5ForConditionalGeneration(nn.Module):
                 num_heads=getattr(vision_config, "num_heads", 16),
                 in_channels=getattr(vision_config, "in_channels", 3),
                 patch_size=getattr(vision_config, "patch_size", 16),
-                spatial_merge_size=getattr(vision_config, "spatial_merge_size", 2),
+                spatial_merge_size=self.spatial_merge_size,
                 temporal_patch_size=getattr(vision_config, "temporal_patch_size", 2),
-                out_hidden_size=getattr(vision_config, "out_hidden_size", 3584),
+                out_hidden_size=getattr(vision_config, "out_hidden_size", tc.hidden_size),
                 num_position_embeddings=getattr(
                     vision_config, "num_position_embeddings", 2304
                 ),
-                deepstack_visual_indexes=getattr(
-                    vision_config, "deepstack_visual_indexes", [8, 16, 24]
-                ),
-                norm_eps=getattr(tc, "rms_norm_eps", 1e-6),
             )
         else:
             self.visual = None
@@ -510,14 +923,15 @@ class Qwen3_5ForConditionalGeneration(nn.Module):
         self.num_gdn_layers = self.model.num_gdn_layers
         self.full_attn_layer_ids = self.model.full_attn_layer_ids
 
-        # LM head (tied to embedding when tie_word_embeddings=True)
+        # LM head
         self.lm_head = Linear(tc.hidden_size, tc.vocab_size, bias=False)
         if getattr(tc, "tie_word_embeddings", False):
             self.lm_head.weight = self.model.embed_tokens.weight
 
         # Vision token IDs
-        self.image_token_id = getattr(config, "image_token_id", 151655)
-        self.video_token_id = getattr(config, "video_token_id", 151656)
+        self.image_token_id = getattr(config, "image_token_id", 248056)
+        self.video_token_id = getattr(config, "video_token_id", 248057)
+        self.vision_start_token_id = getattr(config, "vision_start_token_id", 248053)
 
     @torch.no_grad()
     def forward(
@@ -530,14 +944,92 @@ class Qwen3_5ForConditionalGeneration(nn.Module):
         image_grid_thw: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         # Process vision inputs if provided
-        if input_embeds is None and pixel_values is not None and self.visual is not None:
+        pixel_values = (
+            pixel_values if pixel_values is not None
+            else getattr(forward_batch, "pixel_values", None)
+        )
+        image_grid_thw = (
+            image_grid_thw if image_grid_thw is not None
+            else getattr(forward_batch, "image_grid_thw", None)
+        )
+
+        if forward_batch.forward_mode.is_extend():
+            # Prefill: compute per-sequence 3-D position IDs from input_ids
+            # and image grids, then store per-request deltas for future decode.
+            mrope_positions_list: List[torch.Tensor] = []
+            deltas: List[int] = []
+            image_idx_offset = 0
+
+            for i in range(forward_batch.batch_size):
+                start = int(forward_batch.extend_start_loc[i].item())
+                length = int(forward_batch.extend_seq_lens[i].item())
+                seq_ids = input_ids[start : start + length]
+
+                # Prefix length (cached tokens not in input_ids).
+                # Positions must start from prefix_len so that new tokens
+                # get correct M-RoPE positions even on radix cache hits.
+                prefix_len = int(forward_batch.extend_prefix_lens[i].item()) \
+                    if forward_batch.extend_prefix_lens is not None else 0
+
+                # Determine how many images belong to this sequence.
+                num_img = int((seq_ids == self.vision_start_token_id).sum().item())
+                if image_grid_thw is not None and num_img > 0:
+                    thw_seq = image_grid_thw[
+                        image_idx_offset : image_idx_offset + num_img
+                    ]
+                    image_idx_offset += num_img
+                else:
+                    thw_seq = None
+
+                pos3d, delta = get_rope_index_qwen3_5(
+                    seq_ids,
+                    thw_seq,
+                    self.image_token_id,
+                    self.vision_start_token_id,
+                    self.spatial_merge_size,
+                    start_pos=prefix_len,
+                )
+                mrope_positions_list.append(pos3d)
+                deltas.append(delta)
+
+            # Concatenate across sequences: [3, total_extend_tokens]
+            positions = torch.cat(mrope_positions_list, dim=1).contiguous()
+            forward_batch.mrope_position_deltas = torch.tensor(
+                deltas, dtype=torch.int64, device=input_ids.device
+            )
+        else:
+            # Decode: each sequence emits exactly one token.  Apply the stored
+            # per-request delta so the position matches the image extent.
+            stored_deltas = getattr(forward_batch, "mrope_position_deltas", None)
+            if stored_deltas is not None:
+                pos_1d = forward_batch.positions + stored_deltas
+            else:
+                pos_1d = forward_batch.positions
+            positions = pos_1d.unsqueeze(0).expand(3, -1).contiguous()  # [3, batch_size]
+
+        if (
+            pixel_values is not None
+            and image_grid_thw is not None
+            and self.visual is not None
+            and not forward_batch.forward_mode.is_decode()
+        ):
             input_embeds = self.model.embed_tokens(input_ids)
-            # Run vision encoder
-            visual_embeds = self.visual(pixel_values, grid_thw=image_grid_thw)
-            # Replace image/video token positions with visual embeddings
-            mask = (input_ids == self.image_token_id) | (input_ids == self.video_token_id)
-            if mask.any():
-                input_embeds[mask] = visual_embeds.reshape(-1, visual_embeds.shape[-1])
+            # Vision encoder → list of per-image tensors
+            image_embeds_list = self.visual(pixel_values, grid_thw=image_grid_thw)
+            image_embeds = torch.cat(image_embeds_list, dim=0)
+
+            # Replace image-token positions with visual embeddings
+            image_mask = input_ids == self.image_token_id
+            n_holders = image_mask.sum().item()
+            n_embeds = image_embeds.shape[0]
+            if n_holders != n_embeds:
+                logger.warning(
+                    "image placeholder count (%d) != vision embed count (%d)",
+                    n_holders, n_embeds,
+                )
+            if image_mask.any():
+                mask_3d = image_mask.unsqueeze(-1).expand_as(input_embeds)
+                input_embeds = input_embeds.masked_scatter(mask_3d, image_embeds)
 
         hidden_states = self.model(
             input_ids=input_ids,
@@ -551,32 +1043,37 @@ class Qwen3_5ForConditionalGeneration(nn.Module):
         return logits
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
-        """Load weights, dispatching visual vs language params."""
-        visual_weights = []
-        language_weights = []
+        """Load HuggingFace checkpoint weights (visual + language)."""
+        visual_weights: List[Tuple[str, torch.Tensor]] = []
+        language_weights: List[Tuple[str, torch.Tensor]] = []
 
         for name, weight in weights:
             if "visual" in name or "model.visual" in name:
-                # Normalize visual weight names
                 name = name.replace("model.visual.", "visual.")
-                name = name.replace("attn.qkv.", "attn.qkv_proj.")
                 visual_weights.append((name, weight))
             else:
                 language_weights.append((name, weight))
 
-        # Load language model weights
+        # Language
         self.model.load_weights(language_weights)
 
-        # Load visual weights
+        # Vision
         if self.visual is not None and visual_weights:
             params_dict = dict(self.named_parameters())
+            loaded = 0
             for name, weight in visual_weights:
-                if name in params_dict:
-                    param = params_dict[name]
-                    loader = getattr(param, "weight_loader", None)
-                    if loader is not None:
-                        loader(param, weight)
-                    else:
-                        param.data.copy_(weight)
+                if name not in params_dict:
+                    logger.debug("Skipping visual weight: %s", name)
+                    continue
+                param = params_dict[name]
+                loader = getattr(param, "weight_loader", None)
+                if loader is not None:
+                    loader(param, weight)
+                else:
+                    if weight.dim() != param.dim():
+                        weight = weight.squeeze()
+                    param.data.copy_(weight)
+                loaded += 1
+            logger.info("Loaded %d visual weight tensors", loaded)
 
         logger.info("Qwen3_5ForConditionalGeneration weights loaded")

--- a/pymllm/quantization/methods/compressed_tensors.py
+++ b/pymllm/quantization/methods/compressed_tensors.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from typing import Any, Dict, List, Optional
 
 import torch
@@ -179,13 +180,16 @@ def _validate_supported_signature(config: "CompressedTensorsConfig") -> str:
             raise ValueError(
                 f"Unsupported compressed-tensors num_bits: {config.weight_bits}"
             )
-        if config.group_size != 32:
+        if config.group_size not in MARLIN_SUPPORTED_GROUP_SIZES:
             raise ValueError(
-                f"Unsupported compressed-tensors group_size: {config.group_size}"
+                f"Unsupported compressed-tensors group_size: {config.group_size}. "
+                f"Supported: {MARLIN_SUPPORTED_GROUP_SIZES}"
             )
         if not config.symmetric:
             raise ValueError("v1 only supports symmetric compressed-tensors")
-        if config.actorder is not None:
+        # "static" means standard sequential group order (no activation-based
+        # reordering), which Marlin handles the same as actorder=None.
+        if config.actorder not in (None, "static"):
             raise ValueError(
                 f"Unsupported compressed-tensors actorder: {config.actorder}"
             )
@@ -547,13 +551,35 @@ class CompressedTensorsConfig(QuantizationConfig):
     def get_config_filenames() -> List[str]:
         return ["config.json"]
 
+    @staticmethod
+    def _normalize_ignore(entries: List[str]) -> List[str]:
+        """Strip HuggingFace-style module path prefixes from ignore entries.
+
+        llm-compressor stores ignore entries as full checkpoint paths such as
+        "model.language_model.layers.0.linear_attn.out_proj", but pymllm
+        addresses layers with the outer prefixes already stripped, e.g.
+        "layers.0.linear_attn.out_proj".  Strip the known outer prefixes so
+        the entries can be matched against pymllm's internal module names.
+        Regex entries ("re:...") are left unchanged.
+        """
+        _STRIP_PREFIXES = ("model.language_model.", "model.")
+        out: List[str] = []
+        for entry in entries:
+            if not entry.startswith("re:"):
+                for strip in _STRIP_PREFIXES:
+                    if entry.startswith(strip):
+                        entry = entry[len(strip):]
+                        break
+            out.append(entry)
+        return out
+
     @classmethod
     def from_config(cls, config: Dict[str, Any]) -> "CompressedTensorsConfig":
         weights = _weights_cfg(config)
         input_activations = _input_activations_cfg(config)
         return cls(
             quant_format=config["format"],
-            ignore=list(config.get("ignore", [])),
+            ignore=cls._normalize_ignore(list(config.get("ignore", []))),
             weight_bits=weights["num_bits"],
             group_size=weights["group_size"],
             weight_strategy=weights.get("strategy"),
@@ -592,6 +618,24 @@ class CompressedTensorsConfig(QuantizationConfig):
         self, layer: torch.nn.Module, prefix: str = ""
     ) -> Optional[CompressedTensorsLinearMethod]:
         signature = _validate_supported_signature(self)
-        if any(ignored and prefix.startswith(ignored) for ignored in self.ignore):
+        # Support two matching styles for items in self.ignore:
+        #   1. Exact prefix match: prefix.startswith(ignored)
+        #      e.g. ignore=["lm_head"] matches prefix="lm_head"
+        #   2. Path-component containment: ".ignored." in ".prefix."
+        #      e.g. ignore=["linear_attn"] matches prefix="layers.0.linear_attn.out_proj"
+        # Style 2 is needed because nested module names (e.g. inside decoder layers)
+        # never start with the bare module name.
+        dotted = f".{prefix}."
+        def _is_ignored(ignored: str) -> bool:
+            if not ignored:
+                return False
+            # Support llm-compressor-style regex patterns: "re:.*pattern.*"
+            if ignored.startswith("re:"):
+                try:
+                    return bool(re.search(ignored[3:], prefix))
+                except re.error:
+                    return False
+            return prefix.startswith(ignored) or f".{ignored}." in dotted
+        if any(_is_ignored(ig) for ig in self.ignore):
             return None
         return CompressedTensorsLinearMethod(self, signature)

--- a/pymllm/server/launch.py
+++ b/pymllm/server/launch.py
@@ -100,6 +100,9 @@ async def _iter_with_disconnect_check(
 # ---------------------------------------------------------------------------
 _engine: Optional[Engine] = None
 _tokenizer: Optional[Any] = None
+# Architectures list from model config, e.g. ["Qwen3_5ForConditionalGeneration"].
+# Used to pick the correct image content format for apply_chat_template.
+_model_architectures: Optional[List[str]] = None
 
 
 def _get_engine() -> Engine:
@@ -243,7 +246,7 @@ class AbortRequest(BaseModel):
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Startup / shutdown hooks for the FastAPI app."""
-    global _engine, _tokenizer
+    global _engine, _tokenizer, _model_architectures
     _engine = app.state.engine  # type: ignore[attr-defined]
 
     # Load tokenizer in server process for apply_chat_template
@@ -260,6 +263,11 @@ async def lifespan(app: FastAPI):
         )
     except Exception as e:
         logger.warning("Failed to load tokenizer for chat template: %s", e)
+
+    # Stash model architectures so request handlers can detect the model family.
+    hf_cfg = getattr(cfg.model, "hf_config", None)
+    _model_architectures = getattr(hf_cfg, "architectures", None) if hf_cfg else None
+    logger.info("Model architectures: %s", _model_architectures)
 
     logger.info(
         "HTTP server ready at http://%s:%s",
@@ -505,6 +513,22 @@ def _build_sampling_params(
     return params
 
 
+def _is_qwen3vl_architecture() -> bool:
+    """Return True when the loaded model is a Qwen3-VL / Qwen2-VL model.
+
+    These models use ``{"type": "image", "image": url}`` in their chat
+    templates, whereas Qwen3.5 and OpenAI-compatible models use the
+    ``{"type": "image_url", "image_url": {"url": url}}`` format.
+    """
+    archs = _model_architectures
+    if not archs:
+        return False
+    return any(
+        "Qwen3VL" in a or "Qwen2VL" in a or "Qwen3_VL" in a or "Qwen2_VL" in a
+        for a in archs
+    )
+
+
 def _messages_to_prompt(
     messages: List[ChatMessage],
     chat_template_kwargs: Optional[Dict[str, Any]] = None,
@@ -519,24 +543,43 @@ def _messages_to_prompt(
     chat_template_kwargs
         Extra keyword arguments forwarded to ``apply_chat_template``
         (e.g. ``enable_thinking=True`` for Qwen3).
+
+    Notes
+    -----
+    Image content format is chosen automatically based on the loaded model:
+    - Qwen3-VL / Qwen2-VL: ``{"type": "image", "image": url}``
+    - Qwen3.5 / OpenAI-compatible: ``{"type": "image_url", "image_url": {"url": url}}``
     """
-    # Preserve multimodal message structure for tokenizer.apply_chat_template.
+    use_qwen3vl_image_fmt = _is_qwen3vl_architecture()
+
     msg_dicts: List[Dict[str, Any]] = []
     for msg in messages:
         content = msg.content
         if isinstance(content, list):
-            mm_parts: List[Dict[str, Any]] = []
-            for part in content:
-                if part.type == "text" and part.text is not None:
-                    mm_parts.append({"type": "text", "text": part.text})
-                elif part.type == "image_url" and part.image_url is not None:
-                    # Keep image content so chat template can emit vision tokens.
-                    mm_parts.append(
-                        {"type": "image", "image": part.image_url.url}
-                    )
-            content = mm_parts
+            content_list: List[Dict[str, Any]] = []
+            for p in content:
+                if p.type == "text" and p.text:
+                    content_list.append({"type": "text", "text": p.text})
+                elif p.type == "image_url" and p.image_url is not None:
+                    if use_qwen3vl_image_fmt:
+                        # Qwen3-VL / Qwen2-VL chat template expects:
+                        # {"type": "image", "image": url}
+                        content_list.append(
+                            {"type": "image", "image": p.image_url.url}
+                        )
+                    else:
+                        # Qwen3.5 / OpenAI-compatible:
+                        # {"type": "image_url", "image_url": {"url": url}}
+                        content_list.append(
+                            {
+                                "type": "image_url",
+                                "image_url": {"url": p.image_url.url},
+                            }
+                        )
+            content = content_list
         elif content is None:
             content = ""
+
         d: Dict[str, Any] = {"role": msg.role, "content": content}
         if msg.name is not None:
             d["name"] = msg.name

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-  "scikit-build-core>=0.11.0", "apache-tvm-ffi == 0.1.8"
+  "scikit-build-core>=0.11.0", "apache-tvm-ffi == 0.1.8.post2"
 ]
 build-backend = "scikit_build_core.build"
 


### PR DESCRIPTION
## Summary

This PR brings three Qwen3.5 capabilities to `pymllm` plus one numerical-stability
fix, on top of the existing Jetson Qwen3 family work:

- A **chunkwise-parallel GDN (Gated DeltaNet) prefill path**, available both as a
  CUDA JIT kernel (`gdn_extend_chunkwise`) and a PyTorch reference
  (`gdn_chunkwise`), selectable via a new `gdn_extend_backend` option.
- **Quantized inference support** for Qwen3.5 through the compressed-tensors path
  (W4A16 Marlin), including weight-loading fixes for both pre-fused and
  unfused checkpoints.
- **Native Qwen3.5 multimodal dialogue support**, adding a dedicated Qwen3.5
  vision encoder while keeping Qwen3-VL / Qwen2-VL serving behavior intact.
- A **GDN OPT-3 numerical guard fix** that prevents denormal `gam_t` from
  overflowing FP32 in the chunkwise CUDA kernel.

## What Changed

### GDN chunkwise prefill parallelism
- Add a WY-representation chunkwise GDN extend implementation that parallelizes
  the GDN recurrent scan over token chunks:
  `S_T = γ_C · (S_0 (I − W Kᵀ) + Ũ Kᵀ)`.
- New CUDA JIT kernel `mllm-kernel/.../gdn_extend_chunkwise.cuh` +
  `cuda/jit/gdn_extend_chunkwise.py`: the sequential WY scan runs in shared
  memory inside the CUDA block, while per-token output and the final state
  update are expressed as matrix-like ops for more GPU parallelism on long
  sequences. Includes a `precompile()` helper.
- New PyTorch reference `pymllm/layers/attention/gdn_chunkwise.py` implementing
  the same recurrence in three phases (WY construction, batched-matmul output
  with a causal mask, state update).
- Wire backend selection into `gdn_backend.py`:
  - new `server.gdn_extend_backend` config field and `$PYMLLM_GDN_EXTEND_BACKEND`
    env override, accepting `auto | flashinfer | mllm_kernel | cuda_chunkwise | pytorch`;
  - `auto` priority is FlashInfer (SM90+) → mllm_kernel (SM80+) →
    cuda_chunkwise (SM80+) → PyTorch;
  - when `cuda_chunkwise` is configured, the kernel is eagerly compiled at
    model-load time so the first request doesn't pay the JIT cost;
  - apply `1/√head_k_dim` scaling to `q` in both the extend and chunkwise paths.
- Add `benchmarks/bench_serve.py` to measure server-side prefill (TTFT) and
  decode throughput against `/v1/completions`.
- Bump build dep `apache-tvm-ffi` to `0.1.8.post2`.

### Qwen3.5 quantized inference (compressed-tensors)
- `pymllm/models/qwen3_5.py` `load_weights`:
  - always enable gate/up stacking and use path-component matching
    (`.gate_proj.` rather than a `gate_proj` substring) so it no longer falsely
    matches inside `gate_up_proj`;
  - support both pre-fused checkpoints (our GPTQ script, `gate_up_proj.*` keys)
    and unfused checkpoints (llm-compressor / RedHatAI style, separate
    `gate_proj.*` / `up_proj.*`);
  - map llm-compressor `*.weight` (packed int4) to pymllm's `*.weight_packed`
    parameter;
  - skip non-shardable metadata tensors (e.g. `weight_shape`).
- `pymllm/quantization/methods/compressed_tensors.py`:
  - accept Marlin-supported group sizes (instead of a hard-coded `32`) and
    `actorder == "static"`;
  - normalize `ignore` entries by stripping `model.language_model.` / `model.`
    prefixes;
  - match `ignore` entries by exact prefix, dotted path-component containment,
    or `re:`-style regex.
- `pymllm/layers/rms_norm.py`: guard the empty-batch (`M == 0`) case in
  `GemmaRMSNorm` (100% radix-cache hit) to avoid launching the fused kernel
  with `grid_dim = 0`.

### Qwen3.5 multimodal dialogue (Qwen3-VL kept compatible)
- Add a native Qwen3.5 vision encoder in `qwen3_5.py`
  (`Qwen3_5VisionModel` and submodules: 3-D conv `PatchEmbed`, `VisionMLP`,
  `VisionAttention` with per-image `cu_seqlens` boundaries, `VisionBlock`,
  `RotaryEmbedding`, `PatchMerger`), plus `get_rope_index_qwen3_5` for mRoPE.
  Key differences from Qwen3-VL: **no deepstack** (single merger), **learned
  absolute position embedding** with bilinear interpolation, and **2-D rotary**
  (row/col only). The encoder returns a list of per-image embedding tensors.
- `pymllm/server/launch.py`: stash model `architectures` at startup and pick the
  chat-template image content format automatically:
  - Qwen3-VL / Qwen2-VL → `{"type": "image", "image": url}`;
  - Qwen3.5 / OpenAI-compatible → `{"type": "image_url", "image_url": {"url": url}}`.

### Fix
- `gdn_extend_chunkwise.cuh` (OPT-3): tighten the guard from `gam_t > 0.f` to
  `gam_t > 1e-30f` so `beta / gam_t` stays within FP32 range (post-RMSNorm
  activations can reach ~1e3), and guard the state update with `gam_C > 0.f` to
  avoid `0 * Inf = NaN` propagation. Both are mathematically equivalent to
  setting the affected term to zero.

## Notes for Reviewers
- Chunkwise parallelism targets the **prefill / extend** stage only; the decode
  step path is unchanged. The chunkwise CUDA kernel is SM80+ and validated on
  Jetson Orin; the first compile on a new architecture pays a one-time JIT cost.
- The weight-loading changes are intended to support both fused and unfused
  compressed-tensors checkpoints — please double-check loading against whichever
  checkpoint format you use.
- Multimodal additions are designed to keep Qwen3-VL / Qwen2-VL serving paths
  unchanged; the main regression surface is the chat-template image format
  selection in `launch.py`.
- The OPT-3 guard change only tightens handling of (near-)underflow `gam_t`;
  it should be behavior-preserving for non-degenerate inputs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable GDN extend backend selection (`"auto"`, `"flashinfer"`, `"mllm_kernel"`, `"cuda_chunkwise"`, `"pytorch"`)
  * Enhanced Qwen3.5 vision model with native encoder implementation
  * Improved multimodal image handling with architecture-aware chat template formatting

* **Bug Fixes**
  * Fixed kernel launch failures with empty batches

* **Improvements**
  * Enhanced quantization config validation and ignore-list handling
  * Optimized GDN extend path with improved numerical scaling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/UbiquitousLearning/mllm/pull/679?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->