### PR TITLE
fix(pymllm): KV allocator release sanitization

### DIFF
--- a/pymllm/mem_cache/memory_pool.py
+++ b/pymllm/mem_cache/memory_pool.py
@@ -11,6 +11,7 @@ buffers is reserved as a padding / dummy-output slot and is never allocated.
 """
 
 import logging
+import os
 from typing import List, Optional, Tuple, Union
 
 import torch
@@ -258,7 +259,7 @@ class TokenToKVPoolAllocator:
                 1, self.size + 1, dtype=torch.int32, device=self.device
             )
         else:
-            num_pages = self.size // self.page_size
+            num_pages = self._num_pages()
             self.free_slots = torch.arange(
                 1, num_pages + 1, dtype=torch.int32, device=self.device
             )
@@ -268,16 +269,74 @@ class TokenToKVPoolAllocator:
 
     def available_size(self) -> int:
         """Number of tokens that can still be allocated."""
-        return (len(self.free_slots) + len(self.release_slots)) * self.page_size
+        if self.page_size == 1:
+            return len(self.free_slots) + len(self.release_slots)
+        free_pages = torch.cat((self.free_slots, self.release_slots))
+        if free_pages.numel() == 0:
+            return 0
+        return int(self._page_ids_to_kv_indices(free_pages).numel())
+
+    def _debug_assert_enabled(self) -> bool:
+        return os.environ.get("PYMLLM_DEBUG_KV_ASSERT") == "1"
+
+    def _num_pages(self) -> int:
+        return (self.size + self.page_size - 1) // self.page_size
+
+    def _max_free_slot_value(self) -> int:
+        # page_size == 1 stores real KV indices; page mode stores page ids.
+        return self.size if self.page_size == 1 else self._num_pages()
+
+    def _page_ids_to_kv_indices(self, pages: torch.Tensor) -> torch.Tensor:
+        """Convert 1-based page ids to 1-based KV indices."""
+        offsets = torch.arange(self.page_size, dtype=torch.int64, device=self.device)
+        pages64 = pages.reshape(-1).to(torch.int64)
+        out = ((pages64 - 1)[:, None] * self.page_size + offsets + 1).reshape(-1)
+        out = out[(out > 0) & (out <= self.size)]
+        return out.to(torch.int32)
+
+    def _kv_indices_to_page_ids(self, indices: torch.Tensor) -> torch.Tensor:
+        """Convert 1-based KV indices to 1-based page ids."""
+        indices64 = indices.reshape(-1).to(torch.int64)
+        pages = ((indices64 - 1) // self.page_size) + 1
+        pages = pages[(pages > 0) & (pages <= self._num_pages())]
+        return pages.to(torch.int32)
+
+    def _assert_valid_allocator_state(self, where: str) -> None:
+        if not self._debug_assert_enabled():
+            return
+        max_value = self._max_free_slot_value()
+        for name, slots in (("free_slots", self.free_slots), ("release_slots", self.release_slots)):
+            if slots.numel() == 0:
+                continue
+            if bool(((slots <= 0) | (slots > max_value)).any().item()):
+                raise RuntimeError(
+                    f"[KV_ALLOC_ASSERT] {where}: invalid {name}, "
+                    f"max_value={max_value}, first50={slots[:50].detach().cpu().tolist()}"
+                )
+            if torch.unique(slots).numel() != slots.numel():
+                raise RuntimeError(
+                    f"[KV_ALLOC_ASSERT] {where}: duplicate {name}, "
+                    f"first100={slots[:100].detach().cpu().tolist()}"
+                )
+        if self.available_size() > self.size:
+            raise RuntimeError(
+                f"[KV_ALLOC_ASSERT] {where}: available_size={self.available_size()} > size={self.size}"
+            )
 
     def merge_and_sort_free(self) -> None:
         """Merge ``release_slots`` into ``free_slots`` (and sort if ``need_sort``)."""
         if len(self.release_slots) == 0:
             return
+        max_value = self._max_free_slot_value()
         self.free_slots = torch.cat((self.free_slots, self.release_slots))
+        self.free_slots = self.free_slots[
+            (self.free_slots > 0) & (self.free_slots <= max_value)
+        ]
+        self.free_slots = torch.unique(self.free_slots, sorted=self.need_sort)
         if self.need_sort:
             self.free_slots, _ = torch.sort(self.free_slots)
         self.release_slots = torch.empty((0,), dtype=torch.int32, device=self.device)
+        self._assert_valid_allocator_state("merge_and_sort_free")
 
     def free_group_begin(self) -> None:
         """Start collecting ``free()`` calls; actual release is deferred to ``free_group_end``."""
@@ -304,35 +363,150 @@ class TokenToKVPoolAllocator:
                 return None
             out = self.free_slots[:need_size]
             self.free_slots = self.free_slots[need_size:]
+            if self._debug_assert_enabled():
+                if out.numel() != need_size:
+                    raise RuntimeError(
+                        f"[KV_ALLOC_ASSERT] alloc count mismatch need={need_size} got={out.numel()}"
+                    )
+                if bool(((out <= 0) | (out > self.size)).any().item()):
+                    raise RuntimeError(
+                        f"[KV_ALLOC_ASSERT] alloc returned invalid KV indices: "
+                        f"need={need_size}, out_first50={out[:50].detach().cpu().tolist()}, "
+                        f"free_first50={self.free_slots[:50].detach().cpu().tolist()}, "
+                        f"release_first50={self.release_slots[:50].detach().cpu().tolist()}"
+                    )
+                if torch.unique(out).numel() != out.numel():
+                    raise RuntimeError(
+                        f"[KV_ALLOC_ASSERT] alloc returned duplicate KV indices: "
+                        f"need={need_size}, out_first100={out[:100].detach().cpu().tolist()}"
+                    )
+                self._assert_valid_allocator_state("alloc")
             return out
+
+        if need_size > self.available_size():
+            self.merge_and_sort_free()
+        if need_size > self.available_size():
+            return None
 
         num_pages = (need_size + self.page_size - 1) // self.page_size
         if num_pages > len(self.free_slots):
             self.merge_and_sort_free()
-        if num_pages > len(self.free_slots):
-            return None
         pages = self.free_slots[:num_pages]
         self.free_slots = self.free_slots[num_pages:]
-        offsets = torch.arange(self.page_size, device=self.device)
-        out = (pages[:, None] * self.page_size + offsets).reshape(-1)
-        return out[:need_size]
+        out = self._page_ids_to_kv_indices(pages)
+        while out.numel() < need_size and len(self.free_slots) > 0:
+            extra_page = self.free_slots[:1]
+            self.free_slots = self.free_slots[1:]
+            pages = torch.cat((pages, extra_page))
+            out = self._page_ids_to_kv_indices(pages)
+        out = out[:need_size]
+        if out.numel() != need_size:
+            self.free_slots = torch.cat((pages, self.free_slots))
+            if self.need_sort:
+                self.free_slots, _ = torch.sort(torch.unique(self.free_slots))
+            else:
+                self.free_slots = torch.unique(self.free_slots, sorted=False)
+            return None
+        if self._debug_assert_enabled():
+            if out.numel() != need_size:
+                raise RuntimeError(
+                    f"[KV_ALLOC_ASSERT] paged alloc count mismatch need={need_size} got={out.numel()}"
+                )
+            if bool(((out <= 0) | (out > self.size)).any().item()):
+                raise RuntimeError(
+                    f"[KV_ALLOC_ASSERT] paged alloc returned invalid KV indices: "
+                    f"need={need_size}, out_first50={out[:50].detach().cpu().tolist()}, "
+                    f"free_first50={self.free_slots[:50].detach().cpu().tolist()}, "
+                    f"release_first50={self.release_slots[:50].detach().cpu().tolist()}"
+                )
+            if torch.unique(out).numel() != out.numel():
+                raise RuntimeError(
+                    f"[KV_ALLOC_ASSERT] paged alloc returned duplicate KV indices: "
+                    f"need={need_size}, out_first100={out[:100].detach().cpu().tolist()}"
+                )
+            self._assert_valid_allocator_state("paged_alloc")
+        return out
 
     def free(self, indices: torch.Tensor) -> None:
         """Return *indices* to the free pool."""
         if indices.numel() == 0:
             return
 
+        before = int(indices.numel())
+        indices64 = indices.reshape(-1).to(torch.int64)
+        invalid_mask = (indices64 <= 0) | (indices64 > self.size)
+        invalid_count = int(invalid_mask.sum().item())
+        indices64 = indices64[(indices64 > 0) & (indices64 <= self.size)]
+        indices = indices64.to(torch.int32)
+        if indices.numel() == 0:
+            if invalid_count:
+                logger.warning(
+                    "[KV_ALLOC_SANITIZE] free dropped all invalid indices: before=%d invalid=%d size=%d",
+                    before,
+                    invalid_count,
+                    self.size,
+                )
+            return
+
+        unique_indices = torch.unique(indices)
+        duplicate_count = int(indices.numel() - unique_indices.numel())
+        indices = unique_indices
+
         if not self._is_not_in_free_group:
+            if invalid_count or duplicate_count:
+                logger.warning(
+                    "[KV_ALLOC_SANITIZE] grouped free sanitized: before=%d after=%d invalid=%d duplicate=%d size=%d",
+                    before,
+                    int(indices.numel()),
+                    invalid_count,
+                    duplicate_count,
+                    self.size,
+                )
             self._free_group.append(indices)
             return
 
         if self.page_size != 1:
-            indices = torch.unique(indices // self.page_size)
+            indices = torch.unique(self._kv_indices_to_page_ids(indices))
+            if indices.numel() == 0:
+                return
+
+        existing = torch.cat((self.free_slots, self.release_slots))
+        duplicate_release_count = 0
+        if existing.numel() > 0:
+            duplicate_mask = torch.isin(indices, existing)
+            duplicate_release_count = int(duplicate_mask.sum().item())
+            indices = indices[~duplicate_mask]
+        if indices.numel() == 0:
+            if invalid_count or duplicate_count or duplicate_release_count:
+                logger.warning(
+                    "[KV_ALLOC_SANITIZE] free skipped sanitized duplicate release: "
+                    "before=%d invalid=%d duplicate=%d already_free=%d size=%d",
+                    before,
+                    invalid_count,
+                    duplicate_count,
+                    duplicate_release_count,
+                    self.size,
+                )
+            return
+
+        if invalid_count or duplicate_count or duplicate_release_count:
+            logger.warning(
+                "[KV_ALLOC_SANITIZE] free sanitized: before=%d after=%d invalid=%d duplicate=%d already_free=%d size=%d",
+                before,
+                int(indices.numel()),
+                invalid_count,
+                duplicate_count,
+                duplicate_release_count,
+                self.size,
+            )
 
         if self.need_sort:
             self.release_slots = torch.cat((self.release_slots, indices))
+            self.release_slots = torch.unique(self.release_slots, sorted=True)
         else:
             self.free_slots = torch.cat((self.free_slots, indices))
+            self.free_slots = torch.unique(self.free_slots, sorted=False)
+        self._assert_valid_allocator_state("free")
 
 
 class ReqToTokenPool:

--- a/pymllm/orchestrator/model_runner_process.py
+++ b/pymllm/orchestrator/model_runner_process.py
@@ -1040,6 +1040,40 @@ class ModelRunnerProcess:
         decode_len = len(output_ids) if output_ids else 0
         total_len = prompt_len + decode_len
 
+        def _sanitize_kv_free_indices(
+            indices: Optional[torch.Tensor], where: str
+        ) -> Optional[torch.Tensor]:
+            if indices is None or indices.numel() == 0:
+                return indices
+
+            before = int(indices.numel())
+            raw = indices.reshape(-1).to(torch.int64)
+            allocator_size = int(runner.token_to_kv_pool_allocator.size)
+            bad_mask = (raw <= 0) | (raw > allocator_size)
+            bad_count = int(bad_mask.sum().item())
+            sanitized = raw[(raw > 0) & (raw <= allocator_size)]
+            if sanitized.numel() > 0:
+                sanitized = torch.unique(sanitized)
+
+            after = int(sanitized.numel())
+            if before != after or bad_count:
+                logger.warning(
+                    "[KV_FREE_SANITIZE] rid=%s slot=%s where=%s before=%d after=%d "
+                    "bad_count=%d prompt_len=%d decode_len=%d total_len=%d first10=%s last10=%s",
+                    rid,
+                    slot,
+                    where,
+                    before,
+                    after,
+                    bad_count,
+                    prompt_len,
+                    decode_len,
+                    total_len,
+                    raw[:10].detach().cpu().tolist(),
+                    raw[-10:].detach().cpu().tolist(),
+                )
+            return sanitized
+
         all_kv_indices: Optional[torch.Tensor] = None
         if slot is not None and input_ids is not None:
             all_kv_indices = runner.req_to_token_pool.req_to_token[slot, :total_len].to(
@@ -1062,12 +1096,16 @@ class ModelRunnerProcess:
 
                 # Free duplicate KV indices in the overlap region.
                 if new_prefix_len > cache_protected_len:
-                    dup_indices = prompt_kv[cache_protected_len:new_prefix_len]
-                    if dup_indices.numel() > 0:
+                    dup_indices = _sanitize_kv_free_indices(
+                        prompt_kv[cache_protected_len:new_prefix_len],
+                        "prompt_dup_indices",
+                    )
+                    if dup_indices is not None and dup_indices.numel() > 0:
                         runner.token_to_kv_pool_allocator.free(dup_indices)
 
                 # Free decode KV indices (tree does not own them)
-                if decode_kv.numel() > 0:
+                decode_kv = _sanitize_kv_free_indices(decode_kv, "decode_kv")
+                if decode_kv is not None and decode_kv.numel() > 0:
                     runner.token_to_kv_pool_allocator.free(decode_kv)
             else:
                 # Non-hybrid or no decode tokens: insert full sequence
@@ -1080,8 +1118,11 @@ class ModelRunnerProcess:
 
                 # Free duplicate KV indices in the overlap region.
                 if new_prefix_len > cache_protected_len:
-                    dup_indices = all_kv_indices[cache_protected_len:new_prefix_len]
-                    if dup_indices.numel() > 0:
+                    dup_indices = _sanitize_kv_free_indices(
+                        all_kv_indices[cache_protected_len:new_prefix_len],
+                        "all_dup_indices",
+                    )
+                    if dup_indices is not None and dup_indices.numel() > 0:
                         runner.token_to_kv_pool_allocator.free(dup_indices)
 
             did_insert = True
@@ -1101,15 +1142,21 @@ class ModelRunnerProcess:
                 # Cache enabled but insert skipped (shouldn't happen in
                 # normal flow).  Tree owns [0, cache_protected_len);
                 # free the rest.
-                tail = all_kv_indices[cache_protected_len:]
-                if tail.numel() > 0:
+                tail = _sanitize_kv_free_indices(
+                    all_kv_indices[cache_protected_len:],
+                    "tail",
+                )
+                if tail is not None and tail.numel() > 0:
                     runner.token_to_kv_pool_allocator.free(tail)
             elif not cache_enabled:
                 # Cache disabled — free all newly-allocated KV indices.
+                all_kv_indices = _sanitize_kv_free_indices(all_kv_indices, "all_kv_indices")
                 if all_kv_indices is not None and all_kv_indices.numel() > 0:
                     runner.token_to_kv_pool_allocator.free(all_kv_indices)
-                elif kv_indices is not None and kv_indices.numel() > 0:
-                    runner.token_to_kv_pool_allocator.free(kv_indices)
+                else:
+                    kv_indices = _sanitize_kv_free_indices(kv_indices, "kv_indices_fallback")
+                    if kv_indices is not None and kv_indices.numel() > 0:
+                        runner.token_to_kv_pool_allocator.free(kv_indices)
 
         # ----------------------------------------------------------
         # Phase 5: Free the req pool slot.


### PR DESCRIPTION
## Summary

Fixes a KV cache allocator bug that could corrupt `free_slots` / `release_slots` under repeated requests.

On AGX + pymllm (Qwen3-VL), this caused malformed outputs, repeated decoding, `finish_reason=length`, and `decode_token_count=256`.

## Root cause

Invalid or duplicated KV indices (e.g., `0`, repeats) were passed into `TokenToKVPoolAllocator.free()`, polluting allocator pools and corrupting KV mappings.

## Changes

Modified only:

* `pymllm/mem_cache/memory_pool.py`
* `pymllm/orchestrator/model_runner_process.py`

Key updates:

* Filter invalid (`<=0`, out-of-range) and deduplicate KV indices before free
* Prevent duplicates in `free_slots` / `release_slots`
* Sanitize free slots after merge
* Add optional assertions (`PYMLLM_DEBUG_KV_ASSERT`)
* Add minimal warning logs

No changes to model logic, kernels, sampling, tokenizer, or weights.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache cleanup by sanitizing KV token indices before freeing them, filtering invalid, out-of-range, and duplicate values to prevent double-free issues.
  * Safer free behavior when cache data is missing or empty, avoiding unnecessary free calls in fallback paths.
  * Strengthened allocator validation to better catch inconsistent allocation/free state and ensure returned allocations are valid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->