### PR TITLE
fix(cpu): preserve raw fp16 bits in x86 quantize conversion

### DIFF
--- a/mllm/backends/cpu/kernels/common/ggml/quantize/quantize.hpp
+++ b/mllm/backends/cpu/kernels/common/ggml/quantize/quantize.hpp
@@ -30,6 +30,7 @@
 #include <cassert>
 #include <cmath>
 #include <cstring>
+#include <type_traits>
 
 #include "mllm/core/DataTypes.hpp"
 
@@ -105,8 +106,26 @@ inline static float lookup_fp16_to_fp32(uint16_t f) {
 
 #else
 namespace mllm::cpu {
-#define MLLM_COMPUTE_FP16_TO_FP32(x) _cvtsh_ss(x)
-#define MLLM_COMPUTE_FP32_TO_FP16(x) _cvtss_sh(x, 0)
+template<typename T>
+inline static uint16_t mllm_fp16_bits(const T& f) {
+  if constexpr (std::is_integral_v<std::decay_t<T>>) {
+    return static_cast<uint16_t>(f);
+  } else {
+    static_assert(sizeof(T) == sizeof(uint16_t), "fp16 type must be 16 bits");
+    uint16_t s;
+    memcpy(&s, &f, sizeof(s));
+    return s;
+  }
+}
+
+inline static mllm_fp16_t mllm_fp16_from_bits(uint16_t bits) {
+  mllm_fp16_t f;
+  memcpy(&f, &bits, sizeof(bits));
+  return f;
+}
+
+#define MLLM_COMPUTE_FP16_TO_FP32(x) _cvtsh_ss(mllm_fp16_bits(x))
+#define MLLM_COMPUTE_FP32_TO_FP16(x) mllm_fp16_from_bits(_cvtss_sh(x, 0))
 
 static float table_f32_f16[1 << 16];
 static bool table_f32_f16_init = false;
@@ -127,7 +146,7 @@ inline static float lookup_fp16_to_fp32(uint16_t f) {
 }
 
 #ifndef MLLM_FP16_TO_FP32
-#define MLLM_FP16_TO_FP32(x) lookup_fp16_to_fp32(x)
+#define MLLM_FP16_TO_FP32(x) lookup_fp16_to_fp32(mllm_fp16_bits(x))
 #endif
 #ifndef MLLM_FP32_TO_FP16
 #define MLLM_FP32_TO_FP16(x) MLLM_COMPUTE_FP32_TO_FP16(x)

--- a/mllm/backends/cpu/kernels/common/ggml/quantize/quantize.hpp
+++ b/mllm/backends/cpu/kernels/common/ggml/quantize/quantize.hpp
@@ -106,6 +106,8 @@ inline static float lookup_fp16_to_fp32(uint16_t f) {
 
 #else
 namespace mllm::cpu {
+// Extract a raw 16-bit fp16 bit pattern without numeric conversion. Integral inputs
+// are already bit patterns; non-integral fp16-like values are copied byte-for-byte.
 template<typename T>
 inline static uint16_t mllm_fp16_bits(const T& f) {
   if constexpr (std::is_integral_v<std::decay_t<T>>) {
@@ -118,6 +120,7 @@ inline static uint16_t mllm_fp16_bits(const T& f) {
   }
 }
 
+// Construct an mllm_fp16_t value from a raw 16-bit fp16 bit pattern.
 inline static mllm_fp16_t mllm_fp16_from_bits(uint16_t bits) {
   mllm_fp16_t f;
   memcpy(&f, &bits, sizeof(bits));


### PR DESCRIPTION
### Summary

This fixes x86 fp16 conversion in the common GGML quantization helpers by preserving raw fp16 bits instead of relying on implicit numeric conversion.

On non-ARM platforms, `mllm_fp16_t` is `half_float::half`. Passing it directly to helpers that take `uint16_t` converts the fp16 value numerically, not as raw bits. For small Q4_K/Q6_K scales this can turn the lookup index into `0`, making dequantization produce all-zero output.

### Root cause

The x86 path currently expands `MLLM_FP16_TO_FP32(x)` to `lookup_fp16_to_fp32(x)`, while `lookup_fp16_to_fp32` takes `uint16_t`.

When `x` is `half_float::half`, this does not pass the underlying fp16 bit pattern. For example, fp16 `1.0` has raw bits `0x3c00`, but numeric conversion to `uint16_t` yields `1`.

### Changes

- Add `mllm_fp16_bits()` to read fp16 raw bits explicitly.
- Add `mllm_fp16_from_bits()` to construct `mllm_fp16_t` from raw bits returned by `_cvtss_sh`.
- Route x86 `MLLM_COMPUTE_FP16_TO_FP32`, `MLLM_COMPUTE_FP32_TO_FP16`, and `MLLM_FP16_TO_FP32` through those helpers.

### Context

This was found while investigating the documented Qwen3-0.6B x86 v1 q4_k path. The Qwen3 model-file naming mismatch is tracked separately in #684; this PR only fixes the common x86 quantization conversion issue.

### Validation

- `git diff --check`
- Minimal Q4_K/Q6_K dequantization check compiled against this branch:

```text
sizeof(mllm_fp16_t)=2 is_half_float=1 one_bits=0x3c00 macro_one=1
q4_sum_abs=128 first=0.5
q6_sum_abs=1856 first=-7.5
```

- CMake object-level build for the affected quantization sources:

```bash
cmake --build /tmp/mllm-fp16-pr-build \
  --target mllm/backends/cpu/CMakeFiles/MllmCPUBackend.dir/kernels/common/ggml/quantize/quantize_q4.cpp.o \
           mllm/backends/cpu/CMakeFiles/MllmCPUBackend.dir/kernels/common/ggml/quantize/quantize_q6.cpp.o \
  -j6
```

A full `mllm-qwen3-runner` build currently reaches the link step and then fails on upstream `main` with the existing xxHash static-library PIC issue tracked in #683:

```text
/usr/bin/ld.bfd: lib/libxxhash_static.a(xxhash.c.o): relocation R_X86_64_32S against `.rodata' can not be used when making a shared object; recompile with -fPIC
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved FP16 bit-level handling in CPU inference paths, correcting raw half-precision conversions to improve numerical accuracy, stability, and consistency of floating-point operations across platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->