### PR TITLE
fix(build): build xxHash objects with PIC for MllmRT

### DIFF
--- a/third_party/xxHash/CMakeLists.txt
+++ b/third_party/xxHash/CMakeLists.txt
@@ -20,6 +20,7 @@ target_include_directories(xxhash INTERFACE
 )
 
 add_library(xxhash_impl OBJECT ${_src})
+set_target_properties(xxhash_impl PROPERTIES POSITION_INDEPENDENT_CODE ON)
 target_include_directories(xxhash_impl PUBLIC include)
 if(XXH_ENABLE_DISPATCH)
   target_compile_definitions(xxhash_impl PUBLIC XXH_DISPATCH_ENABLE=1)


### PR DESCRIPTION
## Summary

This PR builds the xxHash object library with position-independent code so it can be safely linked into `MllmRT`.

`MllmRT` is a shared library and links `xxHash::xxhash`. On Linux x86_64, the current build may fail when linking `libMllmRT.so` because `xxhash_static` is created from `$<TARGET_OBJECTS:xxhash_impl>`, while the `xxhash_impl` objects are not compiled with PIC.

## Background

I found this while investigating the official x86 Qwen3-0.6B C++ runner/build path. The x86 build can reach the `MllmRT` link step and fail with:

```text
/usr/bin/ld.bfd: lib/libxxhash_static.a(xxhash.c.o): relocation R_X86_64_32S against `.rodata` can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld.bfd: failed to set dynamic section sizes: bad value
collect2: error: ld returned 1 exit status
```

Other x86 backend findings from that investigation are intentionally kept out of scope. This PR only fixes the xxHash PIC linkage issue.

## Root Cause

`third_party/xxHash/CMakeLists.txt` builds the xxHash sources through the `xxhash_impl` object target, then creates `xxhash_static` from those object files:

```cmake
add_library(xxhash_impl OBJECT ${_src})
add_library(xxhash_static STATIC $<TARGET_OBJECTS:xxhash_impl>)
```

Setting PIC on the static archive target is not enough here, because the object files are already produced by `xxhash_impl`.

## Fix

Enable `POSITION_INDEPENDENT_CODE` on `xxhash_impl`, the target that actually compiles `xxhash.c` and `xxh_x86dispatch.c`.

## Validation

- `git diff --check`
- `cmake -S . -B build-xxhash-pic -G Ninja -DCMAKE_BUILD_TYPE=Release -DHWY_ENABLE_TESTS=OFF -DHWY_ENABLE_EXAMPLES=OFF -DHWY_ENABLE_CONTRIB=OFF -DMLLM_CPU_BACKEND_COMPILE_OPTIONS="-march=native" -DMLLM_KERNEL_USE_THREADS=ON -DMLLM_KERNEL_THREADS_VENDOR_OPENMP=ON -DMLLM_KERNEL_USE_THREADS_VENDOR_MLLM=OFF`
- `cmake --build build-xxhash-pic --target MllmRT -j2`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal build configuration for improved code compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->